### PR TITLE
Fix sub-comments disappearing after page refresh

### DIFF
--- a/app/routes/comment.py
+++ b/app/routes/comment.py
@@ -222,7 +222,7 @@ def get_post_comments(post_id):
         comment_dict = comment.to_dict()
         
         # Include replies if requested
-        if include_replies and not top_level_only:
+        if include_replies:
             comment_dict['replies'] = [
                 reply.to_dict() for reply in comment.replies.filter_by(is_deleted=False)
             ]


### PR DESCRIPTION
Previously, the logic prevented including replies when top_level_only=true, causing sub-comments to vanish after refresh. Now replies are included whenever include_replies=true, regardless of top_level_only parameter.

🤖 Generated with [Claude Code](https://claude.ai/code)