### PR TITLE
Fix email verification status display issue

### DIFF
--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -113,7 +113,7 @@ def get_user(user_id):
     
     # Check if requesting own profile (include more details) or just public info
     current_user_id = get_jwt_identity()
-    include_contact = (current_user_id == user_id)
+    include_contact = (str(current_user_id) == str(user_id))
     
     # Update last active time for the requesting user
     if str(current_user_id) == str(user_id):


### PR DESCRIPTION
- Fixed type comparison bug in get_user endpoint
- JWT identity returns string but user_id is int
- Now properly converts both to string for comparison
- This ensures include_contact=True for own profile requests
- email_verified field will now be included in response

🤖 Generated with [Claude Code](https://claude.ai/code)