### PR TITLE
Fix file upload service errors for OSS integration

### DIFF
--- a/app/services/file_service.py
+++ b/app/services/file_service.py
@@ -163,7 +163,7 @@ class OSSService:
                 'callbackBodyType': 'application/x-www-form-urlencoded'
                 # Optional: Add callbackHost, callback-var for custom headers/variables
             }
-            callback_params = base64.b64encode(json.dumps(callback_dict).encode('utf-8')) # OSS expects base64 encoded JSON
+            callback_params = base64.b64encode(json.dumps(callback_dict).encode('utf-8')).decode('utf-8') # OSS expects base64 encoded JSON as string
 
         try:
             # Generate the signed URL with optional callback


### PR DESCRIPTION
- Add missing base64 import for callback parameter encoding
- Change Auth to StsAuth for proper STS token authentication
- Fix callback params encoding to return string instead of bytes

These fixes resolve 500 errors when uploading files, enabling the OSS upload workflow to function correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)