### PR TITLE
Fix SQL DuplicateAlias error in get_course_posts endpoint

### DIFF
--- a/app/routes/course.py
+++ b/app/routes/course.py
@@ -197,8 +197,6 @@ def get_course_posts(course_id):
     # Query posts with this course tag
     posts = Post.query.join(
         Post.tags
-    ).join(
-        Tag
     ).filter(
         Tag.name.like(tag_filter),
         Tag.tag_type.has(name=TagType.COURSE),


### PR DESCRIPTION
- Remove redundant join to Tag table in course posts query
- Post.tags relationship already joins through post_tags to tags table
- Fixes 500 internal server error when accessing course posts

🤖 Generated with [Claude Code](https://claude.ai/code)