### PR TITLE
Fix OSS callback parameter JSON formatting

### DIFF
--- a/app/services/file_service.py
+++ b/app/services/file_service.py
@@ -163,7 +163,7 @@ class OSSService:
                 'callbackBodyType': 'application/x-www-form-urlencoded'
                 # Optional: Add callbackHost, callback-var for custom headers/variables
             }
-            callback_params = base64.b64encode(json.dumps(callback_dict).encode('utf-8')).decode('utf-8') # OSS expects base64 encoded JSON as string
+            callback_params = base64.b64encode(json.dumps(callback_dict, separators=(',', ':')).encode('utf-8')).decode('utf-8') # OSS expects base64 encoded JSON as string without spaces
 
         try:
             # Generate the signed URL with optional callback


### PR DESCRIPTION
Remove spaces from JSON serialization to prevent signature mismatch. OSS requires compact JSON encoding for callback parameters.

🤖 Generated with [Claude Code](https://claude.ai/code)