### PR TITLE
[codex] auto-sync production scheduler data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,7 @@ def create_app(config_class=Config):
         _auto_init_scheduler_support()
         _auto_sync_course_catalog()
         _auto_sync_academic_curriculum()
+        _auto_seed_scheduler_map()
         _auto_migrate_gugu_reply_columns()
         _auto_init_contest()
         _ensure_mount_admin_role()
@@ -191,6 +192,20 @@ def _auto_sync_academic_curriculum():
     except Exception:
         db.session.rollback()
         logger.exception("Failed to sync academic curriculum requirements")
+
+
+def _auto_seed_scheduler_map():
+    """Seed bundled course universe map data only when the scheduler map is empty."""
+    if current_app.config.get("TESTING"):
+        return
+    try:
+        from app.services.scheduler_map_seed import seed_bundled_scheduler_map_if_empty
+
+        result = seed_bundled_scheduler_map_if_empty()
+        logger.info("Scheduler map seed result: %s", result)
+    except Exception:
+        db.session.rollback()
+        logger.exception("Failed to seed scheduler map")
 
 
 def _ensure_mount_admin_role():

--- a/app/data/scheduler_map_seed.json
+++ b/app/data/scheduler_map_seed.json
@@ -1,0 +1,2699 @@
+{
+  "metadata": {
+    "source": "CoursePlan.search/init/backup/dump_20251227_2.sql",
+    "components": 226,
+    "lines": 158
+  },
+  "components": [
+    {
+      "id": "ex_UFUG1302_UCUG1900",
+      "node_type": false,
+      "x_coordinate": 1076,
+      "y_coordinate": 1462,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1071_UCUG1074",
+      "node_type": false,
+      "x_coordinate": 898,
+      "y_coordinate": 672,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1900_UFUG1302",
+      "node_type": false,
+      "x_coordinate": 525,
+      "y_coordinate": 1680,
+      "category": 3
+    },
+    {
+      "id": "ex_AMAT4901_AMAT4095",
+      "node_type": true,
+      "x_coordinate": 5336,
+      "y_coordinate": 73,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1301_UCUG1900",
+      "node_type": false,
+      "x_coordinate": 1076,
+      "y_coordinate": 1345,
+      "category": 3
+    },
+    {
+      "id": "(DLED3010&AMAT2250)",
+      "node_type": false,
+      "x_coordinate": 5051,
+      "y_coordinate": 40,
+      "category": 1
+    },
+    {
+      "id": "(DSAA2011|AIAA3111)",
+      "node_type": true,
+      "x_coordinate": 3251,
+      "y_coordinate": 1506,
+      "category": 1
+    },
+    {
+      "id": "(UFUG1502|UFUG1504)",
+      "node_type": true,
+      "x_coordinate": 2076,
+      "y_coordinate": 988,
+      "category": 1
+    },
+    {
+      "id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&AMAT2010)",
+      "node_type": false,
+      "x_coordinate": 3047,
+      "y_coordinate": 920,
+      "category": 1
+    },
+    {
+      "id": "(UFUG1301|UFUG1302)",
+      "node_type": true,
+      "x_coordinate": 1572,
+      "y_coordinate": 1422,
+      "category": 1
+    },
+    {
+      "id": "(UFUG2601|UFUG2602)",
+      "node_type": true,
+      "x_coordinate": 2100,
+      "y_coordinate": 1893,
+      "category": 1
+    },
+    {
+      "id": "(UFUG1103|UFUG1106)",
+      "node_type": true,
+      "x_coordinate": 2048,
+      "y_coordinate": 885,
+      "category": 1
+    },
+    {
+      "id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "node_type": true,
+      "x_coordinate": 3725,
+      "y_coordinate": 1596,
+      "category": 1
+    },
+    {
+      "id": "(UCUG1050|UCUG1051)",
+      "node_type": true,
+      "x_coordinate": 511,
+      "y_coordinate": 282,
+      "category": 1
+    },
+    {
+      "id": "(UFUG2601|UFUG2602|DSAA1001)",
+      "node_type": true,
+      "x_coordinate": 2651,
+      "y_coordinate": 1807,
+      "category": 1
+    },
+    {
+      "id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&UFUG1301)",
+      "node_type": false,
+      "x_coordinate": 2152,
+      "y_coordinate": 942,
+      "category": 1
+    },
+    {
+      "id": "(DSAA1001|AIAA2205)",
+      "node_type": true,
+      "x_coordinate": 2651,
+      "y_coordinate": 1505,
+      "category": 1
+    },
+    {
+      "id": "(UFUG2103|UFUG2102)",
+      "node_type": true,
+      "x_coordinate": 2646,
+      "y_coordinate": 815,
+      "category": 1
+    },
+    {
+      "id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504))",
+      "node_type": false,
+      "x_coordinate": 2203,
+      "y_coordinate": 966,
+      "category": 1
+    },
+    {
+      "id": "((UFUG1501|UFUG1503)&(UFUG1102|UFUG1105))",
+      "node_type": false,
+      "x_coordinate": 1586,
+      "y_coordinate": 1005,
+      "category": 1
+    },
+    {
+      "id": "(UFUG1501|UFUG1503)",
+      "node_type": true,
+      "x_coordinate": 1515,
+      "y_coordinate": 1146,
+      "category": 1
+    },
+    {
+      "id": "(AMAT2040&AMAT3060)",
+      "node_type": false,
+      "x_coordinate": 4614,
+      "y_coordinate": 170,
+      "category": 1
+    },
+    {
+      "id": "SMMG4960",
+      "node_type": null,
+      "x_coordinate": 4163,
+      "y_coordinate": 1152,
+      "category": 0
+    },
+    {
+      "id": "(DLED3010|AMAT2250)",
+      "node_type": true,
+      "x_coordinate": 5049,
+      "y_coordinate": 111,
+      "category": 1
+    },
+    {
+      "id": "((DSAA2011|DSAA2012|AIAA3111)&UFUG2103&UFUG2104)",
+      "node_type": false,
+      "x_coordinate": 3763,
+      "y_coordinate": 1356,
+      "category": 1
+    },
+    {
+      "id": "(UCUG1052|UCUG1053)",
+      "node_type": true,
+      "x_coordinate": 1103,
+      "y_coordinate": 372,
+      "category": 1
+    },
+    {
+      "id": "((UFUG1103|UFUG1106)&UFUG2101&UFUG2103)",
+      "node_type": false,
+      "x_coordinate": 2633,
+      "y_coordinate": 906,
+      "category": 1
+    },
+    {
+      "id": "(UFUG2102|UFUG2103|UFUG2104)",
+      "node_type": true,
+      "x_coordinate": 2690,
+      "y_coordinate": 763,
+      "category": 1
+    },
+    {
+      "id": "UFUG1106",
+      "node_type": null,
+      "x_coordinate": 1601,
+      "y_coordinate": 825,
+      "category": 0
+    },
+    {
+      "id": "AIAA3111",
+      "node_type": null,
+      "x_coordinate": 2736,
+      "y_coordinate": 1689,
+      "category": 0
+    },
+    {
+      "id": "(UFUG1303&(UFUG1103|UFUG1106))",
+      "node_type": false,
+      "x_coordinate": 2281,
+      "y_coordinate": 1005,
+      "category": 1
+    },
+    {
+      "id": "(UFUG1102|UFUG1105)",
+      "node_type": true,
+      "x_coordinate": 1526,
+      "y_coordinate": 748,
+      "category": 1
+    },
+    {
+      "id": "UCUG1501",
+      "node_type": null,
+      "x_coordinate": 559,
+      "y_coordinate": 863,
+      "category": 0
+    },
+    {
+      "id": "DSAA4591",
+      "node_type": null,
+      "x_coordinate": 4153,
+      "y_coordinate": 1457,
+      "category": 0
+    },
+    {
+      "id": "AMAT3060",
+      "node_type": null,
+      "x_coordinate": 4139,
+      "y_coordinate": 179,
+      "category": 0
+    },
+    {
+      "id": "UCUG1053",
+      "node_type": null,
+      "x_coordinate": 574,
+      "y_coordinate": 504,
+      "category": 0
+    },
+    {
+      "id": "UCUG1052S",
+      "node_type": null,
+      "x_coordinate": 573,
+      "y_coordinate": 420,
+      "category": 0
+    },
+    {
+      "id": "UCUG1502",
+      "node_type": null,
+      "x_coordinate": 94,
+      "y_coordinate": 953,
+      "category": 0
+    },
+    {
+      "id": "AMAT2030",
+      "node_type": null,
+      "x_coordinate": 3631,
+      "y_coordinate": 148,
+      "category": 0
+    },
+    {
+      "id": "AMAT1510",
+      "node_type": null,
+      "x_coordinate": 2573,
+      "y_coordinate": 343,
+      "category": 0
+    },
+    {
+      "id": "DSAA2088",
+      "node_type": null,
+      "x_coordinate": 3780,
+      "y_coordinate": 1326,
+      "category": 0
+    },
+    {
+      "id": "AMAT3350",
+      "node_type": null,
+      "x_coordinate": 4132,
+      "y_coordinate": 638,
+      "category": 0
+    },
+    {
+      "id": "UFUG2105",
+      "node_type": null,
+      "x_coordinate": 2643,
+      "y_coordinate": 677,
+      "category": 0
+    },
+    {
+      "id": "AMAT4095",
+      "node_type": null,
+      "x_coordinate": 5118,
+      "y_coordinate": 110,
+      "category": 0
+    },
+    {
+      "id": "UFUG2602",
+      "node_type": null,
+      "x_coordinate": 1597,
+      "y_coordinate": 1889,
+      "category": 0
+    },
+    {
+      "id": "UCUG1071",
+      "node_type": null,
+      "x_coordinate": 554,
+      "y_coordinate": 611,
+      "category": 0
+    },
+    {
+      "id": "UFUG1602",
+      "node_type": null,
+      "x_coordinate": 1071,
+      "y_coordinate": 2023,
+      "category": 0
+    },
+    {
+      "id": "SMMG3820",
+      "node_type": null,
+      "x_coordinate": 3228,
+      "y_coordinate": 1064,
+      "category": 0
+    },
+    {
+      "id": "DLED4020",
+      "node_type": null,
+      "x_coordinate": 1772,
+      "y_coordinate": 284,
+      "category": 0
+    },
+    {
+      "id": "UCUG1073",
+      "node_type": null,
+      "x_coordinate": 87,
+      "y_coordinate": 767,
+      "category": 0
+    },
+    {
+      "id": "ex_UCUG1071_UCUG1073",
+      "node_type": false,
+      "x_coordinate": 553,
+      "y_coordinate": 627,
+      "category": 3
+    },
+    {
+      "id": "AMAT4901",
+      "node_type": null,
+      "x_coordinate": 5109,
+      "y_coordinate": 11,
+      "category": 0
+    },
+    {
+      "id": "UCUG1600",
+      "node_type": null,
+      "x_coordinate": 98,
+      "y_coordinate": 1272,
+      "category": 0
+    },
+    {
+      "id": "AMAT3520",
+      "node_type": null,
+      "x_coordinate": 4138,
+      "y_coordinate": 537,
+      "category": 0
+    },
+    {
+      "id": "AMAT2450",
+      "node_type": null,
+      "x_coordinate": 3633,
+      "y_coordinate": 423,
+      "category": 0
+    },
+    {
+      "id": "SMMG4901",
+      "node_type": null,
+      "x_coordinate": 4163,
+      "y_coordinate": 1038,
+      "category": 0
+    },
+    {
+      "id": "AMAT3820",
+      "node_type": null,
+      "x_coordinate": 3171,
+      "y_coordinate": 530,
+      "category": 0
+    },
+    {
+      "id": "SMMG3010",
+      "node_type": null,
+      "x_coordinate": 2273,
+      "y_coordinate": 1114,
+      "category": 0
+    },
+    {
+      "id": "DLED4010",
+      "node_type": null,
+      "x_coordinate": 1774,
+      "y_coordinate": 190,
+      "category": 0
+    },
+    {
+      "id": "UCUG1500",
+      "node_type": null,
+      "x_coordinate": 94,
+      "y_coordinate": 866,
+      "category": 0
+    },
+    {
+      "id": "UCUG1807",
+      "node_type": null,
+      "x_coordinate": 99,
+      "y_coordinate": 1568,
+      "category": 0
+    },
+    {
+      "id": "UCUG1503",
+      "node_type": null,
+      "x_coordinate": 558,
+      "y_coordinate": 956,
+      "category": 0
+    },
+    {
+      "id": "UFUG1301",
+      "node_type": null,
+      "x_coordinate": 1076,
+      "y_coordinate": 1341,
+      "category": 0
+    },
+    {
+      "id": "UFUG1103",
+      "node_type": null,
+      "x_coordinate": 1604,
+      "y_coordinate": 718,
+      "category": 0
+    },
+    {
+      "id": "UCUG1000",
+      "node_type": null,
+      "x_coordinate": 160,
+      "y_coordinate": 49,
+      "category": 0
+    },
+    {
+      "id": "UFUG1501",
+      "node_type": null,
+      "x_coordinate": 1070,
+      "y_coordinate": 1054,
+      "category": 0
+    },
+    {
+      "id": "UCUG1074",
+      "node_type": null,
+      "x_coordinate": 554,
+      "y_coordinate": 768,
+      "category": 0
+    },
+    {
+      "id": "UCUG3801",
+      "node_type": null,
+      "x_coordinate": 102,
+      "y_coordinate": 1983,
+      "category": 0
+    },
+    {
+      "id": "UFUG1701",
+      "node_type": null,
+      "x_coordinate": 1538,
+      "y_coordinate": 2212,
+      "category": 0
+    },
+    {
+      "id": "DLED4040",
+      "node_type": null,
+      "x_coordinate": 1777,
+      "y_coordinate": 503,
+      "category": 0
+    },
+    {
+      "id": "UCUG1050",
+      "node_type": null,
+      "x_coordinate": 25,
+      "y_coordinate": 212,
+      "category": 0
+    },
+    {
+      "id": "UFUG1303",
+      "node_type": null,
+      "x_coordinate": 1602,
+      "y_coordinate": 1459,
+      "category": 0
+    },
+    {
+      "id": "SMMG3040",
+      "node_type": null,
+      "x_coordinate": 2744,
+      "y_coordinate": 1026,
+      "category": 0
+    },
+    {
+      "id": "AMAT2050",
+      "node_type": null,
+      "x_coordinate": 3633,
+      "y_coordinate": 573,
+      "category": 0
+    },
+    {
+      "id": "AMAT2010",
+      "node_type": null,
+      "x_coordinate": 2574,
+      "y_coordinate": 475,
+      "category": 0
+    },
+    {
+      "id": "UFUG1302",
+      "node_type": null,
+      "x_coordinate": 1075,
+      "y_coordinate": 1459,
+      "category": 0
+    },
+    {
+      "id": "DLED3020",
+      "node_type": null,
+      "x_coordinate": 1242,
+      "y_coordinate": 284,
+      "category": 0
+    },
+    {
+      "id": "DSAA1085",
+      "node_type": null,
+      "x_coordinate": 2753,
+      "y_coordinate": 1311,
+      "category": 0
+    },
+    {
+      "id": "UCUG1702",
+      "node_type": null,
+      "x_coordinate": 94,
+      "y_coordinate": 1362,
+      "category": 0
+    },
+    {
+      "id": "UCUG2603",
+      "node_type": null,
+      "x_coordinate": 554,
+      "y_coordinate": 1892,
+      "category": 0
+    },
+    {
+      "id": "AMAT3590",
+      "node_type": null,
+      "x_coordinate": 3165,
+      "y_coordinate": 414,
+      "category": 0
+    },
+    {
+      "id": "UFUG2104",
+      "node_type": null,
+      "x_coordinate": 1606,
+      "y_coordinate": 601,
+      "category": 0
+    },
+    {
+      "id": "AMAT4560",
+      "node_type": null,
+      "x_coordinate": 4639,
+      "y_coordinate": 140,
+      "category": 0
+    },
+    {
+      "id": "AMAT2150",
+      "node_type": null,
+      "x_coordinate": 3166,
+      "y_coordinate": 653,
+      "category": 0
+    },
+    {
+      "id": "DSAA1001",
+      "node_type": null,
+      "x_coordinate": 2167,
+      "y_coordinate": 1371,
+      "category": 0
+    },
+    {
+      "id": "UCUG1072",
+      "node_type": null,
+      "x_coordinate": 316,
+      "y_coordinate": 691,
+      "category": 0
+    },
+    {
+      "id": "UFUG1811",
+      "node_type": null,
+      "x_coordinate": 1541,
+      "y_coordinate": 2122,
+      "category": 0
+    },
+    {
+      "id": "UFUG1801",
+      "node_type": null,
+      "x_coordinate": 1066,
+      "y_coordinate": 2153,
+      "category": 0
+    },
+    {
+      "id": "AIAA3102",
+      "node_type": null,
+      "x_coordinate": 2175,
+      "y_coordinate": 1727,
+      "category": 0
+    },
+    {
+      "id": "AMAT2040",
+      "node_type": null,
+      "x_coordinate": 4138,
+      "y_coordinate": 100,
+      "category": 0
+    },
+    {
+      "id": "AMAT2250",
+      "node_type": null,
+      "x_coordinate": 3632,
+      "y_coordinate": 654,
+      "category": 0
+    },
+    {
+      "id": "AMAT2320",
+      "node_type": null,
+      "x_coordinate": 3633,
+      "y_coordinate": 239,
+      "category": 0
+    },
+    {
+      "id": "AMAT1010",
+      "node_type": null,
+      "x_coordinate": 2572,
+      "y_coordinate": 209,
+      "category": 0
+    },
+    {
+      "id": "UCUG1070",
+      "node_type": null,
+      "x_coordinate": 80,
+      "y_coordinate": 608,
+      "category": 0
+    },
+    {
+      "id": "AIAA2711",
+      "node_type": null,
+      "x_coordinate": 2180,
+      "y_coordinate": 1817,
+      "category": 0
+    },
+    {
+      "id": "DLED4030",
+      "node_type": null,
+      "x_coordinate": 1773,
+      "y_coordinate": 399,
+      "category": 0
+    },
+    {
+      "id": "UFUG2103",
+      "node_type": null,
+      "x_coordinate": 2110,
+      "y_coordinate": 813,
+      "category": 0
+    },
+    {
+      "id": "UFUG1402",
+      "node_type": null,
+      "x_coordinate": 1589,
+      "y_coordinate": 1650,
+      "category": 0
+    },
+    {
+      "id": "SMMG3000",
+      "node_type": null,
+      "x_coordinate": 2272,
+      "y_coordinate": 1020,
+      "category": 0
+    },
+    {
+      "id": "UCUG1907",
+      "node_type": null,
+      "x_coordinate": 562,
+      "y_coordinate": 1763,
+      "category": 0
+    },
+    {
+      "id": "SMMG4030",
+      "node_type": null,
+      "x_coordinate": 3678,
+      "y_coordinate": 1103,
+      "category": 0
+    },
+    {
+      "id": "UFUG1601",
+      "node_type": null,
+      "x_coordinate": 1073,
+      "y_coordinate": 1796,
+      "category": 0
+    },
+    {
+      "id": "UCUG1052",
+      "node_type": null,
+      "x_coordinate": 571,
+      "y_coordinate": 252,
+      "category": 0
+    },
+    {
+      "id": "AMAT4580",
+      "node_type": null,
+      "x_coordinate": 5113,
+      "y_coordinate": 298,
+      "category": 0
+    },
+    {
+      "id": "ex_UCUG1053_UCUG1052A",
+      "node_type": true,
+      "x_coordinate": 827,
+      "y_coordinate": 503,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1052S_UCUG1053",
+      "node_type": true,
+      "x_coordinate": 905,
+      "y_coordinate": 480,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1053_UCUG1052I",
+      "node_type": true,
+      "x_coordinate": 661,
+      "y_coordinate": 502,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1074_UCUG1071",
+      "node_type": false,
+      "x_coordinate": 898,
+      "y_coordinate": 767,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1072_UCUG1071",
+      "node_type": false,
+      "x_coordinate": 540,
+      "y_coordinate": 689,
+      "category": 3
+    },
+    {
+      "id": "ex_SMMG4901_SMMG4960",
+      "node_type": true,
+      "x_coordinate": 4372,
+      "y_coordinate": 1100,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1051_UCUG1050",
+      "node_type": true,
+      "x_coordinate": 224,
+      "y_coordinate": 362,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1900_UFUG1301",
+      "node_type": false,
+      "x_coordinate": 525,
+      "y_coordinate": 1681,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1052_UCUG1053",
+      "node_type": false,
+      "x_coordinate": 742,
+      "y_coordinate": 311,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1053_UCUG1052S",
+      "node_type": true,
+      "x_coordinate": 905,
+      "y_coordinate": 502,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1801_UCUG1807",
+      "node_type": false,
+      "x_coordinate": 1065,
+      "y_coordinate": 2185,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1074_UCUG1073",
+      "node_type": false,
+      "x_coordinate": 554,
+      "y_coordinate": 800,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1073_UCUG1074",
+      "node_type": false,
+      "x_coordinate": 508,
+      "y_coordinate": 800,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1807_UFUG1801",
+      "node_type": false,
+      "x_coordinate": 305,
+      "y_coordinate": 1629,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1050_UCUG1051",
+      "node_type": true,
+      "x_coordinate": 225,
+      "y_coordinate": 273,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1053_UCUG1052",
+      "node_type": false,
+      "x_coordinate": 742,
+      "y_coordinate": 503,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1072_UCUG1074",
+      "node_type": false,
+      "x_coordinate": 735,
+      "y_coordinate": 725,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1052A_UCUG1053",
+      "node_type": true,
+      "x_coordinate": 826,
+      "y_coordinate": 392,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1073_UCUG1071",
+      "node_type": false,
+      "x_coordinate": 507,
+      "y_coordinate": 778,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1071_UCUG1072",
+      "node_type": false,
+      "x_coordinate": 553,
+      "y_coordinate": 648,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1074_UCUG1072",
+      "node_type": false,
+      "x_coordinate": 777,
+      "y_coordinate": 768,
+      "category": 3
+    },
+    {
+      "id": "ex_UCUG1052I_UCUG1053",
+      "node_type": true,
+      "x_coordinate": 660,
+      "y_coordinate": 213,
+      "category": 3
+    },
+    {
+      "id": "SMMG3810",
+      "node_type": null,
+      "x_coordinate": 2745,
+      "y_coordinate": 1195,
+      "category": 0
+    },
+    {
+      "id": "AMAT4810",
+      "node_type": null,
+      "x_coordinate": 5112,
+      "y_coordinate": 445,
+      "category": 0
+    },
+    {
+      "id": "AMAT3530",
+      "node_type": null,
+      "x_coordinate": 4623,
+      "y_coordinate": 366,
+      "category": 0
+    },
+    {
+      "id": "AMAT3360",
+      "node_type": null,
+      "x_coordinate": 4142,
+      "y_coordinate": 381,
+      "category": 0
+    },
+    {
+      "id": "UCUG1506",
+      "node_type": null,
+      "x_coordinate": 95,
+      "y_coordinate": 1151,
+      "category": 0
+    },
+    {
+      "id": "DSAA2043",
+      "node_type": null,
+      "x_coordinate": 2166,
+      "y_coordinate": 1459,
+      "category": 0
+    },
+    {
+      "id": "UCUG1001",
+      "node_type": null,
+      "x_coordinate": 883,
+      "y_coordinate": 52,
+      "category": 0
+    },
+    {
+      "id": "UFUG1102",
+      "node_type": null,
+      "x_coordinate": 1057,
+      "y_coordinate": 664,
+      "category": 0
+    },
+    {
+      "id": "UCUG1900",
+      "node_type": null,
+      "x_coordinate": 104,
+      "y_coordinate": 1669,
+      "category": 0
+    },
+    {
+      "id": "UCUG1052I",
+      "node_type": null,
+      "x_coordinate": 575,
+      "y_coordinate": 153,
+      "category": 0
+    },
+    {
+      "id": "ex_UFUG1105_UFUG1102",
+      "node_type": true,
+      "x_coordinate": 1274,
+      "y_coordinate": 766,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1303_UFUG1301",
+      "node_type": true,
+      "x_coordinate": 1632,
+      "y_coordinate": 1457,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1106_UFUG1103",
+      "node_type": true,
+      "x_coordinate": 1816,
+      "y_coordinate": 823,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1102_UFUG1105",
+      "node_type": true,
+      "x_coordinate": 1274,
+      "y_coordinate": 725,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1301_UFUG1303",
+      "node_type": true,
+      "x_coordinate": 1499,
+      "y_coordinate": 1389,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1302_UFUG1301",
+      "node_type": true,
+      "x_coordinate": 1296,
+      "y_coordinate": 1455,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1501_UFUG1503",
+      "node_type": true,
+      "x_coordinate": 1284,
+      "y_coordinate": 1114,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1103_UFUG1106",
+      "node_type": true,
+      "x_coordinate": 1816,
+      "y_coordinate": 780,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1301_UFUG1302",
+      "node_type": true,
+      "x_coordinate": 1296,
+      "y_coordinate": 1405,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1503_UFUG1501",
+      "node_type": true,
+      "x_coordinate": 1285,
+      "y_coordinate": 1170,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG2102_UFUG2103",
+      "node_type": true,
+      "x_coordinate": 2315,
+      "y_coordinate": 795,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1504_UFUG1502",
+      "node_type": true,
+      "x_coordinate": 1811,
+      "y_coordinate": 1174,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG2103_UFUG2102",
+      "node_type": true,
+      "x_coordinate": 2315,
+      "y_coordinate": 810,
+      "category": 3
+    },
+    {
+      "id": "ex_UFUG1502_UFUG1504",
+      "node_type": true,
+      "x_coordinate": 1811,
+      "y_coordinate": 1138,
+      "category": 3
+    },
+    {
+      "id": "AIAA1010",
+      "node_type": null,
+      "x_coordinate": 2164,
+      "y_coordinate": 1571,
+      "category": 0
+    },
+    {
+      "id": "UFUG1503",
+      "node_type": null,
+      "x_coordinate": 1071,
+      "y_coordinate": 1172,
+      "category": 0
+    },
+    {
+      "id": "ex_SMMG3000_SMMG3010",
+      "node_type": true,
+      "x_coordinate": 2487,
+      "y_coordinate": 1080,
+      "category": 3
+    },
+    {
+      "id": "UCUG1051",
+      "node_type": null,
+      "x_coordinate": 26,
+      "y_coordinate": 364,
+      "category": 0
+    },
+    {
+      "id": "DSAA2031",
+      "node_type": null,
+      "x_coordinate": 2753,
+      "y_coordinate": 1415,
+      "category": 0
+    },
+    {
+      "id": "UFUG1403",
+      "node_type": null,
+      "x_coordinate": 1074,
+      "y_coordinate": 1681,
+      "category": 0
+    },
+    {
+      "id": "co_SMMG4960_(SMMG4901|SMMG4960)",
+      "node_type": null,
+      "x_coordinate": 4589,
+      "y_coordinate": 1181,
+      "category": 2
+    },
+    {
+      "id": "co_AIAA4490_DLED4020[2]",
+      "node_type": null,
+      "x_coordinate": 3649,
+      "y_coordinate": 1764,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT4901_(DLED4010[2]&AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 5200,
+      "y_coordinate": 172,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4010[2]_(DLED4010[2]&AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 5235,
+      "y_coordinate": 750,
+      "category": 2
+    },
+    {
+      "id": "co_DSAA4591_(AIAA4490|DSAA4591)",
+      "node_type": null,
+      "x_coordinate": 4526,
+      "y_coordinate": 1518,
+      "category": 2
+    },
+    {
+      "id": "co_DSAA4591_DLED4020[2]",
+      "node_type": null,
+      "x_coordinate": 4575,
+      "y_coordinate": 1468,
+      "category": 2
+    },
+    {
+      "id": "(DLED4010[2]&AMAT2450)",
+      "node_type": false,
+      "x_coordinate": 5091,
+      "y_coordinate": 566,
+      "category": 2
+    },
+    {
+      "id": "(DLED4010[2]|AMAT2450)",
+      "node_type": true,
+      "x_coordinate": 5297,
+      "y_coordinate": 534,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4020[2]_AIAA4490",
+      "node_type": null,
+      "x_coordinate": 5251,
+      "y_coordinate": 1588,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT2450_(DLED4010[2]&AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 4006,
+      "y_coordinate": 484,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT4095_(DLED4010[2]|AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 5296,
+      "y_coordinate": 173,
+      "category": 2
+    },
+    {
+      "id": "(AMAT4901|AMAT4095)",
+      "node_type": true,
+      "x_coordinate": 5489,
+      "y_coordinate": 552,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4040[2]_SMMG4901",
+      "node_type": null,
+      "x_coordinate": 5245,
+      "y_coordinate": 1054,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4010[2]_(DLED4010[2]|AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 5296,
+      "y_coordinate": 720,
+      "category": 2
+    },
+    {
+      "id": "co_SMMG4901_(SMMG4901|SMMG4960)",
+      "node_type": null,
+      "x_coordinate": 4588,
+      "y_coordinate": 1077,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT2040_AMAT2450",
+      "node_type": null,
+      "x_coordinate": 4137,
+      "y_coordinate": 143,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4010[2]_(AMAT4901|AMAT4095)",
+      "node_type": null,
+      "x_coordinate": 5511,
+      "y_coordinate": 717,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT4095_(AMAT4901|AMAT4095)",
+      "node_type": null,
+      "x_coordinate": 5389,
+      "y_coordinate": 172,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT4901_(AMAT4901|AMAT4095)",
+      "node_type": null,
+      "x_coordinate": 5468,
+      "y_coordinate": 74,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4020[2]_DSAA4591",
+      "node_type": null,
+      "x_coordinate": 5251,
+      "y_coordinate": 1588,
+      "category": 2
+    },
+    {
+      "id": "(AIAA4490|DSAA4591)",
+      "node_type": true,
+      "x_coordinate": 4594,
+      "y_coordinate": 1611,
+      "category": 2
+    },
+    {
+      "id": "co_AIAA4490_(AIAA4490|DSAA4591)",
+      "node_type": null,
+      "x_coordinate": 3649,
+      "y_coordinate": 1783,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT2450_AMAT2040",
+      "node_type": null,
+      "x_coordinate": 4054,
+      "y_coordinate": 439,
+      "category": 2
+    },
+    {
+      "id": "(SMMG4901|SMMG4960)",
+      "node_type": true,
+      "x_coordinate": 4813,
+      "y_coordinate": 1110,
+      "category": 2
+    },
+    {
+      "id": "co_AMAT2450_(DLED4010[2]|AMAT2450)",
+      "node_type": null,
+      "x_coordinate": 4055,
+      "y_coordinate": 459,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4020[2]_(AIAA4490|DSAA4591)",
+      "node_type": null,
+      "x_coordinate": 5249,
+      "y_coordinate": 1610,
+      "category": 2
+    },
+    {
+      "id": "co_SMMG4901_DLED4040[2]",
+      "node_type": null,
+      "x_coordinate": 4587,
+      "y_coordinate": 1055,
+      "category": 2
+    },
+    {
+      "id": "co_DLED4040[2]_(SMMG4901|SMMG4960)",
+      "node_type": null,
+      "x_coordinate": 5246,
+      "y_coordinate": 1082,
+      "category": 2
+    },
+    {
+      "id": "DLED3010",
+      "node_type": null,
+      "x_coordinate": 1242,
+      "y_coordinate": 164,
+      "category": 0
+    },
+    {
+      "id": "AMAT4540",
+      "node_type": null,
+      "x_coordinate": 4623,
+      "y_coordinate": 476,
+      "category": 0
+    },
+    {
+      "id": "DLED4010[2]",
+      "node_type": null,
+      "x_coordinate": 5237,
+      "y_coordinate": 721,
+      "category": 0
+    },
+    {
+      "id": "DLED4020[2]",
+      "node_type": null,
+      "x_coordinate": 5252,
+      "y_coordinate": 1569,
+      "category": 0
+    },
+    {
+      "id": "DLED4030[2]",
+      "node_type": null,
+      "x_coordinate": 5271,
+      "y_coordinate": 1957,
+      "category": 0
+    },
+    {
+      "id": "UFUG2102",
+      "node_type": null,
+      "x_coordinate": 2106,
+      "y_coordinate": 733,
+      "category": 0
+    },
+    {
+      "id": "DLED4040[2]",
+      "node_type": null,
+      "x_coordinate": 5246,
+      "y_coordinate": 1035,
+      "category": 0
+    },
+    {
+      "id": "ex_AMAT4095_AMAT4901",
+      "node_type": true,
+      "x_coordinate": 5336,
+      "y_coordinate": 108,
+      "category": 3
+    },
+    {
+      "id": "AMAT2020",
+      "node_type": null,
+      "x_coordinate": 3166,
+      "y_coordinate": 252,
+      "category": 0
+    },
+    {
+      "id": "AIAA2205",
+      "node_type": null,
+      "x_coordinate": 2169,
+      "y_coordinate": 1653,
+      "category": 0
+    },
+    {
+      "id": "UFUG2101",
+      "node_type": null,
+      "x_coordinate": 2107,
+      "y_coordinate": 651,
+      "category": 0
+    },
+    {
+      "id": "UCUG1052A",
+      "node_type": null,
+      "x_coordinate": 574,
+      "y_coordinate": 332,
+      "category": 0
+    },
+    {
+      "id": "AMAT4570",
+      "node_type": null,
+      "x_coordinate": 4623,
+      "y_coordinate": 638,
+      "category": 0
+    },
+    {
+      "id": "DLED3030",
+      "node_type": null,
+      "x_coordinate": 1247,
+      "y_coordinate": 399,
+      "category": 0
+    },
+    {
+      "id": "UCUG1903",
+      "node_type": null,
+      "x_coordinate": 557,
+      "y_coordinate": 1671,
+      "category": 0
+    },
+    {
+      "id": "UCUG1505",
+      "node_type": null,
+      "x_coordinate": 557,
+      "y_coordinate": 1064,
+      "category": 0
+    },
+    {
+      "id": "SMMG4020",
+      "node_type": null,
+      "x_coordinate": 3683,
+      "y_coordinate": 1025,
+      "category": 0
+    },
+    {
+      "id": "DLED3040",
+      "node_type": null,
+      "x_coordinate": 1246,
+      "y_coordinate": 502,
+      "category": 0
+    },
+    {
+      "id": "UCUG1905",
+      "node_type": null,
+      "x_coordinate": 101,
+      "y_coordinate": 1763,
+      "category": 0
+    },
+    {
+      "id": "ex_SMMG3010_SMMG3000",
+      "node_type": true,
+      "x_coordinate": 2487,
+      "y_coordinate": 1113,
+      "category": 3
+    },
+    {
+      "id": "DSAA2011",
+      "node_type": null,
+      "x_coordinate": 2755,
+      "y_coordinate": 1529,
+      "category": 0
+    },
+    {
+      "id": "AIAA4490",
+      "node_type": null,
+      "x_coordinate": 3229,
+      "y_coordinate": 1747,
+      "category": 0
+    },
+    {
+      "id": "SMMG3050",
+      "node_type": null,
+      "x_coordinate": 2743,
+      "y_coordinate": 1110,
+      "category": 0
+    },
+    {
+      "id": "UCUG1603",
+      "node_type": null,
+      "x_coordinate": 552,
+      "y_coordinate": 1266,
+      "category": 0
+    },
+    {
+      "id": "ex_SMMG4960_SMMG4901",
+      "node_type": true,
+      "x_coordinate": 4373,
+      "y_coordinate": 1148,
+      "category": 3
+    },
+    {
+      "id": "UCUG2500",
+      "node_type": null,
+      "x_coordinate": 103,
+      "y_coordinate": 1887,
+      "category": 0
+    },
+    {
+      "id": "AMAT2380",
+      "node_type": null,
+      "x_coordinate": 3631,
+      "y_coordinate": 344,
+      "category": 0
+    },
+    {
+      "id": "SMMG3020",
+      "node_type": null,
+      "x_coordinate": 2269,
+      "y_coordinate": 1235,
+      "category": 0
+    },
+    {
+      "id": "UCUG1800",
+      "node_type": null,
+      "x_coordinate": 96,
+      "y_coordinate": 1472,
+      "category": 0
+    },
+    {
+      "id": "DSAA2012",
+      "node_type": null,
+      "x_coordinate": 3269,
+      "y_coordinate": 1474,
+      "category": 0
+    },
+    {
+      "id": "UCUG1504",
+      "node_type": null,
+      "x_coordinate": 91,
+      "y_coordinate": 1060,
+      "category": 0
+    },
+    {
+      "id": "UFUG1401",
+      "node_type": null,
+      "x_coordinate": 1073,
+      "y_coordinate": 1605,
+      "category": 0
+    },
+    {
+      "id": "UFUG2601",
+      "node_type": null,
+      "x_coordinate": 1069,
+      "y_coordinate": 1938,
+      "category": 0
+    },
+    {
+      "id": "AIAA2290",
+      "node_type": null,
+      "x_coordinate": 2730,
+      "y_coordinate": 1772,
+      "category": 0
+    },
+    {
+      "id": "DSAA2044",
+      "node_type": null,
+      "x_coordinate": 3239,
+      "y_coordinate": 1366,
+      "category": 0
+    },
+    {
+      "id": "UFUG1105",
+      "node_type": null,
+      "x_coordinate": 1059,
+      "y_coordinate": 770,
+      "category": 0
+    },
+    {
+      "id": "AIAA3201",
+      "node_type": null,
+      "x_coordinate": 2732,
+      "y_coordinate": 1862,
+      "category": 0
+    },
+    {
+      "id": "SMMG4010",
+      "node_type": null,
+      "x_coordinate": 3241,
+      "y_coordinate": 1188,
+      "category": 0
+    },
+    {
+      "id": "UFUG1502",
+      "node_type": null,
+      "x_coordinate": 1603,
+      "y_coordinate": 1078,
+      "category": 0
+    },
+    {
+      "id": "UCUG1804",
+      "node_type": null,
+      "x_coordinate": 548,
+      "y_coordinate": 1472,
+      "category": 0
+    },
+    {
+      "id": "UFUG2106",
+      "node_type": null,
+      "x_coordinate": 1595,
+      "y_coordinate": 1797,
+      "category": 0
+    },
+    {
+      "id": "UFUG1504",
+      "node_type": null,
+      "x_coordinate": 1601,
+      "y_coordinate": 1175,
+      "category": 0
+    }
+  ],
+  "lines": [
+    {
+      "start_id": "UFUG2104",
+      "end_id": "((DSAA2011|DSAA2012|AIAA3111)&UFUG2103&UFUG2104)",
+      "line_type": false,
+      "x_coordinate": 2170,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT3060",
+      "end_id": "(AMAT2040&AMAT3060)",
+      "line_type": false,
+      "x_coordinate": 4585,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2010",
+      "end_id": "AMAT3820",
+      "line_type": null,
+      "x_coordinate": 3059,
+      "category": 1
+    },
+    {
+      "start_id": "ex_SMMG4901_SMMG4960",
+      "end_id": "ex_SMMG4960_SMMG4901",
+      "line_type": true,
+      "x_coordinate": 4372,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UFUG2102_UFUG2103",
+      "end_id": "ex_UFUG2103_UFUG2102",
+      "line_type": true,
+      "x_coordinate": 2315,
+      "category": 3
+    },
+    {
+      "start_id": "DSAA1001",
+      "end_id": "(UFUG2601|UFUG2602|DSAA1001)",
+      "line_type": true,
+      "x_coordinate": 2639,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UFUG1501_UFUG1503",
+      "end_id": "ex_UFUG1503_UFUG1501",
+      "line_type": true,
+      "x_coordinate": 1285,
+      "category": 3
+    },
+    {
+      "start_id": "DSAA2043",
+      "end_id": "DSAA2031",
+      "line_type": null,
+      "x_coordinate": 2652,
+      "category": 1
+    },
+    {
+      "start_id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "end_id": "((DSAA2011|DSAA2012|AIAA3111)&UFUG2103&UFUG2104)",
+      "line_type": false,
+      "x_coordinate": 3739,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UCUG1052A_UCUG1053",
+      "end_id": "ex_UCUG1053_UCUG1052A",
+      "line_type": true,
+      "x_coordinate": 827,
+      "category": 3
+    },
+    {
+      "start_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&UFUG1301)",
+      "end_id": "AMAT4540",
+      "line_type": null,
+      "x_coordinate": 3137,
+      "category": 1
+    },
+    {
+      "start_id": "(UCUG1052|UCUG1053)",
+      "end_id": "DLED3020",
+      "line_type": null,
+      "x_coordinate": 1164,
+      "category": 1
+    },
+    {
+      "start_id": "DSAA2011",
+      "end_id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "line_type": true,
+      "x_coordinate": 3209,
+      "category": 1
+    },
+    {
+      "start_id": "(DLED3010|AMAT2250)",
+      "end_id": "AMAT4095",
+      "line_type": null,
+      "x_coordinate": 5090,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UCUG1807_UFUG1801",
+      "end_id": "ex_UFUG1801_UCUG1807",
+      "line_type": false,
+      "x_coordinate": 305,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1052_UCUG1053",
+      "end_id": "ex_UCUG1053_UCUG1052",
+      "line_type": false,
+      "x_coordinate": 742,
+      "category": 3
+    },
+    {
+      "start_id": "DSAA1085",
+      "end_id": "SMMG4010",
+      "line_type": null,
+      "x_coordinate": 3223,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UCUG1900_UFUG1301",
+      "end_id": "ex_UFUG1301_UCUG1900",
+      "line_type": false,
+      "x_coordinate": 525,
+      "category": 3
+    },
+    {
+      "start_id": "(AMAT4901|AMAT4095)",
+      "end_id": "co_DLED4010[2]_(AMAT4901|AMAT4095)",
+      "line_type": null,
+      "x_coordinate": 5511,
+      "category": 2
+    },
+    {
+      "start_id": "(UFUG2601|UFUG2602)",
+      "end_id": "AIAA2205",
+      "line_type": null,
+      "x_coordinate": 2136,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1051",
+      "end_id": "UCUG1052S",
+      "line_type": null,
+      "x_coordinate": 505,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2103",
+      "end_id": "((UFUG1103|UFUG1106)&UFUG2101&UFUG2103)",
+      "line_type": false,
+      "x_coordinate": 2593,
+      "category": 1
+    },
+    {
+      "start_id": "co_AMAT2450_(DLED4010[2]|AMAT2450)",
+      "end_id": "(DLED4010[2]|AMAT2450)",
+      "line_type": true,
+      "x_coordinate": 5085,
+      "category": 2
+    },
+    {
+      "start_id": "ex_UCUG1071_UCUG1072",
+      "end_id": "ex_UCUG1072_UCUG1071",
+      "line_type": false,
+      "x_coordinate": 540,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1071_UCUG1073",
+      "end_id": "ex_UCUG1073_UCUG1071",
+      "line_type": false,
+      "x_coordinate": 507,
+      "category": 3
+    },
+    {
+      "start_id": "co_AIAA4490_(AIAA4490|DSAA4591)",
+      "end_id": "(AIAA4490|DSAA4591)",
+      "line_type": true,
+      "x_coordinate": 4526,
+      "category": 2
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504))",
+      "line_type": false,
+      "x_coordinate": 2189,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2602",
+      "end_id": "(UFUG2601|UFUG2602)",
+      "line_type": true,
+      "x_coordinate": 2057,
+      "category": 1
+    },
+    {
+      "start_id": "(AIAA4490|DSAA4591)",
+      "end_id": "co_DLED4020[2]_(AIAA4490|DSAA4591)",
+      "line_type": null,
+      "x_coordinate": 4882,
+      "category": 2
+    },
+    {
+      "start_id": "co_AMAT4095_(AMAT4901|AMAT4095)",
+      "end_id": "(AMAT4901|AMAT4095)",
+      "line_type": true,
+      "x_coordinate": 5389,
+      "category": 2
+    },
+    {
+      "start_id": "ex_SMMG3000_SMMG3010",
+      "end_id": "ex_SMMG3010_SMMG3000",
+      "line_type": true,
+      "x_coordinate": 2487,
+      "category": 3
+    },
+    {
+      "start_id": "UFUG1102",
+      "end_id": "(UFUG1102|UFUG1105)",
+      "line_type": true,
+      "x_coordinate": 1502,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2101",
+      "end_id": "((UFUG1103|UFUG1106)&UFUG2101&UFUG2103)",
+      "line_type": false,
+      "x_coordinate": 2578,
+      "category": 1
+    },
+    {
+      "start_id": "ex_AMAT4095_AMAT4901",
+      "end_id": "ex_AMAT4901_AMAT4095",
+      "line_type": true,
+      "x_coordinate": 5336,
+      "category": 3
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&AMAT2010)",
+      "line_type": false,
+      "x_coordinate": 2229,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1501|UFUG1503)",
+      "end_id": "((UFUG1501|UFUG1503)&(UFUG1102|UFUG1105))",
+      "line_type": false,
+      "x_coordinate": 1546,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UFUG1103_UFUG1106",
+      "end_id": "ex_UFUG1106_UFUG1103",
+      "line_type": true,
+      "x_coordinate": 1816,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1900_UFUG1302",
+      "end_id": "ex_UFUG1302_UCUG1900",
+      "line_type": false,
+      "x_coordinate": 525,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1052S_UCUG1053",
+      "end_id": "ex_UCUG1053_UCUG1052S",
+      "line_type": true,
+      "x_coordinate": 905,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UFUG1102_UFUG1105",
+      "end_id": "ex_UFUG1105_UFUG1102",
+      "line_type": true,
+      "x_coordinate": 1274,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UFUG1502_UFUG1504",
+      "end_id": "ex_UFUG1504_UFUG1502",
+      "line_type": true,
+      "x_coordinate": 1811,
+      "category": 3
+    },
+    {
+      "start_id": "UFUG1301",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&UFUG1301)",
+      "line_type": false,
+      "x_coordinate": 1998,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "AMAT2380",
+      "line_type": null,
+      "x_coordinate": 3097,
+      "category": 1
+    },
+    {
+      "start_id": "ex_UCUG1073_UCUG1074",
+      "end_id": "ex_UCUG1074_UCUG1073",
+      "line_type": false,
+      "x_coordinate": 508,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1052I_UCUG1053",
+      "end_id": "ex_UCUG1053_UCUG1052I",
+      "line_type": true,
+      "x_coordinate": 661,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UFUG1301_UFUG1303",
+      "end_id": "ex_UFUG1303_UFUG1301",
+      "line_type": true,
+      "x_coordinate": 1632,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1072_UCUG1074",
+      "end_id": "ex_UCUG1074_UCUG1072",
+      "line_type": false,
+      "x_coordinate": 777,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UFUG1301_UFUG1302",
+      "end_id": "ex_UFUG1302_UFUG1301",
+      "line_type": true,
+      "x_coordinate": 1296,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1071_UCUG1074",
+      "end_id": "ex_UCUG1074_UCUG1071",
+      "line_type": false,
+      "x_coordinate": 898,
+      "category": 3
+    },
+    {
+      "start_id": "ex_UCUG1050_UCUG1051",
+      "end_id": "ex_UCUG1051_UCUG1050",
+      "line_type": true,
+      "x_coordinate": 224,
+      "category": 3
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "((UFUG1103|UFUG1106)&UFUG2101&UFUG2103)",
+      "line_type": false,
+      "x_coordinate": 2296,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1502",
+      "end_id": "(UFUG1502|UFUG1504)",
+      "line_type": true,
+      "x_coordinate": 2062,
+      "category": 1
+    },
+    {
+      "start_id": "AIAA3111",
+      "end_id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "line_type": true,
+      "x_coordinate": 3488,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1303",
+      "end_id": "(UFUG1303&(UFUG1103|UFUG1106))",
+      "line_type": false,
+      "x_coordinate": 2075,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1301",
+      "end_id": "(UFUG1301|UFUG1302)",
+      "line_type": true,
+      "x_coordinate": 1534,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1106",
+      "end_id": "(UFUG1103|UFUG1106)",
+      "line_type": true,
+      "x_coordinate": 2035,
+      "category": 1
+    },
+    {
+      "start_id": "DSAA2011",
+      "end_id": "(DSAA2011|AIAA3111)",
+      "line_type": true,
+      "x_coordinate": 3208,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1501|UFUG1503)",
+      "end_id": "UFUG1502",
+      "line_type": null,
+      "x_coordinate": 1567,
+      "category": 1
+    },
+    {
+      "start_id": "DLED4040",
+      "end_id": "SMMG4960",
+      "line_type": null,
+      "x_coordinate": 2212,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2010",
+      "end_id": "AMAT3590",
+      "line_type": null,
+      "x_coordinate": 3038,
+      "category": 1
+    },
+    {
+      "start_id": "(DSAA1001|AIAA2205)",
+      "end_id": "DSAA2011",
+      "line_type": null,
+      "x_coordinate": 2672,
+      "category": 1
+    },
+    {
+      "start_id": "(DLED3010&AMAT2250)",
+      "end_id": "AMAT4901",
+      "line_type": null,
+      "x_coordinate": 5088,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1504",
+      "end_id": "AMAT4580",
+      "line_type": null,
+      "x_coordinate": 2256,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2102",
+      "end_id": "(UFUG2102|UFUG2103|UFUG2104)",
+      "line_type": true,
+      "x_coordinate": 2582,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1501|UFUG1503)",
+      "end_id": "SMMG3810",
+      "line_type": null,
+      "x_coordinate": 1525,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2601|UFUG2602)",
+      "end_id": "AIAA3201",
+      "line_type": null,
+      "x_coordinate": 2197,
+      "category": 1
+    },
+    {
+      "start_id": "(DLED4010[2]|AMAT2450)",
+      "end_id": "co_AMAT4095_(DLED4010[2]|AMAT2450)",
+      "line_type": null,
+      "x_coordinate": 5296,
+      "category": 2
+    },
+    {
+      "start_id": "co_AMAT2040_AMAT2450",
+      "end_id": "co_AMAT2450_AMAT2040",
+      "line_type": null,
+      "x_coordinate": 4128,
+      "category": 2
+    },
+    {
+      "start_id": "co_DLED4020[2]_AIAA4490",
+      "end_id": "co_AIAA4490_DLED4020[2]",
+      "line_type": null,
+      "x_coordinate": 4712,
+      "category": 2
+    },
+    {
+      "start_id": "(DLED4010[2]&AMAT2450)",
+      "end_id": "co_AMAT4901_(DLED4010[2]&AMAT2450)",
+      "line_type": null,
+      "x_coordinate": 5200,
+      "category": 2
+    },
+    {
+      "start_id": "co_DLED4010[2]_(DLED4010[2]|AMAT2450)",
+      "end_id": "(DLED4010[2]|AMAT2450)",
+      "line_type": true,
+      "x_coordinate": 5296,
+      "category": 2
+    },
+    {
+      "start_id": "co_DLED4010[2]_(DLED4010[2]&AMAT2450)",
+      "end_id": "(DLED4010[2]&AMAT2450)",
+      "line_type": false,
+      "x_coordinate": 5130,
+      "category": 2
+    },
+    {
+      "start_id": "co_SMMG4960_(SMMG4901|SMMG4960)",
+      "end_id": "(SMMG4901|SMMG4960)",
+      "line_type": true,
+      "x_coordinate": 4763,
+      "category": 2
+    },
+    {
+      "start_id": "co_AMAT2450_(DLED4010[2]&AMAT2450)",
+      "end_id": "(DLED4010[2]&AMAT2450)",
+      "line_type": false,
+      "x_coordinate": 4006,
+      "category": 2
+    },
+    {
+      "start_id": "co_SMMG4901_(SMMG4901|SMMG4960)",
+      "end_id": "(SMMG4901|SMMG4960)",
+      "line_type": true,
+      "x_coordinate": 4764,
+      "category": 2
+    },
+    {
+      "start_id": "DLED3010",
+      "end_id": "(DLED3010&AMAT2250)",
+      "line_type": false,
+      "x_coordinate": 1719,
+      "category": 1
+    },
+    {
+      "start_id": "(UCUG1052|UCUG1053)",
+      "end_id": "DLED3010",
+      "line_type": null,
+      "x_coordinate": 1164,
+      "category": 1
+    },
+    {
+      "start_id": "DLED3030",
+      "end_id": "DLED4030",
+      "line_type": null,
+      "x_coordinate": 1690,
+      "category": 1
+    },
+    {
+      "start_id": "SMMG3810",
+      "end_id": "SMMG3820",
+      "line_type": null,
+      "x_coordinate": 3184,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1301|UFUG1302)",
+      "end_id": "AMAT2030",
+      "line_type": null,
+      "x_coordinate": 1940,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2103",
+      "end_id": "((DSAA2011|DSAA2012|AIAA3111)&UFUG2103&UFUG2104)",
+      "line_type": false,
+      "x_coordinate": 2620,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1504",
+      "end_id": "(UFUG1502|UFUG1504)",
+      "line_type": true,
+      "x_coordinate": 2062,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2010",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&AMAT2010)",
+      "line_type": false,
+      "x_coordinate": 3020,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2601|UFUG2602)",
+      "end_id": "AIAA3102",
+      "line_type": null,
+      "x_coordinate": 2153,
+      "category": 1
+    },
+    {
+      "start_id": "DSAA1001",
+      "end_id": "(DSAA1001|AIAA2205)",
+      "line_type": true,
+      "x_coordinate": 2601,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2104",
+      "end_id": "(UFUG2102|UFUG2103|UFUG2104)",
+      "line_type": true,
+      "x_coordinate": 2607,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2250",
+      "end_id": "(DLED3010|AMAT2250)",
+      "line_type": true,
+      "x_coordinate": 4077,
+      "category": 1
+    },
+    {
+      "start_id": "(DSAA1001|AIAA2205)",
+      "end_id": "DSAA2044",
+      "line_type": null,
+      "x_coordinate": 2672,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1102|UFUG1105)",
+      "end_id": "((UFUG1501|UFUG1503)&(UFUG1102|UFUG1105))",
+      "line_type": false,
+      "x_coordinate": 1586,
+      "category": 1
+    },
+    {
+      "start_id": "(UCUG1052|UCUG1053)",
+      "end_id": "DLED3030",
+      "line_type": null,
+      "x_coordinate": 1164,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2103|UFUG2102)",
+      "end_id": "DSAA1085",
+      "line_type": null,
+      "x_coordinate": 2658,
+      "category": 1
+    },
+    {
+      "start_id": "DLED3040",
+      "end_id": "DLED4040",
+      "line_type": null,
+      "x_coordinate": 1689,
+      "category": 1
+    },
+    {
+      "start_id": "DSAA2012",
+      "end_id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "line_type": true,
+      "x_coordinate": 3714,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1051",
+      "end_id": "(UCUG1050|UCUG1051)",
+      "line_type": true,
+      "x_coordinate": 474,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2150",
+      "end_id": "AMAT2250",
+      "line_type": null,
+      "x_coordinate": 3608,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2102|UFUG2103|UFUG2104)",
+      "end_id": "SMMG3050",
+      "line_type": null,
+      "x_coordinate": 2721,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2103",
+      "end_id": "(UFUG2103|UFUG2102)",
+      "line_type": true,
+      "x_coordinate": 2560,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1601",
+      "end_id": "UFUG2106",
+      "line_type": null,
+      "x_coordinate": 1557,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1303&(UFUG1103|UFUG1106))",
+      "end_id": "AMAT2040",
+      "line_type": null,
+      "x_coordinate": 2961,
+      "category": 1
+    },
+    {
+      "start_id": "((DSAA2011|DSAA2012|AIAA3111)&UFUG2103&UFUG2104)",
+      "end_id": "DSAA2088",
+      "line_type": null,
+      "x_coordinate": 3780,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1501|UFUG1503)",
+      "end_id": "SMMG4020",
+      "line_type": null,
+      "x_coordinate": 1525,
+      "category": 1
+    },
+    {
+      "start_id": "(DSAA2011|AIAA3111)",
+      "end_id": "DSAA2012",
+      "line_type": null,
+      "x_coordinate": 3269,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT3350",
+      "end_id": "AMAT4570",
+      "line_type": null,
+      "x_coordinate": 4590,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2102",
+      "end_id": "(UFUG2103|UFUG2102)",
+      "line_type": true,
+      "x_coordinate": 2560,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2040",
+      "end_id": "(AMAT2040&AMAT3060)",
+      "line_type": false,
+      "x_coordinate": 4585,
+      "category": 1
+    },
+    {
+      "start_id": "(AMAT2040&AMAT3060)",
+      "end_id": "AMAT4560",
+      "line_type": null,
+      "x_coordinate": 4614,
+      "category": 1
+    },
+    {
+      "start_id": "AIAA3111",
+      "end_id": "(DSAA2011|AIAA3111)",
+      "line_type": true,
+      "x_coordinate": 3232,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1102|UFUG1105)",
+      "end_id": "UFUG1103",
+      "line_type": null,
+      "x_coordinate": 1563,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2103",
+      "end_id": "AMAT1510",
+      "line_type": null,
+      "x_coordinate": 2545,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1501",
+      "end_id": "(UFUG1501|UFUG1503)",
+      "line_type": true,
+      "x_coordinate": 1504,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "UFUG2103",
+      "line_type": null,
+      "x_coordinate": 2100,
+      "category": 1
+    },
+    {
+      "start_id": "(DSAA2011|DSAA2012|AIAA3111)",
+      "end_id": "DSAA4591",
+      "line_type": null,
+      "x_coordinate": 3800,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1302",
+      "end_id": "(UFUG1301|UFUG1302)",
+      "line_type": true,
+      "x_coordinate": 1535,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1052",
+      "end_id": "(UCUG1052|UCUG1053)",
+      "line_type": true,
+      "x_coordinate": 1041,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1401",
+      "end_id": "UFUG1402",
+      "line_type": null,
+      "x_coordinate": 1553,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&UFUG1301)",
+      "line_type": false,
+      "x_coordinate": 2128,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2601|UFUG2602|DSAA1001)",
+      "end_id": "AIAA3111",
+      "line_type": null,
+      "x_coordinate": 2682,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2103",
+      "end_id": "(UFUG2102|UFUG2103|UFUG2104)",
+      "line_type": true,
+      "x_coordinate": 2606,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2602",
+      "end_id": "(UFUG2601|UFUG2602|DSAA1001)",
+      "line_type": true,
+      "x_coordinate": 2034,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1502|UFUG1504)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504))",
+      "line_type": false,
+      "x_coordinate": 2150,
+      "category": 1
+    },
+    {
+      "start_id": "(SMMG4901|SMMG4960)",
+      "end_id": "co_DLED4040[2]_(SMMG4901|SMMG4960)",
+      "line_type": null,
+      "x_coordinate": 4868,
+      "category": 2
+    },
+    {
+      "start_id": "co_AMAT4901_(AMAT4901|AMAT4095)",
+      "end_id": "(AMAT4901|AMAT4095)",
+      "line_type": true,
+      "x_coordinate": 5468,
+      "category": 2
+    },
+    {
+      "start_id": "co_DLED4020[2]_DSAA4591",
+      "end_id": "co_DSAA4591_DLED4020[2]",
+      "line_type": null,
+      "x_coordinate": 4712,
+      "category": 2
+    },
+    {
+      "start_id": "co_DSAA4591_(AIAA4490|DSAA4591)",
+      "end_id": "(AIAA4490|DSAA4591)",
+      "line_type": true,
+      "x_coordinate": 4526,
+      "category": 2
+    },
+    {
+      "start_id": "co_DLED4040[2]_SMMG4901",
+      "end_id": "co_SMMG4901_DLED4040[2]",
+      "line_type": null,
+      "x_coordinate": 4732,
+      "category": 2
+    },
+    {
+      "start_id": "UCUG1050",
+      "end_id": "UCUG1052I",
+      "line_type": null,
+      "x_coordinate": 510,
+      "category": 1
+    },
+    {
+      "start_id": "AMAT2250",
+      "end_id": "(DLED3010&AMAT2250)",
+      "line_type": false,
+      "x_coordinate": 4102,
+      "category": 1
+    },
+    {
+      "start_id": "((UFUG1103|UFUG1106)&UFUG2101&UFUG2103)",
+      "end_id": "UFUG2105",
+      "line_type": null,
+      "x_coordinate": 2633,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1053",
+      "end_id": "(UCUG1052|UCUG1053)",
+      "line_type": true,
+      "x_coordinate": 1041,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1502|UFUG1504)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&AMAT2010)",
+      "line_type": false,
+      "x_coordinate": 2228,
+      "category": 1
+    },
+    {
+      "start_id": "(UCUG1050|UCUG1051)",
+      "end_id": "UCUG1052",
+      "line_type": null,
+      "x_coordinate": 545,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "UFUG2101",
+      "line_type": null,
+      "x_coordinate": 2074,
+      "category": 1
+    },
+    {
+      "start_id": "DLED3020",
+      "end_id": "DLED4020",
+      "line_type": null,
+      "x_coordinate": 1686,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1302",
+      "end_id": "UFUG1303",
+      "line_type": null,
+      "x_coordinate": 1560,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1502|UFUG1504)",
+      "end_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&UFUG1301)",
+      "line_type": false,
+      "x_coordinate": 2128,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "UFUG2102",
+      "line_type": null,
+      "x_coordinate": 2086,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1503",
+      "end_id": "(UFUG1501|UFUG1503)",
+      "line_type": true,
+      "x_coordinate": 1504,
+      "category": 1
+    },
+    {
+      "start_id": "DLED3010",
+      "end_id": "(DLED3010|AMAT2250)",
+      "line_type": true,
+      "x_coordinate": 1747,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "AIAA2711",
+      "line_type": null,
+      "x_coordinate": 2048,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1105",
+      "end_id": "(UFUG1102|UFUG1105)",
+      "line_type": true,
+      "x_coordinate": 1503,
+      "category": 1
+    },
+    {
+      "start_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504))",
+      "end_id": "AMAT2020",
+      "line_type": null,
+      "x_coordinate": 2350,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1051",
+      "end_id": "UCUG1052A",
+      "line_type": null,
+      "x_coordinate": 505,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1102|UFUG1105)",
+      "end_id": "UFUG2104",
+      "line_type": null,
+      "x_coordinate": 1578,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2601",
+      "end_id": "(UFUG2601|UFUG2602)",
+      "line_type": true,
+      "x_coordinate": 2078,
+      "category": 1
+    },
+    {
+      "start_id": "((UFUG1103|UFUG1106)&(UFUG1502|UFUG1504)&AMAT2010)",
+      "end_id": "AMAT2150",
+      "line_type": null,
+      "x_coordinate": 3117,
+      "category": 1
+    },
+    {
+      "start_id": "DLED3010",
+      "end_id": "DLED4010",
+      "line_type": null,
+      "x_coordinate": 1685,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1105",
+      "end_id": "UFUG1106",
+      "line_type": null,
+      "x_coordinate": 1549,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1502|UFUG1504)",
+      "end_id": "AMAT2050",
+      "line_type": null,
+      "x_coordinate": 2695,
+      "category": 1
+    },
+    {
+      "start_id": "UCUG1050",
+      "end_id": "(UCUG1050|UCUG1051)",
+      "line_type": true,
+      "x_coordinate": 474,
+      "category": 1
+    },
+    {
+      "start_id": "AIAA2205",
+      "end_id": "(DSAA1001|AIAA2205)",
+      "line_type": true,
+      "x_coordinate": 2603,
+      "category": 1
+    },
+    {
+      "start_id": "DSAA1085",
+      "end_id": "SMMG4030",
+      "line_type": null,
+      "x_coordinate": 3203,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG1103|UFUG1106)",
+      "end_id": "(UFUG1303&(UFUG1103|UFUG1106))",
+      "line_type": false,
+      "x_coordinate": 2114,
+      "category": 1
+    },
+    {
+      "start_id": "(UCUG1052|UCUG1053)",
+      "end_id": "DLED3040",
+      "line_type": null,
+      "x_coordinate": 1164,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1103",
+      "end_id": "(UFUG1103|UFUG1106)",
+      "line_type": true,
+      "x_coordinate": 2035,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG2601",
+      "end_id": "(UFUG2601|UFUG2602|DSAA1001)",
+      "line_type": true,
+      "x_coordinate": 2169,
+      "category": 1
+    },
+    {
+      "start_id": "(UFUG2601|UFUG2602)",
+      "end_id": "DSAA2043",
+      "line_type": null,
+      "x_coordinate": 2118,
+      "category": 1
+    },
+    {
+      "start_id": "((UFUG1501|UFUG1503)&(UFUG1102|UFUG1105))",
+      "end_id": "UFUG1504",
+      "line_type": null,
+      "x_coordinate": 1586,
+      "category": 1
+    },
+    {
+      "start_id": "UFUG1601",
+      "end_id": "UFUG2602",
+      "line_type": null,
+      "x_coordinate": 1555,
+      "category": 1
+    }
+  ]
+}

--- a/app/data/scheduler_offerings/25-26spring.json
+++ b/app/data/scheduler_offerings/25-26spring.json
@@ -1,0 +1,16331 @@
+{
+  "semester_id": "2530",
+  "courses": [
+    {
+      "course_code": "AIAA1010",
+      "sections": [
+        {
+          "course_code": "AIAA1010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6417",
+          "quota": 100,
+          "enrol": 53,
+          "avail": 47,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 101, W1",
+              "instructor": "BAI, Ge & CHEN, Huangxun & CHU, Xiaowen & KAN, Ge Lin & LIANG, Junwei & QIN, Chengwei & RIKOS, APOSTOLOS & WANG, Xin & WANG, Zeyu & XIE, Sihong & XIE, Zeke & YANG, Menglin & YUE, Yutao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "1010",
+      "course_title": "Academic Orientation for AI Students",
+      "course_desc": "This course provides guidance to undergraduate students of the AI major for their academic path and future. This course is mostly introductory and aims to inspire UG students for their academic path development and growth of maturity during their UG study. Activities may include seminars, workshops, advising and sharing sessions, interaction with faculty and teaching staff, and discussion with student peers or alumni. Graded P or F.",
+      "credit": 1,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA2205",
+      "sections": [
+        {
+          "course_code": "AIAA2205",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6400",
+          "quota": 50,
+          "enrol": 36,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 148, E1",
+              "instructor": "LIU, Li"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA2205",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6401",
+          "quota": 50,
+          "enrol": 32,
+          "avail": 18,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 147, E1",
+              "instructor": "CHEN, Jintai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "2205",
+      "course_title": "Introduction to Artificial Intelligence",
+      "course_desc": "The objective of this course is to present an overview of the principles and practices of AI and to address complex real-world problems. Through introduction of AI tools and techniques, the course helps students develop a basic understanding of problem solving, search, theorem proving, knowledge representation, reasoning and planning methods of AI; and develop practical applications in vision, language, and so on. Topics include foundations (search, knowledge representation, machine learning and natural language understanding) and applications (data mining, decision support systems, adaptive web sites, web log analysis).",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA2711",
+      "sections": [
+        {
+          "course_code": "AIAA2711",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6418",
+          "quota": 90,
+          "enrol": 90,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 101, E1",
+              "instructor": "ZHONG, Bingzhuo"
+            },
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 101, E1",
+              "instructor": "ZHONG, Bingzhuo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA2711",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6419",
+          "quota": 90,
+          "enrol": 58,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Lecture Hall C",
+              "instructor": "RIKOS, APOSTOLOS"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "2711",
+      "course_title": "Mathematics for AI",
+      "course_desc": "This course aims to teach students the basic math concepts for Artificial Intelligence (AI). Key topics include fundamental Linear Algebra (Matrix Calculations, Norms, Eigenvectors and Eigenvalues), Calculus (Derivative, Taylor series, Multivariate Calculus), and Probability Theory (Distributions, Statistics of Random Variables, Bayes’ theorem). With these mathematical concepts, some basic principles of numerical optimization and typical AI algorithms (Gradient Descent, Maximum-likelihood, Regression, Least Square Estimation, Spectral Clustering, Matrix Decomposition, etc.) will also be introduced as examples to better relate math to AI. The approach of this course is specifically AI application oriented, aiming to help students to quickly establish a fundamental mathematical knowledge structure for AI studies. Through this course, students will acquire the fundamental mathematical concepts required for AI, understand the connections between AI and mathematics, and get prepared to learn the mathematical principles, formulas, inductions, and relevant proofs for advanced AI algorithms.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA3053",
+      "sections": [
+        {
+          "course_code": "AIAA3053",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6420",
+          "quota": 80,
+          "enrol": 76,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 101, E1",
+              "instructor": "RIKOS, APOSTOLOS"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "3053",
+      "course_title": "Reinforcement Learning: Principles and Methods",
+      "course_desc": "The implementation of autonomous systems requires agents to learn how to make decisions. Reinforcement learning is a powerful paradigm for achieving such a goal, and it is relevant to an enormous range of tasks, including robotics, game playing, operations research, healthcare and more. This course provides a solid introduction to the field of reinforcement learning. Students learn about the core challenges and approaches, including generalization and exploration. Through the combination of lectures, written and coding assignments, and course projects, students are equipped with modeling and learning algorithm techniques for sequential decision-making problems. Assignments include the basics of reinforcement learning as well as deep reinforcement learning — an extremely promising new area that combines deep learning advancements with reinforcement learning.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA3201",
+      "sections": [
+        {
+          "course_code": "AIAA3201",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6424",
+          "quota": 48,
+          "enrol": 48,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Rm 147, E1",
+              "instructor": "CHEN, Yingcong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA3201",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6425",
+          "quota": 48,
+          "enrol": 48,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Rm 134, E1",
+              "instructor": "WANG, Hao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA3201",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6426",
+          "quota": 48,
+          "enrol": 48,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1530",
+              "end_time": "1620",
+              "room": "Rm 228, E1",
+              "instructor": "CHEN, Yingcong"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA3201",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6427",
+          "quota": 48,
+          "enrol": 48,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1530",
+              "end_time": "1620",
+              "room": "Rm 134, E1",
+              "instructor": "WANG, Hao"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "3201",
+      "course_title": "Introduction to Computer Vision",
+      "course_desc": "This course aims to provide a solid understanding of modern Computer Vision. It starts with essential backgrounds in image processing and classical vision methods, then transitions to contemporary learning-based techniques. Students will master core architectures including CNNs, Transformers, and generative models like GANs and Diffusion. Advanced modules explore detection, segmentation, and learning-based 3D vision. The course emphasizes problem-solving through a practical mini-project, encouraging students to apply these algorithms to real-world needs such as biomedical analysis or AR/VR. Students will finish the course ready to conduct independent research and develop innovative vision solutions.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Lab required]"
+    },
+    {
+      "course_code": "AIAA4051",
+      "sections": [
+        {
+          "course_code": "AIAA4051",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6428",
+          "quota": 80,
+          "enrol": 80,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 101, E1",
+              "instructor": "XIE, Sihong"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 101, E1",
+              "instructor": "XIE, Sihong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "4051",
+      "course_title": "Introduction to Natural Language Processing",
+      "course_desc": "This course provides a comprehensive journey into Natural Language Processing, first establishing the essential computational fundamentals of words, syntax, and semantics, and then advancing to the modern architectures that define the LLM era, such as transformers and GPT. You will learn to bridge classic techniques with cutting-edge applications—mastering pre-training, fine-tuning, and prompt engineering—while critically examining the advanced capabilities and profound responsibilities surrounding fairness, security, and interpretability. Through a blend of foundational theory and hands-on projects, this course equips you to build, innovate, and lead in the rapidly evolving field of applied NLP.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA4641",
+      "sections": [
+        {
+          "course_code": "AIAA4641",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6429",
+          "quota": 65,
+          "enrol": 55,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1920",
+              "room": "Rm 122, E1",
+              "instructor": "DAI, Enyan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AIAA4641",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6430",
+          "quota": 65,
+          "enrol": 55,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 228, E1 & Rm 227, E1",
+              "instructor": "DAI, Enyan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "4641",
+      "course_title": "Social Information Network Analysis and Engineering",
+      "course_desc": "This course is an introduction to social information network analysis and engineering. Students will learn both mathematical and programming knowledge for analyzing the structures and dynamics of typical social information networks (e.g., Facebook, Twitter, and MSN). They will also learn how social metrics can be used to improve computer system design as people are the networks. It will cover topics such as small world phenomenon; contagion, tipping and influence in networks; models of network formation and evolution; the web graph and PageRank; social graphs and community detection; measuring centrality; greedy routing and navigations in networks; introduction to game theory and strategic behavior; social engineering; and principles of computer system design.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA4711",
+      "sections": [
+        {
+          "course_code": "AIAA4711",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6431",
+          "quota": 40,
+          "enrol": 17,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, W2",
+              "instructor": "BAI, Ge"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "4711",
+      "course_title": "Introduction to Advanced Algorithmic Techniques",
+      "course_desc": "The course aims to introduce advanced methods for designing and analyzing algorithms for solving tough problems. The topics cover useful advanced data structures, graph algorithms, heuristic searching algorithms and optimization algorithms that promote the development of AI. Also, students will learn algorithm design and analysis skills for computationally intractable problems, such as NP-completeness, randomized algorithms, approximation algorithms and amortized analysis. Additional topics, such as string matching, geometric and number-theoretic algorithms, will also be introduced. The course presents the topics at an introductory level and aims at senior undergraduate students. Through the class, students will develop a deeper understanding of algorithm design and demonstrate a basic understanding of the principles of advanced algorithms.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5026",
+      "sections": [
+        {
+          "course_code": "AIAA5026",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6033",
+          "quota": 130,
+          "enrol": 122,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Lecture Hall C",
+              "instructor": "CHEN, Yingcong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5026",
+      "course_title": "Computer Vision and Its Applications",
+      "course_desc": "This course covers popular topics in computer vision, which includes high-level tasks like image classification, object detection, image segmentation, and low-level tasks like image generation, image enhancement, image-to-image translation, etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5032",
+      "sections": [
+        {
+          "course_code": "AIAA5032",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6034",
+          "quota": 120,
+          "enrol": 73,
+          "avail": 47,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W1",
+              "instructor": "LIANG, Junwei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5032",
+      "course_title": "Foundations of Artificial Intelligence",
+      "course_desc": "This course aims to provide students with an overview of Artificial Intelligence (AI) principles and techniques. Key topics include machine learning, search, game theories, Markov decision process, constraint satisfaction problems, Bayesian networks, etc. Through this course, students will learn and practice the foundational principles, techniques and tools to tackle new AI problems.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5033",
+      "sections": [
+        {
+          "course_code": "AIAA5033",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6035",
+          "quota": 80,
+          "enrol": 69,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, W4",
+              "instructor": "ZHONG, Bingzhuo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5033",
+      "course_title": "AI Security and Privacy",
+      "course_desc": "This course introduces potential security and privacy vulnerabilities in Artificial Intelligence (AI) and covers basic and advanced protections. Topics include security and privacy risks in AI technologies, the goal of C.I.A. (Confidentiality, Integrity and Availability) in AI technologies, basic and advanced cryptography, protocol designs for AI security and privacy, etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5047",
+      "sections": [
+        {
+          "course_code": "AIAA5047",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6036",
+          "quota": 40,
+          "enrol": 21,
+          "avail": 19,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 150, E1",
+              "instructor": "XIE, Zeke"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5047",
+      "course_title": "Responsible Artificial Intelligence",
+      "course_desc": "Artificial Intelligence technologies have been maturing and are deployed in real-world applications, such as healthcare, entertainment, business, scientific research, military, etc. In all these domains, the decisions made by AI algorithms can critically impact individuals, organizations and society. The designers, auditors, and users of AI technologies thus need to be equipped with the capabilities to understand, analyze, and eventually discipline these algorithms in the broader contexts. This course will introduce students to the latest research of responsible AI and explore these capabilities in both theoretical and practical ways. Topics include but are not limited to theories and algorithms of secure machine learning, fair machine learning, interpretable AI, and case studies involving natural language processing, computer vision, and reinforcement learning.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5048",
+      "sections": [
+        {
+          "course_code": "AIAA5048",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6038",
+          "quota": 45,
+          "enrol": 40,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W4",
+              "instructor": "WANG, Hao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5048",
+      "course_title": "Multimodal Artificial Intelligence",
+      "course_desc": "This course focuses on the Artificial Intelligence (AI) techniques and applications in multimodal tasks, which involve processing, fusing, and generating contents from multiple data modalities, such as images, videos, text etc. The course will cover the challenges, state-of-the-art methods, as well as hands-on experience in implementing and evaluating multi-modal deep learning models.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA5050",
+      "sections": [
+        {
+          "course_code": "AIAA5050",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6040",
+          "quota": 50,
+          "enrol": 38,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 228, E2",
+              "instructor": "YUE, Yutao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "5050",
+      "course_title": "Machine Consciousness",
+      "course_desc": "The study of consciousness is referred to as the \"ultimate challenge of artificial intelligence.\" This course provides instruction and discussions in the field of machine consciousness. The main content includes an introduction to consciousness research, mainstream theories of consciousness, research on self-awareness, attention mechanisms, optimization of intelligent agent goals, subjectivity and affective computing, consciousness modeling and evaluation of artificial intelligence systems, and analysis and control of risks related to machine consciousness. Through this course, participants can gain a fairly comprehensive and in-depth understanding of the research history and current status of the field of machine consciousness, and engage in collaborative research on several specific issues.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA6091A",
+      "sections": [],
+      "subject": "AIAA",
+      "catalog_number": "6091A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member. Graded P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "3 credits",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA6091B",
+      "sections": [],
+      "subject": "AIAA",
+      "catalog_number": "6091B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA6101",
+      "sections": [
+        {
+          "course_code": "AIAA6101",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6366",
+          "quota": 180,
+          "enrol": 180,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1420",
+              "room": "Lecture Hall C",
+              "instructor": "ZHONG, Bingzhuo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AIAA",
+      "catalog_number": "6101",
+      "course_title": "Artificial Intelligence Seminar I",
+      "course_desc": "Series of seminars presenting research problems currently under investigation, presented by faculty, students, and visiting speakers. Students are expected to attend regularly. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA6990",
+      "sections": [],
+      "subject": "AIAA",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AIAA7990",
+      "sections": [],
+      "subject": "AIAA",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT1010",
+      "sections": [
+        {
+          "course_code": "AMAT1010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6222",
+          "quota": 50,
+          "enrol": 24,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 147, E1",
+              "instructor": "CHEN, Guo & CHU, Xiakun & GAN, Zecheng & GAO, Ping & HUANG, Yang & LI, Haoxiang & LIU, Jinguo & WANG, Jun & WU, Jiaying & WU, Xiaoxiao & YUAN, Jiaxing & ZHOU, Tong & ZHU, Guoyi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AMAT",
+      "catalog_number": "1010",
+      "course_title": "Academic orientation for AMAT students",
+      "course_desc": "The first part of the compulsory one-year development course series for AMAT students. This course aims to provide introduction of materials, giving students the idea regarding the role of materials in the daily life and technological applications. In addition, academic and professional advising to students and to develop their technical and non-technical communication skills and professional ethics will be provided. Graded P/PP/F.",
+      "credit": 1,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT2010",
+      "sections": [
+        {
+          "course_code": "AMAT2010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6226",
+          "quota": 50,
+          "enrol": 7,
+          "avail": 43,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 149, E1",
+              "instructor": "GAN, Zecheng & GAO, Ping"
+            },
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 149, E1",
+              "instructor": "GAN, Zecheng & GAO, Ping"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "AMAT2010",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6227",
+          "quota": 50,
+          "enrol": 7,
+          "avail": 43,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 149, E1",
+              "instructor": "GAN, Zecheng & GAO, Ping"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "AMAT",
+      "catalog_number": "2010",
+      "course_title": "Process and Materials Design Principles",
+      "course_desc": "This course introduces the fundamentals of transport processes in materials and key principles of materials design. Topics cover dimensional analysis, momentum, energy, heat, and mass transfer, and the systematic design and preparation of materials for science and engineering applications.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT5600",
+      "sections": [
+        {
+          "course_code": "AMAT5600",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6039",
+          "quota": 40,
+          "enrol": 15,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, W4",
+              "instructor": "ZHOU, Tong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AMAT",
+      "catalog_number": "5600",
+      "course_title": "Solid State Physics and Quantum Materials",
+      "course_desc": "This is an introductory course for postgraduate students with materials science background. Basic topics of solid state physics including electronic band structure, phonons, electron interactions and spin correlations will be covered. In addition, modern topics of high temperature superconductors, topological electrons, spin liquids and low dimensional systems will be introduced, providing a beginnerâs guide to quantum materials.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT5900",
+      "sections": [
+        {
+          "course_code": "AMAT5900",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6044",
+          "quota": 20,
+          "enrol": 8,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, W1",
+              "instructor": "WU, Jiaying"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AMAT",
+      "catalog_number": "5900",
+      "course_title": "Molecular Physics and Optoelectronic Processes",
+      "course_desc": "This course will cover the physics of the electronic structure of pi-conjugated materials and their neutral, excited and charged states (excitons, polarons), their optical properties (absorption, emission), photophysical processes, photochemistry, energy transfer and charge transport. It will introduce the principles of design and operation of molecular based light emitting devices, solar cells etc. as well as providing an introduction to device fabrication and device engineering for maximum performance and lifetime.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT5910",
+      "sections": [
+        {
+          "course_code": "AMAT5910",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6045",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 134, E1",
+              "instructor": "TAN, Chee Keong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "AMAT",
+      "catalog_number": "5910",
+      "course_title": "Compound Semiconductor Materials Technology",
+      "course_desc": "Compound semiconductor materials have been deeply integrated in various gadgets nowadays, shaping the new world in an unimaginable way. Understanding compound semiconductor materials is critical as one of the first steps towards understanding how the advanced technology evolves continuously, from the past to the future. This course aims to introduce an overview of compound semiconductor materials, linking the fundamental physics, materials and devices to the point where the students can specialize and assist them in their supervised research. The course contains fundamentals of semiconductor physics and semiconductor specifics including technologically relevant materials and their properties, doping and defects and heterostructures. General and detailed discussions on linking materials and devices for applications will be covered at the later stage in the course.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT6900A",
+      "sections": [],
+      "subject": "AMAT",
+      "catalog_number": "6900A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT6900B",
+      "sections": [],
+      "subject": "AMAT",
+      "catalog_number": "6900B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT6990",
+      "sections": [],
+      "subject": "AMAT",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "AMAT7990",
+      "sections": [],
+      "subject": "AMAT",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE5200",
+      "sections": [
+        {
+          "course_code": "BSBE5200",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6130",
+          "quota": 15,
+          "enrol": 7,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, E4",
+              "instructor": "XIA, Jun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "5200",
+      "course_title": "Principles of Neuroscience and Related Diseases",
+      "course_desc": "This course covers the basic knowledge of nervous system, and the clinical manifestation, anatomy, physiology, pathophysiology, diagnosis, and treatment of common nervous system diseases, with focus on the underlying molecular mechanism of the diseases and treatments.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6000J",
+      "sections": [
+        {
+          "course_code": "BSBE6000J",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6132",
+          "quota": 15,
+          "enrol": 5,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, W1",
+              "instructor": "LU, Hongyuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "6000J",
+      "course_title": "Advances and Applications of Bioengineering",
+      "course_desc": "This course provides a comprehensive exploration of the latest advancements and applications within the field of bioengineering. Designed for students with a solid foundation in biology, chemistry, or engineering, this course aims to deepen understanding and enhance skills across key sub-disciplines including protein engineering, synthetic biology, metabolic engineering, and biomedical engineering.\n\nThroughout the course, students will actively engage with cutting-edge research and case studies that demonstrate the practical implementation of bioengineering solutions across diverse sectors such as medicine, industry, and the environment. Core topics encompass the strategic design and modification of proteins for therapeutic and industrial uses, the construction of synthetic biological systems for novel functions, optimization of metabolic pathways for improved production processes, and the development of innovative biomedical devices and techniques for health care improvements.\n\nThis course is designed to ensure that students not only acquire comprehensive theoretical knowledge but also gain practical experience in applying engineering principles to biological systems. Through a blend of lectures, practical sessions, and project work, students will develop the essential knowledge and skills required to tackle complex challenges and lead future innovations in bioengineering.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6000L",
+      "sections": [
+        {
+          "course_code": "BSBE6000L",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6135",
+          "quota": 15,
+          "enrol": 5,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, E3",
+              "instructor": "ZHANG, Cheng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "6000L",
+      "course_title": "Structural Biology and Drug Discovery",
+      "course_desc": "The course is structured into two main sections: the first part explores the fundamental principles and the latest advancements in structural biology, which are essential for understanding the molecular basis underlying drug action. The second part presents a thorough overview of the various modalities to drug discovery as practiced in the pharmaceutical industry, demonstrating how knowledge of protein structures can be used to design and optimize drug molecules.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6000M",
+      "sections": [
+        {
+          "course_code": "BSBE6000M",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6137",
+          "quota": 15,
+          "enrol": 10,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W2",
+              "instructor": "SHEN, Yang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "6000M",
+      "course_title": "Exploring Advanced Techniques in Molecular Biology",
+      "course_desc": "Innovative tools, methods, and approaches continuously reshape various fields, offering fresh perspectives and avenues for exploration. This course is designed to equip students with an understanding of cutting-edge approaches enabling the manipulation and visualization of specific molecular processes within distinct cell types. Participants will learn how to apply these techniques to their own research and refine their capacity to adapt or innovate methodologies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6000P",
+      "sections": [
+        {
+          "course_code": "BSBE6000P",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6138",
+          "quota": 15,
+          "enrol": 11,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 105, E3",
+              "instructor": "PAN, Cuiping"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "6000P",
+      "course_title": "Data Mining in Bioinformatics",
+      "course_desc": "The rapid advancements in omics technologies, such as genomics, transcriptomics, and proteomics, have led to the generation of vast amounts of biological data, highlighting the need for effective analytical methods. This course provides a comprehensive overview of bioinformatics methods and databases, showcasing their applications in biological and biomedical datasets. Students will delve into various data mining algorithms and tools, learn to preprocess and analyze diverse omics data, and gain practical experience in interpreting results. By the end of the course, participants will be able to extract meaningful insights from complex biological data.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6200A",
+      "sections": [],
+      "subject": "BSBE",
+      "catalog_number": "6200A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member on a Bioscience and Biomedical Engineering topic.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6200B",
+      "sections": [],
+      "subject": "BSBE",
+      "catalog_number": "6200B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member on a Bioscience and Biomedical Engineering topic.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6800J",
+      "sections": [
+        {
+          "course_code": "BSBE6800J",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6139",
+          "quota": 80,
+          "enrol": 38,
+          "avail": 42,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "0950",
+              "room": "Rm 102, E4",
+              "instructor": "GOTO, AKIHIRO"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "BSBE",
+      "catalog_number": "6800J",
+      "course_title": "Seminar in Bioscience and Biomedical Engineering",
+      "course_desc": "Seminar topics presented by students, faculty and guest speakers. Students are expected to attend regularly and demonstrate proficiency in presentation in accordance with the program requirements. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE6990",
+      "sections": [],
+      "subject": "BSBE",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "BSBE7990",
+      "sections": [],
+      "subject": "BSBE",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5002",
+      "sections": [
+        {
+          "course_code": "CMAA5002",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6069",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "E2-L3 Digital Media Lab & Rm 105, E3",
+              "instructor": "ZHANG, Junjie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5002",
+      "course_title": "Animation Art: From Concept to Production",
+      "course_desc": "From screenplay through post-production, students are immersed in the collaborative animation pipeline. In this course, students will utilize a variety of animation tools and techniques to tell a compelling story and experience the diverse roles within the animation industry through storyboarding, editing and completion of a short animated film.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5007",
+      "sections": [
+        {
+          "course_code": "CMAA5007",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6273",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 103, E1",
+              "instructor": "ZHANG, Kang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "CMAA5007",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6274",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 103, E1",
+              "instructor": "ZHANG, Kang"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5007",
+      "course_title": "Computational Approach to Chinese Calligraphy",
+      "course_desc": "This course covers the most fundamental knowledge and techniques of Chinese calligraphy and its important role in the modern technological advances. The history and various styles of calligraphy, history and principles of making rice paper, seal making and its role, and best-known calligraphers are introduced. Students will first learn and practice writing Chinese calligraphy on rice paper and then use deep learning tools to transfer interesting calligraphy styles. Students will develop projects, such as programming to generate or drive robots to write calligraphy. There will be guest lectures by well-known Chinese calligraphers and researchers in digitizing and modernizing Chinese calligraphy. A trip is planned to visit the best-known rice paper factory (çº¢æå®£çº¸å) in Jingxian, Anhui, where all Four Treasures of calligraphy are located.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[2-1-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5013",
+      "sections": [
+        {
+          "course_code": "CMAA5013",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6043",
+          "quota": 20,
+          "enrol": 17,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 202, W1",
+              "instructor": "YIP, David Kei Man"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5013",
+      "course_title": "Interactive Storytelling",
+      "course_desc": "This course explores interactive storytelling as cinematic, narrative and interactive art forms. It focuses on the art and techniques of visual storytelling that can interact thematically with the audience in meaningful ways. Students will learn about the key aspects of filmmaking and can apply narrative and interactive principles to storytelling in playable media and platform.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5017",
+      "sections": [
+        {
+          "course_code": "CMAA5017",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6382",
+          "quota": 20,
+          "enrol": 18,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, W2",
+              "instructor": "FAN, Mingming"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5017",
+      "course_title": "AR/VR/MR/XR: Concepts, Theory and Techniques",
+      "course_desc": "This course introduces students to the concepts, theories, and interaction techniques in AR/VR/MR/XR. It covers both the fundamental concepts and design theories and the state-of-the-art interaction techniques in the field. In addition, students will work independently or in teams to design, develop, and evaluate AR/VR/MR/XR applications. In sum, by the end of the class, students will have a solid grasp of the fundamental concepts, and theories and hands-on experience in AR/VR/MR/XR.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5022",
+      "sections": [
+        {
+          "course_code": "CMAA5022",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6278",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1650",
+              "room": "Rm 223, W1",
+              "instructor": "HUI, Pan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "CMAA5022",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6279",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 223, W1",
+              "instructor": "HUI, Pan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5022",
+      "course_title": "Social Media for Creatives",
+      "course_desc": "This course introduces art and media students to the various online social media platforms, as well as the fundamentals of producing artistic and creative media content in collaborative group projects. The course covers a wide range of interesting topics related to art and creativity techniques and functions on social media platforms, including but not limited to: digital storytelling, games and gamification, immersive art technologies, presentation, and advertisement. By the end of this course, students will have a better understanding of art and creativity on social media platforms.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[2-1-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5027",
+      "sections": [
+        {
+          "course_code": "CMAA5027",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6047",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, E3",
+              "instructor": "SHE, Pei Man James"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5027",
+      "course_title": "Emerging Technologies in Media, Art and Heritage",
+      "course_desc": "This course provides students with the necessary knowledge and skills to critically evaluate the role and use of emerging computational technologies in Art, Media, and Heritage. These technologies include Generative AI, Natural Language Processing, Sentiment Analysis, and others. Students will learn to select and assess these technologies based on their ability to best support the core values of art creation, media production, and heritage applications through various coursework. The course will feature real-world experience, case studies, and guest speakers to provide students with a practical understanding of these technologies. Furthermore, students will receive hands-on technical training through weekly or bi-weekly practical activities. Eventually, students will develop innovative content or applications for exhibition or real-world collaboration.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5030",
+      "sections": [
+        {
+          "course_code": "CMAA5030",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6048",
+          "quota": 20,
+          "enrol": 11,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, E4",
+              "instructor": "COSTA HAMIDO, OMAR"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5030",
+      "course_title": "Interactive Music Systems Design",
+      "course_desc": "The course provides a comprehensive overview of the main digital sound manipulation and synthesis and their application in the design of interactive music systems. At the end of the course, students will have a solid knowledge of Pure Data, a visual programming language that can be incorporated in a number of interactive environments. Additionally, a number of research topics in the field will be explored.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5032",
+      "sections": [
+        {
+          "course_code": "CMAA5032",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6050",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 223, W1",
+              "instructor": "LIANG, Haining"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5032",
+      "course_title": "Advanced Game Development",
+      "course_desc": "This course delves deeper into the intricacies of creating sophisticated and engaging video games. This course is designed for students who have a foundational understanding of game development and are looking to enhance their skills in areas such as advanced programming, complex game mechanics, AI integration, and immersive storytelling. Emphasizing a project-based approach, the course allows students to work on elaborate game projects, encouraging collaboration and innovation. Throughout the course, students will also explore emerging trends and technologies shaping the future of the gaming industry. This course is perfect for those aiming to refine their game development expertise and craft compelling, high-quality gaming experiences.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5033",
+      "sections": [
+        {
+          "course_code": "CMAA5033",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6052",
+          "quota": 15,
+          "enrol": 9,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 201, E4",
+              "instructor": "DR. REICHLE, INGEBORG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5033",
+      "course_title": "Computational Media and Arts Theory I",
+      "course_desc": "This course delves into the critical exploration of cultural and philosophical theories that underpin the evolving landscape of computational media arts. It immerses students in relevant readings and discussions, providing them with a deep understanding of the complex interplay between humanities, science, technology, culture, and art. Through the examination of key texts and critical debates, students will engage with concepts that shape the field, such as digital aesthetics, media archaeology, cybernetics, posthumanism, and the impact of technology on society.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5041",
+      "sections": [
+        {
+          "course_code": "CMAA5041",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6055",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 202, E1",
+              "instructor": "WANG, Yuyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5041",
+      "course_title": "Experiment Design for Protocol Optimization",
+      "course_desc": "This course is for students who want to improve their skills in designing and optimizing experiment protocol in HCI study. It focuses on helping students understand the difference between exploring new ideas and confirming what we already know. The course covers key concepts like how to plan experiments, test different variables, and find the best solutions using advanced techniques to verify their new interaction protocol. Students will also learn both quantitative (numbers-based) and qualitative (observation-based) research methods, giving them a strong foundation for conducting experiments. Along with learning how to design experiments, students will get hands on experience with statistical tools to analyze data and make informed decisions. By the end of the course, students will be confident in using these methods to solve real-world problems and improve processes in different areas of research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA5043",
+      "sections": [
+        {
+          "course_code": "CMAA5043",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6059",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 202, W4",
+              "instructor": "TONG, Xin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "5043",
+      "course_title": "Creative Prototyping: Designing Interactive Experiences",
+      "course_desc": "This course offers a comprehensive introduction to UX/interfaces/interaction design methods with a focus on prototyping interactive and intelligent interfaces and systems. Students will explore core design theories, human-centered design principles, and gain hands-on experience in developing prototypes using web frameworks and generative AI tools. Through a combination of seminars, practical design sessions, and a final project, students will acquire the technical and critical thinking skills needed to create innovative, interactive, and intelligent technologies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6018A",
+      "sections": [],
+      "subject": "CMAA",
+      "catalog_number": "6018A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6018B",
+      "sections": [],
+      "subject": "CMAA",
+      "catalog_number": "6018B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6019H",
+      "sections": [
+        {
+          "course_code": "CMAA6019H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6446",
+          "quota": 15,
+          "enrol": 11,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 202, W2 & E2-L3 Open Lab",
+              "instructor": "MINSKY, MARGARET DIANE REZVAN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "6019H",
+      "course_title": "E-Textiles",
+      "course_desc": "Textiles are one of the oldest, most pervasive, and most continually evolving technologies used throughout human activity. The intimacy of textiles with our daily lives and our senses provides an opportunity to create useful, evocative, and fun creations. Whether we are making one-of-a kind garment creations, or exploring techniques that can be applied more broadly to textiles for work, play, and display, we learn how to combine traditionally soft and conforming materials with other technologies. We will integrate electronic technologies for signals and light, programming of computer embroidery machines, and explore new manufacturing technologies. The class is grounded in project-based learning, combined with reading and discussion of research papers. We will create and exhibit wearable and/or portable e-Textile items as final projects.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6019I",
+      "sections": [
+        {
+          "course_code": "CMAA6019I",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6447",
+          "quota": 15,
+          "enrol": 15,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 201, E4 & E2-L3 Open Lab",
+              "instructor": "MERENDINO, NICOLO"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "6019I",
+      "course_title": "Digital Fabrication & Physical Computing",
+      "course_desc": "In the Digital Fabrication and Physical Computing course, 3D printing, laser cutting, CNC milling, and other fabrication technologiesâalongside fundamental electronics, coding, and circuit designâwill be introduced to students. Adopting a hands-on approach, this course equips students with foundational prototype development skills; no prior experience is required. The construction of physical devices is an important part of contemporary artistic and non-artistic practices, and prototype development proficiency often shapes project progression. Structured around project-based activities, the course also delivers theoretical grounding via scholarly discussions and research outcome analysis. It emphasizes a FLOSS (Free/Libre and Open-Source Software)-centered approach, with instruction in classrooms and university laboratories.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0-3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6019J",
+      "sections": [
+        {
+          "course_code": "CMAA6019J",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6072",
+          "quota": 15,
+          "enrol": 9,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 201, E4",
+              "instructor": "HORVATH, ANCA-SIMONA"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "6019J",
+      "course_title": "City as Canvas: Art & Technology in Public Space",
+      "course_desc": "The course will introduce students to theories and practical methods of creating public space art using emerging technologies, quantitative and qualitative analysis methods for urban and public spaces, theories about public space in general and public space art in particular. We will design and build a large-scale installation to be placed in a public or semi-public space. Each student will be in charge of a part/section of this participatory work. The course is grounded in project-based and problem-based learning combined with reading and discussion of relevant literature.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6102",
+      "sections": [
+        {
+          "course_code": "CMAA6102",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6298",
+          "quota": 100,
+          "enrol": 101,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 101, W1",
+              "instructor": "GRIMSHAW-AAGAARD, MARK NICHOLAS & MINSKY, MARGARET DIANE REZVAN & ZHOU, QIUSHI"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CMAA",
+      "catalog_number": "6102",
+      "course_title": "Computational Media and Arts Program Seminar II",
+      "course_desc": "A regular series of seminars presenting research problems currently under investigation. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA6990",
+      "sections": [],
+      "subject": "CMAA",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "CMAA7990",
+      "sections": [],
+      "subject": "CMAA",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC5100",
+      "sections": [
+        {
+          "course_code": "CNCC5100",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6383",
+          "quota": 40,
+          "enrol": 14,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 233, W1",
+              "instructor": "LIU, Jiangong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNCC",
+      "catalog_number": "5100",
+      "course_title": "Carbon Neutrality and Climate Change",
+      "course_desc": "This course explores the concepts of climate neutrality and climate change from a multidisciplinary perspective. The course covers the scientific, technological, economic, political, and social aspects of climate neutrality and climate change, including mitigation and adaptation strategies, carbon accounting, renewable energy, energy efficiency, carbon markets, climate policy, and international climate negotiations. The course also examines the ethical and justice dimensions of climate change, including the distributional impacts of climate policies and the responsibilities of different actors in addressing climate change. By the end of the course, students will have a comprehensive understanding of the challenges and opportunities of achieving climate neutrality and addressing climate change, as well as the skills to engage in cutting-edge research in this field.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC5300",
+      "sections": [
+        {
+          "course_code": "CNCC5300",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6384",
+          "quota": 15,
+          "enrol": 12,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 103, E1",
+              "instructor": "LU, Jiaqi & SONG, Yuqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNCC",
+      "catalog_number": "5300",
+      "course_title": "Policy and Technology for Carbon Neutrality",
+      "course_desc": "All industries in China are actively taking effective actions to develop new and clean technologies in order to achieve the carbon peak and neutrality goal of shouldering the common destiny of human beings. This course examines the scientific, technological, and policy approaches that China and the rest of the world can take to achieve carbon peak and carbon neutrality.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC5400",
+      "sections": [
+        {
+          "course_code": "CNCC5400",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6385",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "TBA",
+              "instructor": "WANG, Wenjun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNCC",
+      "catalog_number": "5400",
+      "course_title": "Environmental Economics and Sustainable Development",
+      "course_desc": "This is a graduate-level interdisciplinary course focusing on the economics of environmental and sustainable development problems and the solutions to those problems. Students will learn to use tools from applied economics and relevant disciplines to better understand and evaluate a series of current policy questions, such as air and water pollution, climate change, environmental amenities, agricultural production, ecosystem services, and biodiversity.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC6000B",
+      "sections": [],
+      "subject": "CNCC",
+      "catalog_number": "6000B",
+      "course_title": "Independent Study",
+      "course_desc": "Independent study in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on carbon neutrality and climate change related topics. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "1-3 credits",
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC6910",
+      "sections": [
+        {
+          "course_code": "CNCC6910",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6394",
+          "quota": 25,
+          "enrol": 25,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1420",
+              "room": "Rm 202, E3",
+              "instructor": "GUMBER, ANURAG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNCC",
+      "catalog_number": "6910",
+      "course_title": "CNCC Program Seminar II",
+      "course_desc": "This course is expected to expose the RPg students to the current carbon neutrality and climate change research and development, and provide them with opportunities to make social contacts with the speakers inenvironmental and climate change communities. This course will be an essential part of training for our RPg students. Seminar II is an extension of Seminar I. While the overall design of the seminar course looks essentially the same, topics covered and guests invited will be differentiated. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1-0-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC6990",
+      "sections": [],
+      "subject": "CNCC",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by supervisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "CNCC7990",
+      "sections": [],
+      "subject": "CNCC",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by supervisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "CNGF5010",
+      "sections": [
+        {
+          "course_code": "CNGF5010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6367",
+          "quota": 60,
+          "enrol": 40,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, E1",
+              "instructor": "GUMBER, ANURAG & SONG, Yuqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNGF",
+      "catalog_number": "5010",
+      "course_title": "Green Technology and Innovation",
+      "course_desc": "This course delves into the multifaceted realm of Green Technology and Innovation (GTI), exploring its significance in today's world. Through examining innovation systems, economic policies, and global disparities, we analyze the transition from fossil fuels to renewable energy sources like wind, solar, and hydroelectric power. Additionally, we scrutinize the pivotal roles of lithium batteries, electric vehicles, and industry choices in shaping sustainable development.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNGF5200",
+      "sections": [
+        {
+          "course_code": "CNGF5200",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6368",
+          "quota": 20,
+          "enrol": 14,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 105, W3",
+              "instructor": "WOON, KOK SIN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "CNGF",
+      "catalog_number": "5200",
+      "course_title": "Life Cycle Assessment: From Theory to Application",
+      "course_desc": "Life Cycle Assessment (LCA) is a crucial tool for evaluating the environmental performance of products and processes throughout their whole life cycle. This course provides comprehensive knowledge and practical skills in understanding the fundamental steps to conduct and utilize LCA for improvement and innovation towards sustainable practices. The students will also learn about the application of LCA in various industries, including energy, solid waste, and green buildings.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "CNGF6980A",
+      "sections": [],
+      "subject": "CNGF",
+      "catalog_number": "6980A",
+      "course_title": "Independent Project",
+      "course_desc": "Independent project in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on a topic of Carbon Neutrality and Green Finance. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied. Graded P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "3 credits",
+      "matching": ""
+    },
+    {
+      "course_code": "DLED3020",
+      "sections": [
+        {
+          "course_code": "DLED3020",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6693",
+          "quota": 25,
+          "enrol": 22,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 223, W1",
+              "instructor": "LI, Yue"
+            },
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 223, W1",
+              "instructor": "LI, Yue"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DLED3020",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6694",
+          "quota": 25,
+          "enrol": 15,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Yue"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Yue"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DLED",
+      "catalog_number": "3020",
+      "course_title": "English Communication I for Information Hub programs",
+      "course_desc": "The course provides students with exposure to and practice in using English within the specific fields of Artificial Intelligence, Computer Media Arts, Internet of Things, Data Science. The course aims to encourage students to develop their abilities as thoughtful communication strategists, to communicate effectively, appropriately and confidently in relevant academic and professional contexts, and to use language to express critically the wider social implications of their fields on topics relevant to all INFH students.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DLED3040",
+      "sections": [
+        {
+          "course_code": "DLED3040",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6228",
+          "quota": 40,
+          "enrol": 21,
+          "avail": 19,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 202, E3",
+              "instructor": "QIU, Guoxiong"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 202, E3",
+              "instructor": "QIU, Guoxiong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DLED",
+      "catalog_number": "3040",
+      "course_title": "English Communication I for Systems Hub programs",
+      "course_desc": "The course provides students with exposure to, and practice in using English within the field of Bioscience and Biomedical Engineering, Intelligent Transportation, Robotics, Smart Manufacturing. The course aims to encourage students to develop their abilities as thoughtful communication strategists, to communicate effectively, appropriately and confidently in relevant academic and professional contexts, and to use language to explore and to express critically the wider social implications of their fields.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA1085",
+      "sections": [
+        {
+          "course_code": "DSAA1085",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6439",
+          "quota": 40,
+          "enrol": 40,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Rm 102, W1",
+              "instructor": "SUN, Jianfeng"
+            },
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 102, W1",
+              "instructor": "SUN, Jianfeng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "1085",
+      "course_title": "Probability and Statistics",
+      "course_desc": "This course will introduce topics in probability and statistics. Topics include probability spaces and random variables, distributions (absolutely continuous and singular distributions) and probability densities, moment inequalities, moment generating functions, conditional expectations, independence, conditional distributions, convergence concepts (weak, strong and in distribution), law of large numbers (weak and strong) and central limit theorem.",
+      "credit": 4,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA2011",
+      "sections": [
+        {
+          "course_code": "DSAA2011",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6435",
+          "quota": 70,
+          "enrol": 70,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 134, E1",
+              "instructor": "YANG, Weikai & ZHONG, Zixin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA2011",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6436",
+          "quota": 70,
+          "enrol": 67,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 122, E1",
+              "instructor": "YANG, Weikai & ZHONG, Zixin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA2011",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6437",
+          "quota": 70,
+          "enrol": 68,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "Rm 122, E1",
+              "instructor": "YANG, Weikai & ZHONG, Zixin"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "DSAA2011",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6438",
+          "quota": 70,
+          "enrol": 69,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 122, E1",
+              "instructor": "YANG, Weikai & ZHONG, Zixin"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "2011",
+      "course_title": "Machine Learning",
+      "course_desc": "Machine learning is an exciting and fast-growing field that leverages data to build models which can make predictions or decisions. This is an introductory machine learning course that covers fundamental topics in model assessment and selection, supervised learning (e.g., linear regression, logistic regression, neural networks, deep learning, support vector machines, Bayes classifiers, decision trees, ensemble methods); unsupervised learning (e.g., clustering, dimensionality reduction); and reinforcement learning. Students will also gain practical programming skills in machine learning to tackle real-world problems. Basic knowledge on mathematics (e.g., basic of probability theory, linear algebra, calculus and optimization), programming (e.g., Python / C++ / Matlab) and data science are essential and will benefit the study of this course.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA2012",
+      "sections": [
+        {
+          "course_code": "DSAA2012",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6440",
+          "quota": 70,
+          "enrol": 59,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 134, E1",
+              "instructor": "LIANG, Chen"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA2012",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6441",
+          "quota": 70,
+          "enrol": 59,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 134, E1",
+              "instructor": "LIANG, Chen"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "2012",
+      "course_title": "Deep Learning",
+      "course_desc": "This course provides students with an extensive exposure to deep learning. Topics include shallow and deep neural networks, activation functions and rectified linear unit, construction of deep neural networks and matrix representations including deep convolutional neural networks and deep recursive neural networks, computational issues including backpropagation, automatic differentiation, stochastic gradient descent, complexity analysis, approximation analysis including universality of approximation, design of deep neural network architectures and programming according to various applications.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA2031",
+      "sections": [
+        {
+          "course_code": "DSAA2031",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6442",
+          "quota": 50,
+          "enrol": 29,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 148, E1",
+              "instructor": "TANG, Nan"
+            },
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 148, E1",
+              "instructor": "TANG, Nan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA2031",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6443",
+          "quota": 50,
+          "enrol": 29,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "Rm 228, E2",
+              "instructor": "TANG, Nan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "2031",
+      "course_title": "Database Management Systems",
+      "course_desc": "Topics include: principles of database systems; conceptual modeling and data models; logical and physical database design; query languages and query processing; database services including concurrency, crash recovery, security and integrity. Hands-on DBMS experience.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA2043",
+      "sections": [
+        {
+          "course_code": "DSAA2043",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6444",
+          "quota": 48,
+          "enrol": 47,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 122, E1",
+              "instructor": "ZHANG, Yanlin"
+            },
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 122, E1",
+              "instructor": "ZHANG, Yanlin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA2043",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6445",
+          "quota": 48,
+          "enrol": 47,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 227, E1",
+              "instructor": "ZHANG, Yanlin"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "2043",
+      "course_title": "Design and Analysis of Algorithms",
+      "course_desc": "Design and Analysis of Algorithms is an important course that bridges students to a number of advanced courses in data science and analytics. This course introduces core data structures and algorithms. It covers advanced asymptotic complexity analysis, introduces common algorithmic paradigms (e.g., divide-and-conquer, greedy, and dynamic programming), a collection of classic algorithms (e.g., graph algorithms) and introduces the computational complexity theory. The course employs a range of assessment methods, including individual projects, coding exercises and closed-book exams, to foster both theoretical and practical foundation.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA3041",
+      "sections": [
+        {
+          "course_code": "DSAA3041",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6415",
+          "quota": 40,
+          "enrol": 19,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 202, W4",
+              "instructor": "LU, Shangqi"
+            },
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 202, W4",
+              "instructor": "LU, Shangqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA3041",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6416",
+          "quota": 40,
+          "enrol": 19,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1550",
+              "room": "Rm 227, E1",
+              "instructor": "LU, Shangqi"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "3041",
+      "course_title": "Advanced Algorithms",
+      "course_desc": "This course introduces advanced algorithmic techniques, including amortized analysis, randomized algorithms, and approximation algorithms. Students will learn about advanced data structures and their applications, as well as advanced solutions for optimization problems like linear programming and network flow. The course emphasizes the design and analysis of these techniques while also covering problem hardness and tractability, providing a solid foundation in advanced algorithms.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA3053",
+      "sections": [
+        {
+          "course_code": "DSAA3053",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6413",
+          "quota": 25,
+          "enrol": 15,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 233, W1",
+              "instructor": "ZHONG, Zixin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA3053",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6414",
+          "quota": 25,
+          "enrol": 15,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1400",
+              "end_time": "1450",
+              "room": "Rm 228, E1",
+              "instructor": "ZHONG, Zixin"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "3053",
+      "course_title": "Introduction to Reinforcement Learning",
+      "course_desc": "Topics include history and motivations of reinforcement learning, tabular solution methods such as multi-arm bandits, finite Markov decision process, dynamic programming, monte carlo methods and temporal difference learning, approximate solution such as on-policy approximation of action values, and off-policy approximation.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA3071",
+      "sections": [
+        {
+          "course_code": "DSAA3071",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6412",
+          "quota": 40,
+          "enrol": 24,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 102, W1",
+              "instructor": "LU, Shangqi & WANG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "3071",
+      "course_title": "Theories in Computing",
+      "course_desc": "This course is an introduction to the foundation of computing. Topics include set theory and countability, formal languages, finite automata and regular languages, pushdown automata and context-free languages, Turing machines, undecidability, P and NP, NP completeness, Approximate Algorithms, and Advanced algorithm Analysis.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA4040",
+      "sections": [
+        {
+          "course_code": "DSAA4040",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6410",
+          "quota": 40,
+          "enrol": 11,
+          "avail": 29,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, W4",
+              "instructor": "TANG, Guoming"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA4040",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6411",
+          "quota": 40,
+          "enrol": 11,
+          "avail": 29,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 150, E1",
+              "instructor": "TANG, Guoming"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "4040",
+      "course_title": "Cloud Computing and Big Data Systems",
+      "course_desc": "Big data systems, including Cloud Computing and parallel data processing frameworks, emerge as enabling technologies in managing and mining the massive amount of data across hundreds or even thousands of commodity servers in datacenters. This course exposes students to both the theory and hands-on experience of this new technology. The course will cover the following topics. (1) Basic concepts of Cloud Computing and production Cloud services; (2) MapReduce - the de facto datacenter-scale programming abstraction - and its open source implementation of Hadoop. (3) Apache Spark - a new generation parallel processing framework - and its infrastructure, programming model, cluster deployment, tuning and debugging, as well as a number of specialized data processing systems built on top of Spark. By walking through a number of hands-on labs and assignments, students are expected to gain first-hand experience programming on real world clusters in production datacenters.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA4086",
+      "sections": [
+        {
+          "course_code": "DSAA4086",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6402",
+          "quota": 40,
+          "enrol": 19,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 201, E1",
+              "instructor": "CUI, Ying"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "DSAA4086",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6403",
+          "quota": 40,
+          "enrol": 19,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 150, E1",
+              "instructor": "CUI, Ying"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "4086",
+      "course_title": "Introduction to Optimization",
+      "course_desc": "This course introduces fundamental theory and techniques of optimization. Topics include linear programming, unconstrained optimization, and constrained optimization. Numerical implementations of optimization methods are also discussed.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA5009",
+      "sections": [
+        {
+          "course_code": "DSAA5009",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6234",
+          "quota": 120,
+          "enrol": 106,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 102, E4",
+              "instructor": "XIA, Jun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "5009",
+      "course_title": "Deep Learning in Data Science",
+      "course_desc": "In this course, theories, models, algorithms of deep learning and their application to data science will be introduced. The basics of machine learning will be reviewed at first, then some classical deep learning models will be discussed, including AlexNet, LeNet, CNN, RNN, LSTM, and Bert. In addition, some advanced deep learning techniques will also be studied, such as reinforcement learning, transfer learning and graph neural networks. Finally, end-to-end solutions to apply these techniques in data science applications will be discussed, including data preparation, data enhancement, data sampling and optimizing training and inference processes.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA5013",
+      "sections": [
+        {
+          "course_code": "DSAA5013",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6250",
+          "quota": 80,
+          "enrol": 47,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, W4",
+              "instructor": "CHU, Xiaowen"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "5013",
+      "course_title": "Advanced Machine Learning",
+      "course_desc": "In this course, advanced algorithms for data science will be introduced. It covers most of the classical advanced topics in algorithm design, as well as some recent algorithmic developments, in particular algorithms for data science and analytics.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA5022",
+      "sections": [
+        {
+          "course_code": "DSAA5022",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6251",
+          "quota": 80,
+          "enrol": 30,
+          "avail": 50,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 228, E2",
+              "instructor": "TANG, Jing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "5022",
+      "course_title": "Data Analysis and Privacy Protection in Blockchain",
+      "course_desc": "This course introduces basic concepts and technologies of blockchain, such as the hash function and digital signature, as well as data analysis and privacy protection over blockchain applications. The students will learn the consensus protocols and algorithms, the incentives and politics of the block chain community, the mechanics of Bitcoin and Bitcoin mining, data analysis techniques over blockchain and user/transaction privacy protection.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA5027",
+      "sections": [
+        {
+          "course_code": "DSAA5027",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6252",
+          "quota": 40,
+          "enrol": 16,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 222, W1",
+              "instructor": "LI, Lei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "5027",
+      "course_title": "Spatio-Temporal Data Analysis",
+      "course_desc": "In this course, we will introduce spatial and multimedia database management concepts, theories and technologies, from data representation, indexing, fundamental operations to advanced query processing. Challenges and solution for high dimensional data will also be introduced.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA5037",
+      "sections": [
+        {
+          "course_code": "DSAA5037",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6299",
+          "quota": 90,
+          "enrol": 65,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 101, E1",
+              "instructor": "ZHANG, Yongqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "5037",
+      "course_title": "Introduction to Graph Learning",
+      "course_desc": "Graph, as a very expressive model, has been widely used to model real-world entities and their relationships in application-specific networks. In this course, students will gain a thorough introduction to the basics of graph theories, as well as cutting-edge research in deep learning for graphs. The topics include graph embeddings, graph neural networks, graph clustering models, graph generative models, adversarial attacks on graphs, graph reasoning, etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6000J",
+      "sections": [
+        {
+          "course_code": "DSAA6000J",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6301",
+          "quota": 55,
+          "enrol": 47,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1920",
+              "room": "Rm 134, E1",
+              "instructor": "GUO, Zhijiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6000J",
+      "course_title": "Foundations of Language Agents",
+      "course_desc": "Large language model (LLM) based-Agents have been an important frontier in AI, however, they still fall short critical skills, such as complex reasoning, for solving hard problems and enabling applications in real-world scenarios. This course covers the foundations and applications of language agents that can continuously improve themselves through interaction with the environment. The course will start with inference and post-training techniques for building language agents, such as scaling test-time compute, combining tools with LLMs, and reinforcement learning with verified rewards, etc. We focus on two application domains: mathematics and programming. Our goal is that the students learn from the latest research papers, discuss the suggested readings in each class, work on an original research project in this area, and learn from invited academic and industry speakers about applications in building language agents.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6000O",
+      "sections": [
+        {
+          "course_code": "DSAA6000O",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6448",
+          "quota": 40,
+          "enrol": 29,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 147, E1",
+              "instructor": "LUO, Yuyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6000O",
+      "course_title": "Table Representation Learning",
+      "course_desc": "Tables are a crucial component of data management and analysis, yet their potential is often underutilized. This project-driven course addresses this gap by equipping students with both theoretical knowledge and practical skills in table representation learning. The course is divided into four parts: (1) Theory: Core concepts of table representation learning, including tabular data analysis, representation learning, multimodal integration (with code and text), and retrieval-augmented generation (RAG). (2) Tools and Techniques: Exploration of advanced tools such as deep learning models, large language models (LLMs), multimodal LLMs, and RAG methods, with a focus on pre-training paradigms for table-related tasks. (3) Table Analysis Applications: Practical applications, including Natural language to SQL (NL2SQL), Table Question Answering (TableQA), Table Visualization, and Data storytelling, demonstrating the use of table representation learning in real-world scenarios. (4) Course Project: A solo project where students apply the concepts and tools learned to address a real-world problem related to table representation learning.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6000Q",
+      "sections": [
+        {
+          "course_code": "DSAA6000Q",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6449",
+          "quota": 160,
+          "enrol": 120,
+          "avail": 40,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Lecture Hall A",
+              "instructor": "WEI, Jiaheng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6000Q",
+      "course_title": "Large Language Models: Theory and Practice",
+      "course_desc": "This course delves into the foundational theories and cutting-edge advancements in large language models (LLMs). The course emphasizes LLM's application in real-world scenarios, focusing on topics such as domain-specific LLMs (e.g., continuous pretraining, SFT, and RLHF), data-intensive and document-intensive scenarios (e.g., NL2SQL RAG). Active student participation is encouraged through mini-projects, presentations, and discussions, providing hands-on experience in leveraging LLMs for real-world challenges.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6000S",
+      "sections": [
+        {
+          "course_code": "DSAA6000S",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6303",
+          "quota": 40,
+          "enrol": 4,
+          "avail": 36,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, E1",
+              "instructor": "DUAN, Huayi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6000S",
+      "course_title": "Data Communication and Security",
+      "course_desc": "This course provides a comprehensive introduction to the fundamental principles and practices of how data is transmitted, managed, and protected across modern computer networks. It examines the architecture, design, and operation of the Internet from the application to the network layer, articulating how data is encoded, routed, and delivered over distributed systems. We will also learn the mechanisms that ensure data remains confidential, authentic, and available as it moves through complex communication environments. By integrating principles of data communication with the foundations of network security, the course provides a coherent view of how the modern Internet support scalable, reliable and secure exchange of massive data in the digital age.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6010",
+      "sections": [
+        {
+          "course_code": "DSAA6010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6709",
+          "quota": 100,
+          "enrol": 95,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6010",
+      "course_title": "Industry Round Table",
+      "course_desc": "This course offers students opportunities to learn the possible industry topics and supervisors that they will work with during their internship. The goals are: (a) understand (i) problems in industry, (ii) existing data-sets, (iii) AI models, (iv) service scenario and KPI, (v) challenges; (b) propose industrial projects based on the understanding; and (c) matching for their industrial projects. This course is only available for MSc(DCAI) students. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6018A",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6018A",
+      "course_title": "Independent Study",
+      "course_desc": "In this course, an independent research project will be carried out under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6018B",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6018B",
+      "course_title": "Independent Study",
+      "course_desc": "In this course, an independent research project will be carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6018C",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6018C",
+      "course_title": "Independent Study",
+      "course_desc": "In this course, an independent research project will be carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6102",
+      "sections": [
+        {
+          "course_code": "DSAA6102",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6300",
+          "quota": 150,
+          "enrol": 133,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 101, W1",
+              "instructor": "TANG, Nan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "DSAA",
+      "catalog_number": "6102",
+      "course_title": "Data Science and Analytics Program Seminar II",
+      "course_desc": "In this course, students are required to attend at least 6 seminars offered by the program. The program will offer at least 10 seminars related to the state-of-the-art research on data science and analytics in each term. These seminars will help students to broaden the horizons of their knowledge on data science and analytics. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1-0-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6800",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6800",
+      "course_title": "Independent Project",
+      "course_desc": "In this course, the student will work on a practical project. The independent project is related to real problems existing in data science and AI application domains. The student needs to conduct literature survey, method comparison, solution selection and implementation, experimental study and write the final report. The course will train students skills on proposing end-to-end solution for a realapplications problem. This course is only available for MSc(DCAI) students. Graded P or F.",
+      "credit": 6,
+      "pg_course": true,
+      "vector": "[6 credits]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6921",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6921",
+      "course_title": "Industry Internship â¡",
+      "course_desc": "In this course, students will be trained in the industry. They will work under the guidance of their supervisors (industry and academia) to practice what they have learned in the program, and apply the data science and AI knowledge and techniques to various real-life problems. In Part II, students are required to complete an Intermediate report with oral examination on the studentâs progress and industry collaboration progress. This course is only available for MSc(DCAI) students. Graded PP, P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3 credits]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6922",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6922",
+      "course_title": "Industry Internship â¢",
+      "course_desc": "In this course, students will be trained in the industry. They will work under the guidance of their supervisors (industry and academia) to practice what they have learned in the program, and apply the data science and AI knowledge and techniques to various real-life problems. In Part III, students are required to complete a Final report with oral examination on the final output from the internship project and whether the student indeed knows how to apply AI techniques to concrete data science applications. This course is only available for MSc(DCAI) students. Graded PP, P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3 credits]",
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA6990",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "DSAA7990",
+      "sections": [],
+      "subject": "DSAA",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS5004",
+      "sections": [
+        {
+          "course_code": "EOAS5004",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6051",
+          "quota": 30,
+          "enrol": 5,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 201, E1",
+              "instructor": "LIU, Zhen & YU, Liuqian"
+            },
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, E1",
+              "instructor": "LIU, Zhen & YU, Liuqian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "EOAS",
+      "catalog_number": "5004",
+      "course_title": "Earth System Modeling",
+      "course_desc": "The course covers major processes and interactions of Earth system components and introduces the related numerical modeling concepts and techniques. It provides hands-on modeling projects to explore ideas of designing, constructing, and applying models to test hypotheses and enhance understanding of the Earth system processes and their response and feedback to the climate.",
+      "credit": 4,
+      "pg_course": true,
+      "vector": "[4-0-0:4]",
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS5007",
+      "sections": [
+        {
+          "course_code": "EOAS5007",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6053",
+          "quota": 30,
+          "enrol": 4,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 102, E1",
+              "instructor": "CHI, Jinshu & LIU, Yi"
+            },
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 102, E1",
+              "instructor": "CHI, Jinshu & LIU, Yi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "EOAS",
+      "catalog_number": "5007",
+      "course_title": "Watershed Biogeochemistry",
+      "course_desc": "This course addresses foundational theories, knowledge, and current challenges within the broad and interdisciplinary field of watershed biogeochemistry, focusing on the biogeochemical, hydrological, and ecological connections across the land-air-water continuum in watersheds. General themes will be explored through lectures on basic theories and discussions of recent literature. More specific questions and methodological approaches will be introduced using hands-on practices and excursions to field sites. This course will enhance students' understanding of water, carbon, and nutrient cycling along the terrestrial-aquatic interface.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS6000G",
+      "sections": [
+        {
+          "course_code": "EOAS6000G",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6056",
+          "quota": 30,
+          "enrol": 5,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 201, W2",
+              "instructor": "GUO, Yixin"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 201, W2",
+              "instructor": "GUO, Yixin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "EOAS",
+      "catalog_number": "6000G",
+      "course_title": "Global Environmental Challenges: Science, Technology & Policy",
+      "course_desc": "Our generations face rapid global environmental changes resulting from rising human interventions to the air, water, land and climate. Addressing crucial contemporary environmental challenge requires an interdisciplinary mind set that recognizes the interconnections among environmental problems, as well as the science of their causes, potential technological solutions and policy instruments. This is a course covering selected topics in cutting-edge earth system studies and the science, technology and policy aspects, in order to equip students with both knowledge and analytical tools for approaching pressing environmental problems. Topics include planetary boundaries and sustainable development goals, the reactive nitrogen cycle, global land use change, biodiversity losses, transboundary air pollution, co-mitigation of air pollution and greenhouse gas emissions, international trade and environmental justice, etc. Through guided literature reading, seminar discussions, group presentations and projects, students will develop critical thinking skills, interdisciplinary research design capabilities, and passion for sustainable development, which could be adopted for their own future research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS6000H",
+      "sections": [
+        {
+          "course_code": "EOAS6000H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6057",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 105, E3",
+              "instructor": "CAI, Lanlan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "EOAS",
+      "catalog_number": "6000H",
+      "course_title": "Global Change Biology",
+      "course_desc": "How will life on Earth withstand the combined pressures of climate change, habitat loss, and invasive species? Global Change Biology addresses this urgent challenge by applying core ecological principles to interpret and predict nature's responses. We will move beyond cataloging environmental problems to uncover the ecological rules governing how species and ecosystems respond to stress. This course emphasizes the interconnectedness of global change threats and trains students to apply ecological thinking to real-world biosecurity challenges. The goal is to equip students with the knowledge to develop solutions for preserving biodiversity, securing food systems, and protecting public health in an era of rapid global change.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS6900A",
+      "sections": [],
+      "subject": "EOAS",
+      "catalog_number": "6900A",
+      "course_title": "Independent Study",
+      "course_desc": "Study on selected topics in the Earth, Ocean and Atmospheric Sciences under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS6990",
+      "sections": [],
+      "subject": "EOAS",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "EOAS7990",
+      "sections": [],
+      "subject": "EOAS",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC1010",
+      "sections": [
+        {
+          "course_code": "FTEC1010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6409",
+          "quota": 60,
+          "enrol": 56,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 101, E1",
+              "instructor": "BAI, Ruoqi & CAI, Ning & CAO, Yiyue & LI, Siguang & QIU, Shi & SUN, Shuo & WANG, Junxuan & WANG, Xuechao & YUAN, Zixuan & ZHANG, Chao & ZHANG, Guang & ZHANG, Leifu & ZHANG, Liang & ZHANG, Yi & ZHU, Zimu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "1010",
+      "course_title": "Academic Orientation for FTEC Students",
+      "course_desc": "This is the compulsory one-year development course for FTEC students. The course provides academic and professional advising to students on the development of professional ethics, social awareness, responsibilities, and communication skills. An intended learning outcome is to develop a holistic, interdisciplinary, and evidence-based understanding of the issues in FinTech in the financial markets. Grading Type: Pass/ Fail",
+      "credit": 1,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC2120",
+      "sections": [
+        {
+          "course_code": "FTEC2120",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6404",
+          "quota": 40,
+          "enrol": 5,
+          "avail": 35,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 222, W1",
+              "instructor": "NI, Bingye & WANG, Xiaoyu"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 222, W1",
+              "instructor": "NI, Bingye & WANG, Xiaoyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FTEC2120",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6405",
+          "quota": 40,
+          "enrol": 5,
+          "avail": 35,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 201, W2",
+              "instructor": "NI, Bingye & WANG, Xiaoyu"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "2120",
+      "course_title": "Probability",
+      "course_desc": "Sample spaces, conditional probability, random variables, independence, discrete and continuous distributions, expectation, correlation, moment generating function, distributions of function of random variables, law of large numbers and limit theorems.",
+      "credit": 4,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC4320",
+      "sections": [
+        {
+          "course_code": "FTEC4320",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6406",
+          "quota": 30,
+          "enrol": 18,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 223, W1",
+              "instructor": "SUN, Shuo & ZHAO, Mingxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FTEC4320",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6407",
+          "quota": 30,
+          "enrol": 18,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 201, W2",
+              "instructor": "SUN, Shuo & ZHAO, Mingxuan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "4320",
+      "course_title": "Financial Data Analysis",
+      "course_desc": "Financial Data Analysis explores state-of-the-art approaches for extracting insights and building AI-driven intelligent systems using diverse financial data sources. Students will engage in hands-on projects that involve analyzing and modeling multimodal financial data, including time-series (e.g., stock prices), textual data (e.g., news and social media), graph data (e.g., supply chain), tabular data (e.g., company fundamentals), and alternative data (satellite images). Drawing on tools from artificial intelligence and statistical modeling, students will learn to design and evaluate data-driven solutions to real-world financial tasks such as market prediction, sentiment analysis, and risk estimation. Through guided projects and open-ended problem-solving, students will gain experience in end-to-end data workflows, from acquisition and preprocessing to modeling and evaluation. The course emphasizes implementation and experimentation, preparing students for future research and industry roles in FinTech.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5030",
+      "sections": [
+        {
+          "course_code": "FTEC5030",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6077",
+          "quota": 40,
+          "enrol": 22,
+          "avail": 18,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 122, E1",
+              "instructor": "XU, Yuanjian & ZHANG, Guang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5030",
+      "course_title": "Statistical Methods for Financial Technology",
+      "course_desc": "This course will survey modern financial technology, through the lens of statistics, which is the science of the analysis of data. Students will learn how statistical methodology, in conjunction with advances in technology, is used to efficiently acquire, utilize and interpret data, as it relates to innovations in the financial services sector. This course will develop skillsets for Big Data analytics and Predictive modelling, for better understanding of the financial markets.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5040",
+      "sections": [
+        {
+          "course_code": "FTEC5040",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6079",
+          "quota": 60,
+          "enrol": 30,
+          "avail": 30,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, E4",
+              "instructor": "CAI, Ning & XUN, Zixiong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5040",
+      "course_title": "Financial Technology Research",
+      "course_desc": "The objective of this course is to provide students with an extensive exposure to important research in financial technology and a rigorous training in related research methodologies. Main topics include cryptocurrencies, blockchain, P2P lending, crowdfunding, robo-advisors, regulatory technology (RegTech), and insurance technology (InsurTech). This course also enables students to gain an appreciation for how research in financial technologies improves traditional financial services and overcomes various difficulties inherent in the current financial system.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5100",
+      "sections": [
+        {
+          "course_code": "FTEC5100",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6080",
+          "quota": 40,
+          "enrol": 17,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, W2",
+              "instructor": "WANG, Xiang & ZHANG, Leifu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5100",
+      "course_title": "Research in Corporate Finance",
+      "course_desc": "This course introduces the main issues in corporate finance, identifies principal theoretical tools and empirical approaches, and fosters thinking about current research questions. The theoretical part includes classic theories such as ModiglianiâMiller theorem, Coase theorem, and Fisher separation theorem, with a focus on financing decisions of firms, corporate governance, and their implications. The empirical part reviews econometric methods commonly used in corporate finance research and covers selected topics.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5110",
+      "sections": [
+        {
+          "course_code": "FTEC5110",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6081",
+          "quota": 40,
+          "enrol": 24,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 122, E1",
+              "instructor": "PENG, Dexin & WANG, Junxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5110",
+      "course_title": "Research in Asset Pricing",
+      "course_desc": "This course addresses issues in both theoretical development and empirical studies of asset pricing. The theoretical part covers portfolio theory, arbitrage pricing theory with large numbers of assets, the intertemporal asset pricing model and the production-based asset pricing model. Topics related to derivative pricing are also covered. The empirical part covers asset return predictability, volatility-return relationship, asset pricing testing methodology, popular factor models used by practitioners and empirical findings in derivative markets.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5120",
+      "sections": [
+        {
+          "course_code": "FTEC5120",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6082",
+          "quota": 30,
+          "enrol": 19,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 150, E1",
+              "instructor": "PENG, Meishu & ZHANG, Yi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5120",
+      "course_title": "Text Mining in Finance and Economics",
+      "course_desc": "This course provides an introduction to textual analysis in social science research. It covers text mining models and related statistical tools, including Dictionary Method, SVD, Word2Vec, WEAT, Probabilistic Modeling, Regression Modeling, and Large Language Models in modern social science research. Applications related to the financial market are emphasized, including macro-finance, empirical asset pricing, empirical corporate finance, and ESG.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5210",
+      "sections": [
+        {
+          "course_code": "FTEC5210",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6083",
+          "quota": 20,
+          "enrol": 18,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 205, C7 Library & Rm 101, E1 & Rm 101, E4",
+              "instructor": "HAN, Bingyan & ZHANG, Yifan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5210",
+      "course_title": "Quantitative Models for Financial Derivatives",
+      "course_desc": "This course covers basic pricing theory of financial derivatives and risk hedging of exotic options. The course starts with the fundamental theorem of asset pricing and risk neutral valuation principle. The renowned Black-Scholes pricing theory and martingale pricing theory are introduced. Advanced topics include exchange options, quanto options, implied volatility and VIX.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5220",
+      "sections": [
+        {
+          "course_code": "FTEC5220",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6084",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W2",
+              "instructor": "CHENG, Ziteng & LI, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5220",
+      "course_title": "Monte Carlo Simulation in Finance",
+      "course_desc": "This course covers Monte Carol simulation methods from the perspectives of derivatives pricing, credit risk modeling and trading strategies. The first topic starts with various sampling methods for generating random variables, like the basic inverse transform method and acceptance-rejection method. Special emphasis is placed on simulation of normal distributions. Next, we consider pricing financial derivatives via simulation. The dynamic price processes include the Geometric Brownian motion and jump diffusion models. Various variance reduction techniques, like the antithetic variate, control variate, conditioning and stratified sampling are considered. The solution of the optimal stopping model of an American option via the Longstaff-Schwartz regression method is discussed. We also consider rare event simulation via various importance sampling methods, like the mean drift method and cross entropy method. Applications in risk measures calculation in credit risk models, like the Gaussian copula models, are considered.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC5320",
+      "sections": [
+        {
+          "course_code": "FTEC5320",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6085",
+          "quota": 20,
+          "enrol": 14,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, E4",
+              "instructor": "SU, Hongxu & WANG, Xuechao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "5320",
+      "course_title": "Decentralized Finance",
+      "course_desc": "This course introduces various novel types of financial instruments enabled by blockchains, collectively known as Decentralized Finance (DeFi). Students will delve into key DeFi elements, gaining both theoretical knowledge and practical skills to effectively navigate and engage with DeFi platforms and protocols.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6101G",
+      "sections": [
+        {
+          "course_code": "FTEC6101G",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6308",
+          "quota": 70,
+          "enrol": 47,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 102, W4",
+              "instructor": "LI, Siguang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6101G",
+      "course_title": "FinTech Program Seminar",
+      "course_desc": "Advanced seminar series presented by guest speakers and faculty members on selected topics in Financial Technology. This course is offered every regular term. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6900C",
+      "sections": [],
+      "subject": "FTEC",
+      "catalog_number": "6900C",
+      "course_title": "Independent Study",
+      "course_desc": "Independent study in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on a topic of Financial Technology. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1-0-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6910E",
+      "sections": [
+        {
+          "course_code": "FTEC6910E",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6745",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, E4",
+              "instructor": "HU, Jiaqi & LI, Siguang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6910E",
+      "course_title": "Game Theory",
+      "course_desc": "This course offers an in-depth analysis of game theory and its advanced applications in fin-tech related fields. First, it covers theoretical foundations, including extensive form game, strategic form game, Nash Equilibrium and its existence, backward induction, games of incomplete information, sub-game perfection, Bayesian Nash equilibrium, sequential equilibrium. Second, it covers mechanism design, including non-linear pricing, dominant strategy mechanism, Bayesian mechanism design, robust mechanism design, and dynamic mechanism design. The course fosters a deep understanding of game theory, equipping students with advanced tools to engage in independent research, and contribute to the development of novel financial technologies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6910F",
+      "sections": [
+        {
+          "course_code": "FTEC6910F",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6746",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, E4",
+              "instructor": "CHEN, Zhanghao & ZHANG, Chao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6910F",
+      "course_title": "Machine Learning for Finance",
+      "course_desc": "This course offers an in-depth introduction to the fundamental concepts of artificial intelligence (AI) and its advanced applications in finance. It covers key AI techniques, including linear models, tree-based methods, clustering algorithms, neural networks, and reinforcement learning, with an emphasis on both theoretical and practical implementation. Applications in finance, including risk management, asset pricing, fraud detection, and high-frequency trading, will be critically analyzed through real-world datasets. The course fosters a deep understanding of AI methods, enabling students to engage in independent research, and contribute to the development of novel financial technologies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6910G",
+      "sections": [
+        {
+          "course_code": "FTEC6910G",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6086",
+          "quota": 20,
+          "enrol": 6,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E4",
+              "instructor": "CHENG, Ziteng & YAN, He"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6910G",
+      "course_title": "Robo-Advising and Portfolio Management",
+      "course_desc": "This course provides an overview of methods used in the rapidly evolving field of robo-advising, focusing on customized portfolio optimization. It aims to introduce the theory of portfolio management and popular techniques in automated trading. The course also explores the nascent field of understanding client risk preference in robo-advising. These techniques combine to offer the basis for developing a robo-advisory system.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6910H",
+      "sections": [
+        {
+          "course_code": "FTEC6910H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6087",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, E4",
+              "instructor": "HUA, Fengrui & ZHANG, Liang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6910H",
+      "course_title": "Graph Machine Learning: Methods and Applications",
+      "course_desc": "Graph data are pervasive in finance and business management. The course will be organized in three parts. Part I introduces graph data types and representations, including typical simple/weighted and directed/undirected graphs; bipartite, heterogeneous and knowledge graphs; temporal/dynamic graphs; hypergraphs together with node/edge attributes and common storage/processing patterns. Part II introduces graph data modeling methods from shallow embeddings to modern graph neural networks (message passing mechanism, heterogeneous/temporal architectures, contrastive pretraining) and LLM-based approaches (graph-aware prompting, graph-based RAG, graph foundation models). Part III examines graph data based applications in finance and business management, including anomaly and fraud detection, stock market prediction, and recommendation systems, with emphasis on reproducible, practice-oriented implementation.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6910I",
+      "sections": [
+        {
+          "course_code": "FTEC6910I",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6089",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 103, E1",
+              "instructor": "LYU, Aoqing & QIU, Shi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FTEC",
+      "catalog_number": "6910I",
+      "course_title": "Applied Econometrics in Financial Technology",
+      "course_desc": "The overarching goal of this course is to equip students with a working knowledge of important econometric techniques necessary to understand and interpret financial data in a broad sense. We will investigate topics such as market efficiency, event studies, factor models, return anomalies, bond markets, among others. Apart from model-based approaches, we will also partially cover state-of-the-art design-based approaches such as synthetic control, regression discontinuity, matrix completion, double machine learning and so on. This course will involve both lecture and paper discussion.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC6990",
+      "sections": [],
+      "subject": "FTEC",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FTEC7990",
+      "sections": [],
+      "subject": "FTEC",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "FUNH5000",
+      "sections": [
+        {
+          "course_code": "FUNH5000",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6058",
+          "quota": 80,
+          "enrol": 78,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1000",
+              "end_time": "1150",
+              "room": "Rm 101, W1",
+              "instructor": "LIU, Zhen & YANG, Qichun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH5000",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6060",
+          "quota": 83,
+          "enrol": 82,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1000",
+              "end_time": "1150",
+              "room": "Rm 101, E1",
+              "instructor": "CHI, Jinshu & YANG, Qichun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH5000",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6061",
+          "quota": 80,
+          "enrol": 78,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1000",
+              "end_time": "1150",
+              "room": "Rm 101, E1",
+              "instructor": "YANG, Qichun & YU, Liuqian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH5000",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6063",
+          "quota": 80,
+          "enrol": 7,
+          "avail": 73,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1650",
+              "room": "Rm 103, E1",
+              "instructor": "YANG, Qichun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FUNH",
+      "catalog_number": "5000",
+      "course_title": "Introduction to Function Hub for Sustainable Future",
+      "course_desc": "This course covers background knowledge in the thrust areas of the Function Hub, including Advanced Materials, Sustainable Energy and Environment, Microelectronics, and Earth, Ocean and Atmospheric Sciences.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-0:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "FUNH6770",
+      "sections": [
+        {
+          "course_code": "FUNH6770",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6064",
+          "quota": 150,
+          "enrol": 74,
+          "avail": 76,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 101, W1",
+              "instructor": "CAI, Lanlan & FANG, Ting & LIU, Zhen & LU, Zhonghai & XU, Jiang & YANG, Qichun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FUNH",
+      "catalog_number": "6770",
+      "course_title": "Professional Development for Function Hub",
+      "course_desc": "This course aims at providing research postgraduate students basic training in scientific ethics in research studies in advanced materials, sustainable energy and environment, earth, ocean and atmospheric sciences and microelectronics, research management, professional career development, and related professional skills. Guest speakers from various professional areas will be invited to share their career paths in professional career developments. Students will have chances to connect to talents in various professional areas. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "FUNH6800J",
+      "sections": [
+        {
+          "course_code": "FUNH6800J",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6065",
+          "quota": 120,
+          "enrol": 71,
+          "avail": 49,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 101, W1",
+              "instructor": "HUANG, Yang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH6800J",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6066",
+          "quota": 60,
+          "enrol": 26,
+          "avail": 34,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 228, E2",
+              "instructor": "HE, Quanfu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH6800J",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6067",
+          "quota": 120,
+          "enrol": 96,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 101, W1",
+              "instructor": "CHEN, Sihan & XU, Jiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "FUNH6800J",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6068",
+          "quota": 120,
+          "enrol": 81,
+          "avail": 39,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, Jiaqiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "FUNH",
+      "catalog_number": "6800J",
+      "course_title": "Function Hub Seminar",
+      "course_desc": "Seminar topics presented by students, faculty and guest speakers. Students are expected to attend regularly and demonstrate proficiency in presentation in accordance with the program requirements. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "INFH5000",
+      "sections": [
+        {
+          "course_code": "INFH5000",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6333",
+          "quota": 200,
+          "enrol": 187,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Lecture Hall B",
+              "instructor": "LI, Hongyu & TANG, Nan & WANG, Xin & WANG, Yuyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "INFH5000",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6334",
+          "quota": 200,
+          "enrol": 176,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Lecture Hall B",
+              "instructor": "LI, Hongyu & TANG, Nan & WANG, Xin & WANG, Yuyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INFH",
+      "catalog_number": "5000",
+      "course_title": "Information Science and Technology: Essentials and Trends",
+      "course_desc": "This inquiry-based course aims to introduce students to the concepts and skills needed to drive digital transformation in the information age. Students will learn to conduct research, explore real-world applications, and discuss grand challenges in the four thrust areas of the Information hub, namely Artificial Intelligence, Data Science and Analytics, Internet of Things, and Computational Media and Arts. The course incorporates various teaching and learning formats including lectures, seminars, online courses, group discussions, and a term project.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-0:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "INFH6780",
+      "sections": [
+        {
+          "course_code": "INFH6780",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6335",
+          "quota": 250,
+          "enrol": 248,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1530",
+              "end_time": "1620",
+              "room": "Lecture Hall B",
+              "instructor": "TONG, Xin & WANG, Zeyu & ZHANG, Kang & ZHOU, QIUSHI"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INFH",
+      "catalog_number": "6780",
+      "course_title": "Career Development for Information Hub Students",
+      "course_desc": "This course aims at equipping RPg students of the Information Hub with the skills conducive to their professional career development. Students are required to attend the 3 hours' training focusing on personality self-exploration and discipline-specific training at the thrust level, and another 10 hours' training at the hub level, at their own choice. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR5120",
+      "sections": [
+        {
+          "course_code": "INTR5120",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6140",
+          "quota": 30,
+          "enrol": 8,
+          "avail": 22,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, E4",
+              "instructor": "JIA, Shuai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "5120",
+      "course_title": "Optimization Methods for Transport and Logistics Management",
+      "course_desc": "This course will introduce important optimization problems arising from transport and logistics management, including network flow problems, routing and scheduling problems, and problems involving uncertainty. It will focus on modeling techniques and solution methodology for problem solving. Theoretical and operational insights into the problems will also be discussed. The goal of the course is to train students to a level of technical competency to formulate and solve related optimization problems that they may encounter in both research and real-life.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR5210",
+      "sections": [
+        {
+          "course_code": "INTR5210",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6141",
+          "quota": 40,
+          "enrol": 7,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W4",
+              "instructor": "SUN, Xiaotong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "5210",
+      "course_title": "Game Theoretical Methods in Transportation",
+      "course_desc": "This postgraduate-level course introduces how game-theoretical methods are used to model strategic behaviors and to support decision making in transportation systems. Fundamental knowledge in game theory and mechanism design, including different game representations, equilibrium concepts and information asymmetry will first be covered. Variational inequality will then be introduced, with an emphasize of its importance in determining equilibrium solutions for transportation network models.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR5240",
+      "sections": [
+        {
+          "course_code": "INTR5240",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6142",
+          "quota": 30,
+          "enrol": 27,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, E1",
+              "instructor": "ZHENG, Xinhu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "5240",
+      "course_title": "The Principle and Application of Intelligent Connected Vehicle",
+      "course_desc": "Intelligent connected vehicles (ICVs) are believed to change peopleâs life in the near future by making the transportation safer, cleaner and more comfortable. Although many prototypes of ICVs have been developed to prove the concept of autonomous driving and the feasibility of improving traffic efficiency, there still exists a significant gap before achieving mass production of high-level ICVs. This course aims to present an overview of both the state of the art and future perspectives of key technologies that are needed for future ICVs. Through the study of this course, students will understand and master the basic concepts, key technologies and applications of ICV, and initially learn and master the ability to use that knowledge to solve practical problems, especially in cross-disciplinary communication and transportation context.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR5260",
+      "sections": [
+        {
+          "course_code": "INTR5260",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6143",
+          "quota": 15,
+          "enrol": 6,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Room 521H VR Room, W1",
+              "instructor": "HE, Dengbo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "5260",
+      "course_title": "Engineering Psychology and Transportation Applications",
+      "course_desc": "The course will cover a wide range of engineering psychology topics as well as how the research in these directions can affect policies and regulations in vehicle design and surface transportation. The students will gain an understanding of the characteristics and limitations of human beings from engineering psychology perspectives of view and how the design of traffic control devices, the roadway, the in-vehicle devices, regulations and traffic rules can be affected by the research in these directions.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR5290",
+      "sections": [
+        {
+          "course_code": "INTR5290",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6147",
+          "quota": 25,
+          "enrol": 25,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1900",
+              "end_time": "2150",
+              "room": "Rm 202, E3",
+              "instructor": "LI, Haoang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "5290",
+      "course_title": "Simultaneous Localization and Mapping (SLAM) and Its Applications",
+      "course_desc": "This course introduces the principles and algorithms of Simultaneous Localization and Mapping (SLAM), which is widely used in intelligent transportation and robotics. Students will learn how to reconstruct 3D maps of environments and track the positions of mobile agents simultaneously. Practical applications of SLAM in autonomous vehicles, drones, and smart manufacturing will be explored through hands-on projects.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR6000N",
+      "sections": [
+        {
+          "course_code": "INTR6000N",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6148",
+          "quota": 30,
+          "enrol": 5,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 101, W2",
+              "instructor": "LIU, Zhidan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "6000N",
+      "course_title": "Mobile Sensing and Computing for Transportation",
+      "course_desc": "Harness the power of mobile devices to revolutionize transportation with this postgraduate course. As mobile sensing and computing become increasingly integral to our understanding of the physical world, this postgraduate-level course provides a comprehensive look at their transformative impact on urban transportation. Students will gain a solid grasp of the fundamental concepts and cutting-edge techniques in mobile sensing and computing, enabling the development of intelligent transportation systems and applications. Key topics include mobile device sensing, computing, and communication fundamentals, as well as advanced discussions on mobile computing enabled transportation management, localization and tracking, mobile crowdsensing paradigm, social sensing, vehicular mobile systems, and mobile intelligence. This course is designed for students and professionals seeking to leverage mobile technology for innovative solutions in transportation.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR6000Q",
+      "sections": [
+        {
+          "course_code": "INTR6000Q",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6151",
+          "quota": 30,
+          "enrol": 3,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1900",
+              "end_time": "2150",
+              "room": "Rm 150, E1",
+              "instructor": "MA, Jun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "6000Q",
+      "course_title": "Smart Production and Operations Management",
+      "course_desc": "This course explores how emerging technologiesâsuch as AI, IoT, robotics, and data analyticsâare transforming modern production and operations management. Students will learn to design, analyze, and optimize intelligent production systems that enhance efficiency, flexibility, and sustainability. Topics include smart manufacturing systems, digital twins, humanârobot collaboration, supply chain integration, and data-driven decision-making. Through case studies and practical projects, students gain both theoretical foundations and hands-on experience in managing operations within Industry 4.0 environments.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR6000R",
+      "sections": [
+        {
+          "course_code": "INTR6000R",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6152",
+          "quota": 30,
+          "enrol": 7,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, W1",
+              "instructor": "MA, Ke"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "6000R",
+      "course_title": "Autonomous Vehicle System and Test",
+      "course_desc": "Autonomous vehicles (AVs) integrate perception, planning, and control to enable intelligent driving. This course introduces fundamental models and testing methodologies for evaluating AV systems. The first part covers traditional modular architectures, including sensing, perception, trajectory planning, and control algorithms. The second part focuses on emerging end-to-end learning frameworks that directly map sensor inputs to driving actions, emphasizing data processing, training, and safety evaluation. The course concludes with an overview of connected and automated vehicle (CAV) extensions that enhance perception and coordination through communication technologies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR6800K",
+      "sections": [
+        {
+          "course_code": "INTR6800K",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6149",
+          "quota": 80,
+          "enrol": 54,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 101, E1",
+              "instructor": "MA, Jun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "INTR",
+      "catalog_number": "6800K",
+      "course_title": "Seminar in Intelligent Transportation",
+      "course_desc": "Seminar topics presented by students, faculty and guest speakers. Students are expected to attend regularly and demonstrate proficiency in presentation in accordance with the program requirements. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "INTR6990",
+      "sections": [],
+      "subject": "INTR",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "INTR7990",
+      "sections": [],
+      "subject": "INTR",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5001",
+      "sections": [
+        {
+          "course_code": "IOTA5001",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6099",
+          "quota": 30,
+          "enrol": 9,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 221, W1",
+              "instructor": "TYSON, Gareth John"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5001",
+      "course_title": "Social and Web Computing",
+      "course_desc": "This course will introduce students to the fundamentals of Social and Web Computing, as well as providing detailed coverage of recent research in this space. It will consist of two major parts. First, students will learn about fundamental social computing theories, alongside computational methodologies that can be used to understand human interactions online. Second, students will be exposed to a range of recent applied research that has employed these methodologies. There will be an empirical focus in the course, and students will be exposed to a range of measurement research capturing how social and web systems work in-the-wild. Students will learn about social network analysis and relevant APIs, alongside related aspects of the Web, user privacy and online advertisement.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5009",
+      "sections": [
+        {
+          "course_code": "IOTA5009",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6396",
+          "quota": 20,
+          "enrol": 3,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "TBA",
+              "instructor": "FAN, Mingming"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5009",
+      "course_title": "AR/VR/MR/XR: Concepts, Theory, and Techniques",
+      "course_desc": "This course introduces students to the concepts, theories, and interaction techniques in AR/VR/MR/XR. It covers both the fundamental concepts and design theories and the state-of-the-art interaction techniques in the field. In addition, students will work independently or in teams to design, develop, and evaluate AR/VR/MR/XR applications. In sum, by the end of the class, students will have a solid grasp of the fundamental concepts and theories and hands-on experience in AR/VR/MR/XR.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5106",
+      "sections": [
+        {
+          "course_code": "IOTA5106",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6101",
+          "quota": 40,
+          "enrol": 5,
+          "avail": 35,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 202, E3",
+              "instructor": "TSANG, Hin Kwok"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5106",
+      "course_title": "Introduction to Communication Networks",
+      "course_desc": "This course introduces students to different types of communication networks, with a focus on Internet technologies. Topics covered include error control, flow control, medium access control, routing, congestion control, packet scheduling, queueing theory, and network optimization. The course will provide students with the fundamental knowledge required to understand, analyze, and optimize the performance of communication networks. It is suitable for students who do not have an existing background in communication networks.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5107",
+      "sections": [
+        {
+          "course_code": "IOTA5107",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6120",
+          "quota": 30,
+          "enrol": 5,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, W4",
+              "instructor": "KUTSCHER, Dirk"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5107",
+      "course_title": "Advanced Networked Systems for AI and Multimedia Systems",
+      "course_desc": "This course focuses on relevant current research topics in Networked Systems such as Networking for AI, Multimedia Communication, Data-Center Networks, Software-Defined Networking, Dataplane Programmability, Information-Centric Networking, Quantum Internet Communication, Privacy Preserving Communication, Constrained (IoT) Networks. This course will provide a structured introduction to the state-of-the-art and recent research in the field of networked systems. It will further introduce students to recent development efforts in the academic community as well as in Internet standardization.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5202",
+      "sections": [
+        {
+          "course_code": "IOTA5202",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6108",
+          "quota": 30,
+          "enrol": 24,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, W1",
+              "instructor": "CHEN, Huangxun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5202",
+      "course_title": "Efficient Machine Learning for Resource Constrained Environments",
+      "course_desc": "This course explores cutting-edge techniques for creating efficient machine-learning models to address the growing demand for real-time decision-making and localized processing across diverse application fields, including IoT/robotics/smart manufacturing systems and beyond. Key topics include model compression, pruning, quantization, neural architecture search, knowledge distillation, on-device fine-tuning, transfer learning, application-specific acceleration techniques, etc. Through hands-on projects, students will learn to optimize and adapt deep learning models for resource-constrained devices while maintaining accuracy and performance.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5502",
+      "sections": [
+        {
+          "course_code": "IOTA5502",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6110",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 101, E4",
+              "instructor": "CUI, Ying"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5502",
+      "course_title": "Convex and Nonconvex Optimization II",
+      "course_desc": "This course covers advanced theory, algorithms, and applications for convex and nonconvex optimization, including: subgradient methods, localization methods, decomposition methods, proximal methods, alternating direction methods of multipliers, conjugate direction methods, successive approximation methods, convex-cardinality problems, low-rank optimization problems, neural networks, semidefinite programming and relaxation, robust optimization, discrete optimization, stochastic optimization, etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA5505",
+      "sections": [
+        {
+          "course_code": "IOTA5505",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6125",
+          "quota": 30,
+          "enrol": 9,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 222, W1",
+              "instructor": "GONG, Zijun & XING, Hong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "5505",
+      "course_title": "Statistical Inference for Machine Learning and Signal Processing",
+      "course_desc": "This course introduces the fundamentals and advanced topics of statistics that cover multivariate distribution along with dimension-reduction techniques, concentration inequalities, performance metrics for statistical learning, and applications in statistical signal processing, including estimation theory and methods, detection theory and methods, and selected advanced algorithms such as Markov Chain Monte Carlo (MCMC) and expectation maximization (EM), etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6102",
+      "sections": [
+        {
+          "course_code": "IOTA6102",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6338",
+          "quota": 50,
+          "enrol": 46,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 228, E2",
+              "instructor": "CHEN, Huangxun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "6102",
+      "course_title": "Internet of Things Seminar II",
+      "course_desc": "A series of regular seminars presented by postgraduate students, faculty, and guest speakers on IoT-related research problems currently under investigation. Students are expected to attend regularly. Continuation of IOTA 6101. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6900A",
+      "sections": [],
+      "subject": "IOTA",
+      "catalog_number": "6900A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member on an Internet of Things topic.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "3 credits",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6900B",
+      "sections": [],
+      "subject": "IOTA",
+      "catalog_number": "6900B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent research project carried out under the supervision of a faculty member on an Internet of Things topic.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6910I",
+      "sections": [
+        {
+          "course_code": "IOTA6910I",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6747",
+          "quota": 40,
+          "enrol": 25,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 222, W1",
+              "instructor": "HE, Haiyun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "6910I",
+      "course_title": "Information Theory and its Applications in Machine Learning",
+      "course_desc": "This course introduces the fundamentals of information theory and its applications in machine learning and statistics. Beyond compression and transmission, information theory also addresses information extraction and learning. By formulating operational problems with elegant mathematics and solving them through powerful techniques, it characterizes fundamental performance limits and offers deep insights into system design. We will cover both classical and modern topics. The course begins with core information measuresâentropy, f-divergences, convex duality, and variational characterizationsâfollowed by data compression, channel coding, and strong data-processing inequalities, which illustrate the operational meaning of these definitions. We then explore information-theoretic treatments of inference, hypothesis testing, and large deviations. Applications include deriving generalization bounds, and inequalities in machine learning, as well as insights for statistical estimation. By the end of the course, students will gain both the tools and intuition to analyze fundamental limits and to apply information-theoretic methods to modern problems in learning and inference.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6910J",
+      "sections": [
+        {
+          "course_code": "IOTA6910J",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6757",
+          "quota": 40,
+          "enrol": 13,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, W4",
+              "instructor": "LONG, Yan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "6910J",
+      "course_title": "Sensing Security and Privacy in IoT and AI Systems",
+      "course_desc": "This course will teach students advanced methods to measure, model, and protect the security and privacy of sensing technologies and their users in the age of AI and IoT, with an emphasis on the hardware-software interface in embedded systems and the physics of sensing and computation. Application domains of security analysis include smartphone and AR/VR devices, smart home IoT, autonomous driving, healthcare and medical devices, AI-based controls and Deepfakes, etc. Group projects will have students build voice assistant systems from scratch and explore various offensive and defensive security techniques.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6910K",
+      "sections": [
+        {
+          "course_code": "IOTA6910K",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6749",
+          "quota": 30,
+          "enrol": 18,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 201, W2",
+              "instructor": "SU, Ningxin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IOTA",
+      "catalog_number": "6910K",
+      "course_title": "Distributed and Federated Machine Learning",
+      "course_desc": "From operating systems to artificial intelligence, the principles of distributed computing underpin much of contemporary computer science. This course provides a comprehensive introduction to distributed systems and their applications in distributed learning. The first part focuses on foundational concepts in distributed computing, covering classical problems such as synchronization, fault tolerance, and communication protocols, as well as the theoretical challenges that arise when computation and communication are distributed across multiple nodes. Building on this foundation, the second part explores how distributed principles are applied to large-scale machine learning. Topics include federated learning, large language models (LLMs), and distributed AI agent coordination, highlighting how distributed systems continue to evolve and shape the future of intelligent computing.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA6990",
+      "sections": [],
+      "subject": "IOTA",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "IOTA7990",
+      "sections": [],
+      "subject": "IOTA",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5100",
+      "sections": [
+        {
+          "course_code": "IPEN5100",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6126",
+          "quota": 40,
+          "enrol": 7,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 233, W1",
+              "instructor": "HOU, Yun & LI, Moyan & SHIN, Jihoon"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5100",
+      "course_title": "Innovation, Policy and Entrepreneurship",
+      "course_desc": "This course focuses on the practices and processes that managers in the business sector adopt to advance innovation and attention is also paid to the strategies that policy-makers from regulatory background pursue to manage innovation. Technological innovation will be examined through its process of exploring, executing, leveraging, and renewing from both the perspectives of entrepreneurs and regulators. Students will be guided to seek a collaborative governance mechanism that is workable for different players and sectors in innovation to achieve sustainable growth.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5111",
+      "sections": [
+        {
+          "course_code": "IPEN5111",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6127",
+          "quota": 30,
+          "enrol": 12,
+          "avail": 18,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W1",
+              "instructor": "XU, Kewei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5111",
+      "course_title": "Public Management and Institutional Analysis",
+      "course_desc": "This course focuses on the theoretical and analytical perspective of public management and institutions. It introduces students to key concepts in the discipline of public management and institutional analysis. The course begins with a review of the evolution of thinking in this field. In the following sessions, students will be extensively exposed to theoretical frameworks. The course aims to equip students with theories that help students in building up their capacity toward academic research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5120",
+      "sections": [
+        {
+          "course_code": "IPEN5120",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6134",
+          "quota": 60,
+          "enrol": 9,
+          "avail": 51,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 228, E2",
+              "instructor": "WU, Xun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5120",
+      "course_title": "Research Design for Innovation, Policy and Entrepreneurship Studies",
+      "course_desc": "The purposes of the course are to introduce to students key concepts in research design, and to help them develop skills in the design of empirical research for conducting innovation, policy and entrepreneurship studies. Specific emphasis will be on the use of quasi-experimental designs in policy research, as well as on their potentials and limitations.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5140",
+      "sections": [
+        {
+          "course_code": "IPEN5140",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6128",
+          "quota": 40,
+          "enrol": 19,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, W2",
+              "instructor": "LI, Chenyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5140",
+      "course_title": "Quantitative Analysis and Empirical Methods",
+      "course_desc": "This course introduces students to empirical methods and data management tools used in the current social science disciplines, with some special focuses on strategy, finance and applied micro-economics. The overall approach is to understand the common methods and research design used in the empirical research through intensive reading and replicating papers published in top journals. Students would also become proficient in the use of computer software that is widely used in analyzing quantitative data via empirical assignments.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5160",
+      "sections": [
+        {
+          "course_code": "IPEN5160",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6129",
+          "quota": 60,
+          "enrol": 45,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, W4",
+              "instructor": "MIAO, Lili"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5160",
+      "course_title": "Big Data Applications for Business and Government",
+      "course_desc": "This course will cover the key concepts and technologies of big data and data analysis, with a focus on the application of big data in formulating business strategies and policies, and related research issues on how big data affects the direction of business and policy development. The course will provide students with practical training on big data and data analysis based on real-world business or policy issues, ranging from collecting and preprocessing to organizing and analyzing large-scale data.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5180",
+      "sections": [
+        {
+          "course_code": "IPEN5180",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6136",
+          "quota": 60,
+          "enrol": 44,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 122, E1",
+              "instructor": "LI, Guohuibin & MIAO, Lili"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5180",
+      "course_title": "Disruptive Technologies and Society",
+      "course_desc": "This course gives students a broad introduction to the key disruptive technologies, such as mobile internet, AI, and robotics, that have transformed our society. We will examine the practical applications of these technologies and discuss their socioeconomic impacts and policy responses. We will also look at the potential for businesses and governments to harness these disruptive technologies to deliver new services or improve existing ones and enhance value in public and private sectors.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5310",
+      "sections": [
+        {
+          "course_code": "IPEN5310",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6144",
+          "quota": 30,
+          "enrol": 22,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W4",
+              "instructor": "HONG, Jihao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5310",
+      "course_title": "Behavioral Economics and Public Policy",
+      "course_desc": "This course introduces behavioral economics - the incorporation of insights from psychology into economics - with an emphasis on its value for improving empirical predictions and policy decisions. Students will learn the major themes of behavioral economics and apply them to improve the design, implementation, and evaluation of public policies in a wide variety of domains.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5700",
+      "sections": [
+        {
+          "course_code": "IPEN5700",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6150",
+          "quota": 40,
+          "enrol": 17,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 150, E1",
+              "instructor": "HOU, Yun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5700",
+      "course_title": "Strategic Management of Technology and Innovation",
+      "course_desc": "Technological innovation is increasingly the source of sustainable competitive advantage for firms worldwide. This course introduces a grounding in the field of technology and innovation, with an emphasis on economic policy and business strategy. The course will be highly interactive and apply multiple disciplines including economics, management, law and public policy.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5800",
+      "sections": [
+        {
+          "course_code": "IPEN5800",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6159",
+          "quota": 40,
+          "enrol": 5,
+          "avail": 35,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W4",
+              "instructor": "WANG, Xin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5800",
+      "course_title": "New Venture Creation",
+      "course_desc": "This is an introductory course to entrepreneurship research. Entrepreneurship is defined as the creation and growth of business ventures, either as new organizations or inside existing ones, and as transformation of existing organizations. This course covers fundamental readings and current research with an emphasis on business venture creation. The objective is to give enough training that students can follow and contribute to entrepreneurship research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5810",
+      "sections": [
+        {
+          "course_code": "IPEN5810",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6161",
+          "quota": 30,
+          "enrol": 15,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 202, W4",
+              "instructor": "REN, Qianping"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5810",
+      "course_title": "Data Science in Empirical Economics",
+      "course_desc": "In the digital age, there is more data available than ever before on human behavior: from analyzing an elected officialâs opinion on Twitter to identifying a farmerâs crop choices through satellite images. This course aims to familiarize students in applied economics, public policy, and relevant disciplines with recent research that has used big data to push the cutting-edge of the applied economic and public policy fields. Through a combination of problem sets and independent projects, students will acquire the statistical and computational tools needed for making use of big data in empirical research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN5820",
+      "sections": [
+        {
+          "course_code": "IPEN5820",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6163",
+          "quota": 10,
+          "enrol": 2,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, W2",
+              "instructor": "WANG, Wenjun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "5820",
+      "course_title": "Environmental Economics and Sustainable Development",
+      "course_desc": "This is a graduate-level interdisciplinary course focusing on the economics of environmental and sustainable development problems and the solutions to those problems. Students will learn to use tools from applied economics and relevant disciplines to better understand and evaluate a series of current policy questions, such as air and water pollution, climate change, environmental amenities, agricultural production, ecosystem services, and biodiversity.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6000B",
+      "sections": [],
+      "subject": "IPEN",
+      "catalog_number": "6000B",
+      "course_title": "Independent Study",
+      "course_desc": "Independent study in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on a topic of Innovation, Policy and Entrepreneurship. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied. Graded P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6000E",
+      "sections": [],
+      "subject": "IPEN",
+      "catalog_number": "6000E",
+      "course_title": "Independent Study",
+      "course_desc": "Independent study in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on a topic of Innovation, Policy and Entrepreneurship. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied. Graded P or F.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1 - 3credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100C",
+      "sections": [
+        {
+          "course_code": "IPEN6100C",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6192",
+          "quota": 30,
+          "enrol": 19,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, E1",
+              "instructor": "PAN, Jiahua"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100C",
+      "course_title": "Carbon Emissions and Mitigation",
+      "course_desc": "This course introduces where, how and why carbon emissions come from and can be mitigated, with further understanding of related economic, technological and environmental aspects of actions. \nThe course is organized into three main parts:\nâ¢ Part I: A general understanding of the major sources and removals of, sectoral and regional contributions to, greenhouse gas (carbon dioxide (CO2), methane (CH4), nitrous oxide (N2O), and F gases) emissions across natural and anthropogenic systems, with an emphasis on transition away from fossil fuels. Focuses will be mainly on questions related to where, why, when and how. In addition, MRV (measurable, reportable, and verifiable) issues will covered in this part.\nâ¢ Part II: An in-depth investigation into mitigation options, their respective economic, social and technological potentials, and sectoral and regional effectiveness and impacts.\nâ¢ Part III: An overview of policy options, governance and co-operation among market and political entities, and further comparative analysis of mitigation policies and actions.  \nThrough lectures, readings, case examinations/illustrations and field trips, and data analysis exercises, students will develop skills to interpret CO2 emissions and mitigation options, evaluate methodological strengths and limitations, and carry out GHG MRV and carbon footprints assessments.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100F",
+      "sections": [
+        {
+          "course_code": "IPEN6100F",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6183",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E4",
+              "instructor": "CHEN, Zichong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100F",
+      "course_title": "Greenhouse Gas Emission Quantification",
+      "course_desc": "This course introduces the scientific principles and practical methods for quantifying greenhouse gas (GHG) emissions using both bottom-up and top-down approaches. The course is organized into three main parts:\nâ¢ Part I: Overview of the major sources and sinks of carbon dioxide (COâ), methane (CHâ), and nitrous oxide (NâO) across natural and anthropogenic systems, with emphasis on global budgets and controlling processes.\nâ¢ Part II: Bottom-up approaches, including emission inventories, process-based modeling, and activity data analysis, with applications to key sectors such as energy, agriculture, and land use.\nâ¢ Part III: Top-down approaches, including atmospheric observations from ground stations, aircraft, and satellites, coupled with atmospheric transport models and inverse modeling techniques to infer emissions.\nThrough lectures, readings, and data analysis exercises, students will develop skills to interpret GHG fluxes, evaluate methodological strengths and limitations, and integrate complementary approaches for robust emission assessments. The course emphasizes both theoretical foundations and up-to-date research literature.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100G",
+      "sections": [
+        {
+          "course_code": "IPEN6100G",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6187",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W1",
+              "instructor": "LU, Jiaqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100G",
+      "course_title": "Global Environmental and Climate Policy",
+      "course_desc": "As the magnitudes of environmental problems have increased, many of the most severe issues have become truly global challenges. Hundreds of international agreements have been signed, but their effectiveness has been inconsistent. Heightened concern about environmental quality has increased demand analysts who can navigate the political, economic, scientific, and technological dimensions of these issues to inform critical policy decisions in a multinational context. This class is designed to introduce students to the main concepts, frameworks, and actors involved in addressing environmental and climate problems of global scale.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100H",
+      "sections": [
+        {
+          "course_code": "IPEN6100H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6219",
+          "quota": 20,
+          "enrol": 13,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 202, E1",
+              "instructor": "LUO, Lina"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100H",
+      "course_title": "Nature-based Solutions to Carbon Neutrality",
+      "course_desc": "Nature-based solutions (NbS) are becoming increasingly important as effective strategies for achieving carbon neutrality and addressing climate change. This course offers an integrated introduction to how natural and managed ecosystems contribute to carbon removal, how NbS are designed and implemented, and how they fit within broader sustainability and climate policy frameworks.\n\nThe course is organized into three parts:\nPart I: Scientific foundations\nA concise overview of climate change, the global carbon cycle, and the roles of land, ocean, and atmospheric systems in storing and releasing carbon. This section provides essential background for students from diverse disciplinary backgrounds.\nPart II: NbS strategies and real-world applications\nAn in-depth exploration of major nature-based approaches across different ecosystems, including: land-based NbS such as soil and forest carbon enhancement and landscape restoration; wetland NbS including peatland restoration and riparian systems; coastal and marine NbS (blue carbon) such as mangroves and saltmarsh ecosystems; and urban and hybrid NbS including green infrastructure and emerging integrated approaches. Case studies from China and around the world will be used to illustrate effectiveness, co-benefits, risks, and implementation challenges.\nPart III: Policy, governance, and sustainability practice\nA review of how NbS are incorporated into national and global climate strategies, carbon neutrality pathways, ESG and corporate sustainability frameworks. This section highlights real-world decision-making and career-relevant perspectives in climate policy, sustainability planning, and environmental management.\n\nThrough lectures, discussions, and group projects, students will develop interdisciplinary skills to understand, evaluate, and communicate how NbS contribute to carbon neutrality pathways in both scientific and practical contexts.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100I",
+      "sections": [
+        {
+          "course_code": "IPEN6100I",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6721",
+          "quota": 30,
+          "enrol": 15,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W4",
+              "instructor": "HE, Jinyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100I",
+      "course_title": "ESG Fundamentals and Strategy for Business",
+      "course_desc": "As ESG (Environmental, Social, and Governance) momentum sweeps the globe, companies must proactively chart their course and craft actionable strategies for engaging with society and the environmentâthereby mitigating related risks and building sustainable competitive advantage. This course introduces and maps out the frameworks and tools for business ESG strategy, enriched with case studies, simulations, and field study to inform both executive decision-making and frontline implementation.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100J",
+      "sections": [
+        {
+          "course_code": "IPEN6100J",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6722",
+          "quota": 30,
+          "enrol": 8,
+          "avail": 22,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 102, W1",
+              "instructor": "XIE, Danyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100J",
+      "course_title": "Entrepreneurship and Innovation: From Idea to Impact",
+      "course_desc": "This course provides a comprehensive overview of entrepreneurship and innovation, guiding students through the entire process from identifying opportunities to launching and scaling new ventures. It emphasizes experiential learning and real-world application, with a unique focus on direct engagement with successful entrepreneurs and innovators. Through a series of guest speaker sessions, students will gain invaluable insights into the challenges and triumphs of building a business, fostering a strong entrepreneurial mindset, and developing practical skills for navigating the dynamic landscape of innovation.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6100K",
+      "sections": [
+        {
+          "course_code": "IPEN6100K",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6723",
+          "quota": 40,
+          "enrol": 29,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 202, E3",
+              "instructor": "LI, Moyan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6100K",
+      "course_title": "Health Care Management and Policy",
+      "course_desc": "This course examines the health care sector and healthy policy issues using theoretical frameworks and empirical evidence. We will provide a broad understanding of the global health care system, with an emphasis on payers, providers, products, and patients. This course also introduces the statistical methods used for evaluating health outcomes that enable us to assess the true effectiveness of health care policies and strategies.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6102",
+      "sections": [
+        {
+          "course_code": "IPEN6102",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6180",
+          "quota": 40,
+          "enrol": 13,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 102, W1",
+              "instructor": "REN, Qianping"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6102",
+      "course_title": "IPEN Program Seminar II",
+      "course_desc": "This course is expected to expose the RPg students to the current innovation, policy and entrepreneurship research and development, and provide them with opportunities to make social contacts with the speakers in both environmental innovation communities and policy communities. This course will be an essential part of training for our RPg students. Seminar II is an extension of Seminar I. While the overall design of the seminar course looks essentially the same, topics covered and guests invited will be differentiated. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6110",
+      "sections": [
+        {
+          "course_code": "IPEN6110",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6181",
+          "quota": 40,
+          "enrol": 40,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 102, W4",
+              "instructor": "HOU, Yun & XU, Kewei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "IPEN",
+      "catalog_number": "6110",
+      "course_title": "Capstone Project",
+      "course_desc": "This course consists of 6 credits and will last for two regular terms. In the first term, students learn and integrate the latest technology topics through seminars,lectures, and workshops. After completing four micro-policy analysis reports, students can familiarize themselves with technology policy hot spots and policy analysis tools, as well as the cooperation skills and role division among the groups. In the second term, they will complete group projects on selected topics for science and technology policy under the supervision offaculty members. The participation of the universityâs internal community and external organizations in these projects will be highly encouraged. The university will be responsible for the control, management and evaluation of the project. Students will exercise their teamwork skills, analyze science and technology policy issues and develop concise reports of their findings and recommendations. They should write the paper acting as an assistant to a particular decision-maker in a government, nonprofit organization, business or private sector. This course is for MSc(TP) students only. May be graded PP.",
+      "credit": 6,
+      "pg_course": true,
+      "vector": "[6 credits]",
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN6990",
+      "sections": [],
+      "subject": "IPEN",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "IPEN7990",
+      "sections": [],
+      "subject": "IPEN",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "LANG5000",
+      "sections": [
+        {
+          "course_code": "LANG5000",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6275",
+          "quota": 25,
+          "enrol": 22,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 222, W1",
+              "instructor": "LI, Yuguo & ZHANG, Wei"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 222, W1",
+              "instructor": "LI, Yuguo & ZHANG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "LANG",
+      "catalog_number": "5000",
+      "course_title": "Foundation in Listening & Speaking for Postgraduate Students",
+      "course_desc": "For students whose level of spoken English is lower than ELPA Level 4 (Speaking) when they enter the University. The course addresses the immediate linguistic needs of research postgraduate students for oral communication on campus using English. To complete the course, students are required to attain at least ELPA Level 4 (Speaking). Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-3-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS1010",
+      "sections": [
+        {
+          "course_code": "MICS1010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6229",
+          "quota": 60,
+          "enrol": 48,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1730",
+              "end_time": "1820",
+              "room": "Rm 147, E1",
+              "instructor": "XU, Jiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "1010",
+      "course_title": "Introduction to IC Chip",
+      "course_desc": "This course introduces integrated circuit (IC) and insights into key IC technologies. Through visiting chip fabrication facilities and watching examples, it helps students understand the importance of IC to our daily lives and societies. The course overviews topics including IC fabrication, architecture, systems, applications, and electronic design automation (EDA). The IC history and development trends are discussed in the course. Graded Pass/Fail.",
+      "credit": 1,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "MICS5220",
+      "sections": [
+        {
+          "course_code": "MICS5220",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6070",
+          "quota": 20,
+          "enrol": 8,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, W1",
+              "instructor": "WANG, Renjie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "5220",
+      "course_title": "Micro Fabrication of Advanced Optoelectronic Devices",
+      "course_desc": "This course explores the core principles of micro/nano processing technologies crucial for developing sophisticated optoelectronic devices. This course delves into the thermodynamics, kinetics of material growth, deposition methods, vacuum technology, cutting-edge deposition and characterization techniques, and advanced lithography. Students will learn to manipulate control parameters of these processes and understand their impact on optoelectronic device performance and applications. These devices are widely used in fields such as communications, transportation, environmental monitoring, aerospace applications, energy production, medical applications, and others.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS5420",
+      "sections": [
+        {
+          "course_code": "MICS5420",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6071",
+          "quota": 20,
+          "enrol": 3,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, E4",
+              "instructor": "HUANG, Zhiqiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "5420",
+      "course_title": "Clock Generation Integrated Circuits",
+      "course_desc": "This course introduces the design and analysis of clock generation integrated circuits. The covered topics include basic concepts, basic oscillator, oscillator analysis, advanced oscillator techniques, basic phase-locked loop architecture, integer-N PLLs, fractional-N PLLs, frequency dividers and multipliers, digital PLLs, advanced frequency synthesis and clock data recovery.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS5450",
+      "sections": [
+        {
+          "course_code": "MICS5450",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6075",
+          "quota": 20,
+          "enrol": 6,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, E4",
+              "instructor": "ZONG, Zhirui"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "5450",
+      "course_title": "High-Speed Integrated Circuits Design",
+      "course_desc": "This course will focus on the circuits and architectures for high-speed wireline data communications. The topics that will be covered in this course include wireline data link systems, transmitters, receivers, equalizers, clock and data recovery, etc. Upon finishing this course, students are expected to understand the basic principles of modern high-speed data link systems and grasp the essentials to design the integrated circuits for such systems.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS5460",
+      "sections": [
+        {
+          "course_code": "MICS5460",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6076",
+          "quota": 20,
+          "enrol": 4,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, W4",
+              "instructor": "JIANG, Hongwu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "5460",
+      "course_title": "Advanced VLSI Design",
+      "course_desc": "This course offers an in-depth exploration of the contemporary VLSI circuit design. The material covers the design principles of digital circuits, as well as the designs of core VLSI building units, including combinational logic, sequential elements, arithmetic circuits, memory sub-systems, and other important circuits for VLSI system integration. Implementations in CMOS will be considered in relation to key design metrics such as timing, power, area, and reliability. This course is a project-oriented class, which requires students to design and layout VLSI circuits and sub-systems using commercially available design tools.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS5910",
+      "sections": [
+        {
+          "course_code": "MICS5910",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6088",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, E4",
+              "instructor": "LYU, Yangdi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "5910",
+      "course_title": "Embedded System Design",
+      "course_desc": "This course introduces the basic concepts of embedded system design. It covers the modeling and specification, hardware/software co-design, architectures, real-time operating systems, compression, compilation, and design space exploration. It will also cover other topics, such as security, verification, and validation. The goal of this course is to help students develop a comprehensive understanding of the technologies behind the embedded systems design.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6001D",
+      "sections": [
+        {
+          "course_code": "MICS6001D",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6090",
+          "quota": 20,
+          "enrol": 3,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, E3",
+              "instructor": "CAI, Guigang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6001D",
+      "course_title": "Integrated Switch Mode Power Converters Design",
+      "course_desc": "Switch mode power converters (SMPCs) are the most widely used power management circuits. This course covers the working principles of the SMPCs, along with discussion of the topologies, continuous and discontinuous conduction mode, loop gain analysis and relevant mathematical tools, stability and compensation. This course delves into the design details and optimization of integrated SMPCs. This course provides a comprehensive understanding of the SMPCs.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6001L",
+      "sections": [
+        {
+          "course_code": "MICS6001L",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6091",
+          "quota": 20,
+          "enrol": 13,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W2",
+              "instructor": "CHEN, Yun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6001L",
+      "course_title": "Secure Hardware Architecture",
+      "course_desc": "In this course, we will first introduce classic microarchitectural side-channel attacks, such as Spectre, Meltdown, Hertbleed, Fallout, and AfterImage. You will learn how they leak data from modern processors. This course will then introduce how to design secure microarchitecture to defend against these attacks. You will use some simulators to reproduce these defenses and finally design your own secure processor.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6001N",
+      "sections": [
+        {
+          "course_code": "MICS6001N",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6092",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 201, E3",
+              "instructor": "JIANG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "MICS6001N",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6093",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 201, E3",
+              "instructor": "JIANG, Wei"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6001N",
+      "course_title": "Fundamentals and Design Practice of CMOS Integrated Circuits",
+      "course_desc": "This course focuses on the design practice of CMOS integrated circuits (ICs). In the begining of the course, we will talk about some fundamentals regarding the MOSFET models, voltage/current reference, supply-independent biasing and its startup circuits, amplifiers, output buffers, switched-capacitor circuits and memories. After understanding the fundatmentals of ICs, we will focus the design pratice of the CMOS integrated circuits using the Cadence IC design tools.  We will explore the designs and simulations of the following blocks: current sink, bandgap reference, amplifier, switched-capacitor circuits, output buffers and etc. After finishing this course, students are expected to obtain the practical experience of the design and simulation methdologies of  some of the key digital and analog circuit blocks using the Cadence tools.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[2-1-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6001Q",
+      "sections": [
+        {
+          "course_code": "MICS6001Q",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6095",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Rm 202, W2",
+              "instructor": "CHENG, Bojun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "MICS6001Q",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6096",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1530",
+              "end_time": "1620",
+              "room": "Rm 202, W2",
+              "instructor": "CHENG, Bojun"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6001Q",
+      "course_title": "Neuromorphic Sensing and Computing",
+      "course_desc": "This course provides an in-depth study of neuromorphic hardware, including both computing and sensing blocks. Students will engage with foundational principles as well as cutting-edge developments in neuromorphic devices and circuits, gaining a comprehensive understanding of their architecture, function, and potential impact. The curriculum begins by covering essential components such as CMOS transistors, vision sensors, acoustic sensors, and other sensory devices. Students will also explore advanced neuromorphic systems, including silicon neurons, synapses, retinas and cochlear, as well as utilize event-driven, spike-based communication for neuromorphic system. Emerging technologies beyond CMOS, such as memristors and MEMS devices, will be examined for their transformative potential in neuromorphic computing and sensing applications.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[2-1-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6001V",
+      "sections": [
+        {
+          "course_code": "MICS6001V",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6098",
+          "quota": 25,
+          "enrol": 16,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, W2",
+              "instructor": "CHEN, Xinyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6001V",
+      "course_title": "Accelerated Computing with GPUs",
+      "course_desc": "This course introduces the fundamentals of GPU-accelerated computing, focusing on how GPUs enable high-performance solutions for complex tasks in fields like AI, data analytics, and scientific simulations. Students will explore GPU architectures, learn parallel programming models such as CUDA and ROCM, and develop skills in memory management, performance optimization, and thread synchronization. Through hands-on projects, participants will gain practical experience in leveraging GPU parallelism to solve real-world computational challenges, preparing them to apply these techniques in industries.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002K",
+      "sections": [
+        {
+          "course_code": "MICS6002K",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6100",
+          "quota": 20,
+          "enrol": 8,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, E1",
+              "instructor": "LU, Zhonghai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002K",
+      "course_title": "Artificial Intelligence for Time-Series Analysis",
+      "course_desc": "Time-series data represent a major category of real-world data collected over time from various sensors or measurement equipment. This course introduces foundational Artificial Intelligence (AI) methods for analyzing time-series data, in particular, about time-series modeling and prediction. We start from investigating the basic properties of time-series data, then discuss a range of popular AI models widely used for time-series modeling and prediction such as Autoregressive Integrated Moving Average (ARIMA) models, Neural Network (NN), Physics-Informed Neural Network (PINN), Hidden Markov Model (HMM) and Kalman Filter (KF) etc. Besides supervised learning, we also discuss un-supervised learning such as clustering algorithms and Self-Organizing Map (SOM) for analyzing time-series data. Broadly this course is a fundamental AI course for all students who intend to master essential theoretical AI methods and practical AI skills needed to develop, assess, and deploy intelligent functionalities in smart electronic and computer systems, Internet-of-Things (IoT), cyber-physical systems (CPS), and any forecasting-relevant applications in finance, economics, data analytics, and other relevant science & engineering fields. Grading Type: Pass or Fail",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002L",
+      "sections": [
+        {
+          "course_code": "MICS6002L",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6102",
+          "quota": 40,
+          "enrol": 37,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 150, E1",
+              "instructor": "XU, Renjing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002L",
+      "course_title": "Introduction to Humanoid Computing",
+      "course_desc": "Humanoid Computing sits at the exciting intersection of AI, robotics, neuroscience, and engineering. It is for students who are curious about the future of intelligent systems and want to contribute to technologies that work in harmony with human abilities. This course will equip you with a unique, bio-inspired perspective that is becoming increasingly critical for innovation in artificial intelligence and robotics. It encompasses human-inspired approaches to computation, including topics such as humanoid robots, tactile perception, and brain-inspired algorithms.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002M",
+      "sections": [
+        {
+          "course_code": "MICS6002M",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6103",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 103, E1",
+              "instructor": "XU, Zefeng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002M",
+      "course_title": "Introduction to Semiconductorized Photonics",
+      "course_desc": "Photonics is transforming the world by enabling breakthroughs in AI, robotics, and next-generation computing. This course explores the rapidly evolving field of photonic technologies that are driving innovation across multiple industries, with a particular emphasis on the semiconductor industry. Over the past decade, photonics has become increasingly integrated into semiconductor processes and is undergoing a trend of being âsemiconductorizedâ. Students will begin by learning the fundamentals of active photonic devices and advanced nanofabrication techniques. The course will then dive into emerging applications, including photonic sensing, photonic computing, and biophotonic technologies. By the end of the course, students will gain a deep understanding of the pivotal role of photonics in technological advancement and will be well-prepared to engage with future innovations in this field. Grading Type: Pass or Fail",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002N",
+      "sections": [
+        {
+          "course_code": "MICS6002N",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6104",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E4",
+              "instructor": "YANG, Kezhou"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002N",
+      "course_title": "Random Process with Applications to Signal",
+      "course_desc": "Signals in the form of fluctuating quantities such as voltage, temperatures or others are usually not subject to precise prediction. On the other hand, disturbances such as thermal noise, or errors during signal transmission also contribute to such unpredictability. These quantities which vary with time are referred to as random processes. This course introduces how random signals can be characterized with the help of knowledge of random processes. As prerequisites, the course will also cover basic knowledge about random processes (including a quick review of necessary knowledge about probability theory), as well as signal processing (mainly focus on linear time-invariant systems). The course will also give a brief introduction about the underlying physics mechanisms in electronic devices which account for the intrinsic randomness in the electronic system.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002O",
+      "sections": [
+        {
+          "course_code": "MICS6002O",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6107",
+          "quota": 20,
+          "enrol": 4,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W2",
+              "instructor": "ZHANG, Jian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002O",
+      "course_title": "Advanced Operating System",
+      "course_desc": "This course is designed for graduate students who already understand OS fundamentals. This course will spend some time in the class to refresh the basics and discuss the following topics: OS structure, virtual memory management, file system design, threads and scheduling, virtualization, and distributed systems. For each topic, we will discuss seminal papers and ideas, current influential papers, and future research trends.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6002P",
+      "sections": [
+        {
+          "course_code": "MICS6002P",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6105",
+          "quota": 20,
+          "enrol": 3,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 105, W3",
+              "instructor": "LIU, Xiwen"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MICS",
+      "catalog_number": "6002P",
+      "course_title": "Advanced Logic and Memory Devices",
+      "course_desc": "Building on semiconductor fundamentals and device physics, this course explores the latest developments in advanced logic and memory devices, covering nanoscale CMOS transistor scaling, short-channel effects, advanced process technologies, and reliability challenges. Beyond logic devices, it offers a comprehensive overview of memory technologies, including volatile memories (SRAM, DRAM) and non-volatile memories (Flash, ReRAM, ferroelectric memory), emphasizing their device physics, charge or polarization mechanisms, performance trade-offs, and integration with logic circuits. Through comparative analysis, the course highlights how emerging memory technologies complement and extend CMOS logic to enable next-generation computing architectures.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6090B",
+      "sections": [],
+      "subject": "MICS",
+      "catalog_number": "6090B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "MICS6990",
+      "sections": [],
+      "subject": "MICS",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "MICS7990",
+      "sections": [],
+      "subject": "MICS",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "MSSM5009",
+      "sections": [
+        {
+          "course_code": "MSSM5009",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6153",
+          "quota": 40,
+          "enrol": 14,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "2120",
+              "room": "Rm 202, E3",
+              "instructor": "CHEN, Li"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MSSM",
+      "catalog_number": "5009",
+      "course_title": "Fundamental Theories and Algorithms of CAD/CAM",
+      "course_desc": "This course covers topics such as curves and surfaces, geometric modeling basics, data structures in CAD/CAM, optimization, numerical control technology, numerical control machining, and projects. In addition to lectures, a 3-hour lab in SolidWorks and MATLAB programming will be offered.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "MSSM5010",
+      "sections": [
+        {
+          "course_code": "MSSM5010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6154",
+          "quota": 40,
+          "enrol": 12,
+          "avail": 28,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, E4",
+              "instructor": "TANG, Kai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "MSSM",
+      "catalog_number": "5010",
+      "course_title": "Numerical Methods for Engineers",
+      "course_desc": "This course is intended for teaching numerical methods for engineering students at the postgraduate level. The course will have three important objectives: (1) to teach the basic theories and fundamentals of numerical methods; (2) to help the students to acquire skills to implement these methods for computer solution; and finally (3) to provide an environment where the students can familiarize themselves with many todayâs popular commercial software systems and their use in the solution of engineering problems.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6770K",
+      "sections": [
+        {
+          "course_code": "PDEV6770K",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6695",
+          "quota": 999,
+          "enrol": 308,
+          "avail": 691,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6770K",
+      "course_title": "Professional Development for Research Postgraduate Students",
+      "course_desc": "This course aims at equipping research postgraduate students with transferrable skills conducive to their professional development. Students are required to attend 3 hours of mandatory training on Professional Conduct, and complete 12 hours of workshops, at their own choice, under the themes of Communication Skills, Research Competency, Entrepreneurship, SelfâManagement, and Career Development. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6770L",
+      "sections": [
+        {
+          "course_code": "PDEV6770L",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6696",
+          "quota": 999,
+          "enrol": 578,
+          "avail": 421,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6770L",
+      "course_title": "Professional Development for Research Postgraduate Students",
+      "course_desc": "This course aims at equipping research postgraduate students with transferrable skills conducive to their professional development. Students are required to attend 3 hours of mandatory training on Professional Conduct, and complete 12 hours of workshops, at their own choice, under the themes of Communication Skills, Research Competency, Entrepreneurship, SelfâManagement, and Career Development. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6770M",
+      "sections": [
+        {
+          "course_code": "PDEV6770M",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6697",
+          "quota": 999,
+          "enrol": 308,
+          "avail": 691,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6770M",
+      "course_title": "Professional Development for Research Postgraduate Students",
+      "course_desc": "This course aims at equipping research postgraduate students with transferrable skills conducive to their professional development. Students are required to attend 3 hours of mandatory training on Professional Conduct, and complete 12 hours of workshops, at their own choice, under the themes of Communication Skills, Research Competency, Entrepreneurship, SelfâManagement, and Career Development. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6770N",
+      "sections": [
+        {
+          "course_code": "PDEV6770N",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6698",
+          "quota": 999,
+          "enrol": 163,
+          "avail": 836,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6770N",
+      "course_title": "Professional Development for Research Postgraduate Students",
+      "course_desc": "This course aims at equipping research postgraduate students with transferrable skills conducive to their professional development. Students are required to attend 3 hours of mandatory training on Professional Conduct, and complete 12 hours of workshops, at their own choice, under the themes of Communication Skills, Research Competency, Entrepreneurship, SelfâManagement, and Career Development. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6770S",
+      "sections": [
+        {
+          "course_code": "PDEV6770S",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6699",
+          "quota": 999,
+          "enrol": 0,
+          "avail": 999,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6770S",
+      "course_title": "Professional Development for Research Postgraduate Students",
+      "course_desc": "This course aims at equipping research postgraduate students with transferrable skills conducive to their professional development. Students are required to attend 3 hours of mandatory training on Professional Conduct, and complete 12 hours of workshops, at their own choice, under the themes of Communication Skills, Research Competency, Entrepreneurship, SelfâManagement, and Career Development. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800K",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800K",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800L",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800L",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800M",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800M",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800N",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800N",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800O",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800O",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800P",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800P",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800Q",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800Q",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800R",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800R",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800S",
+      "sections": [],
+      "subject": "PDEV",
+      "catalog_number": "6800S",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800X",
+      "sections": [
+        {
+          "course_code": "PDEV6800X",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6720",
+          "quota": 10,
+          "enrol": 4,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1400",
+              "end_time": "1550",
+              "room": "TBA",
+              "instructor": "KUO, YI LUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PDEV6800X",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6724",
+          "quota": 10,
+          "enrol": 1,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1400",
+              "end_time": "1550",
+              "room": "TBA",
+              "instructor": "KUO, YI LUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6800X",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PDEV6800Y",
+      "sections": [
+        {
+          "course_code": "PDEV6800Y",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6276",
+          "quota": 60,
+          "enrol": 54,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1400",
+              "end_time": "1550",
+              "room": "Rm 228, E2",
+              "instructor": "KUO, YI LUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PDEV6800Y",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6277",
+          "quota": 60,
+          "enrol": 56,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1400",
+              "end_time": "1550",
+              "room": "Rm 228, E2",
+              "instructor": "KUO, YI LUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PDEV",
+      "catalog_number": "6800Y",
+      "course_title": "Introduction to Teaching and Learning in Higher Education",
+      "course_desc": "The course is designed to strengthen studentsâ competence in teaching. It comprises 2 parts: Part 1 aims to equip all full-time research postgraduate (RPg) students with basic teaching skills before assuming teaching assistant duties for the department. Good teaching skills can be acquired through learning and practice.Â  This 10-hour mandatory training course provides all graduate teaching assistants (GTA) with the necessary theoretical knowledge with practical opportunities to apply and build up their knowledge, skills and confidence in taking up their teaching duties. At the end of the course, GTAs should be able to (1) facilitate teaching in tutorials and laboratory settings; (2) provide meaningful feedback to their students; and (3) design an active learning environment to engage their students. In Part 2, students are required to perform instructional delivery assigned by their respective departments to complete this course. MPhil students are required to give at least one 30-minute session of instructional delivery in front of a group of students for one term. PhD students are required to give at least one such session each in two different terms. Graded PP, P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "PLED5001",
+      "sections": [
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6280",
+          "quota": 25,
+          "enrol": 22,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 205, C7 Library",
+              "instructor": "PARK, Jaeuk"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 205, C7 Library",
+              "instructor": "PARK, Jaeuk"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6281",
+          "quota": 25,
+          "enrol": 24,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 205, C7 Library",
+              "instructor": "PARK, Jaeuk"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 205, C7 Library",
+              "instructor": "PARK, Jaeuk"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6282",
+          "quota": 25,
+          "enrol": 24,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 222, W1",
+              "instructor": "BRENNAN, SHANE"
+            },
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 222, W1",
+              "instructor": "BRENNAN, SHANE"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6283",
+          "quota": 25,
+          "enrol": 14,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 205, C7 Library",
+              "instructor": "BRENNAN, SHANE"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 205, C7 Library",
+              "instructor": "BRENNAN, SHANE"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6285",
+          "quota": 25,
+          "enrol": 19,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 205, C7 Library",
+              "instructor": "ZHANG, TIEFU"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 205, C7 Library",
+              "instructor": "ZHANG, TIEFU"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6286",
+          "quota": 25,
+          "enrol": 24,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 233, W1",
+              "instructor": "ZHANG, TIEFU"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 233, W1",
+              "instructor": "ZHANG, TIEFU"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6287",
+          "quota": 25,
+          "enrol": 18,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 202, E3",
+              "instructor": "LIAO, Simei"
+            },
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 202, E3",
+              "instructor": "LIAO, Simei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "PLED5001",
+          "section_type": "T",
+          "name": "T09",
+          "bundle": 9,
+          "semester_id": "2530",
+          "section_id": "6288",
+          "quota": 25,
+          "enrol": 5,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 205, C7 Library",
+              "instructor": "HUANG, Yuqing"
+            },
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 205, C7 Library",
+              "instructor": "HUANG, Yuqing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "PLED",
+      "catalog_number": "5001",
+      "course_title": "Communicating Research in English",
+      "course_desc": "This course aims to help research postgraduate students to develop skills they need to understand how to successfully communicate research in English to academic, cross-disciplinary and non-specialist audiences. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-3-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5111",
+      "sections": [
+        {
+          "course_code": "ROAS5111",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6760",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, E1",
+              "instructor": "YASA, Oncay"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5111",
+      "course_title": "Soft Robotics",
+      "course_desc": "This course provides a comprehensive introduction to soft robotics, focusing on the design, fabrication, and application of compliant and flexible robots. Students will explore the fundamental principles of soft materials, actuation methods, and sensing technologies that enable soft robots to interact safely with complex, unstructured environments. It covers key topics including material selection, mechanical modeling, control strategies, and manufacturing techniques. Through detailed case studies, students will examine how specific materials and design choices improve the functionality and efficiency of these robots for applications in healthcare and exploration.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5120",
+      "sections": [
+        {
+          "course_code": "ROAS5120",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6155",
+          "quota": 20,
+          "enrol": 8,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, W2",
+              "instructor": "JI, Yiding"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5120",
+      "course_title": "Formal Verification and Control of Dynamical Systems",
+      "course_desc": "Formal methods originate from theoretical computer science and have been seamlessly integrated with dynamical systems. At its core, formal methods involve formulating specifications to form proof obligations, verifying that the systems indeed meet their specifications via algorithmic proof search, and designing systems to meet those obligations. This course bridges fundamental gaps between formal methods and control theory. It introduces fundamental theories and techniques of formal methods that apply broadly to various dynamical systems, such as robots, autonomous systems and cyber physical systems. Particularly, the following topics will be covered: symbolic system modeling, regular and omega-regular properties, linear temporal logic, model checking, system simulation and abstraction, game theoretic control synthesis and cutting-edge engineering applications.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5210",
+      "sections": [
+        {
+          "course_code": "ROAS5210",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6156",
+          "quota": 30,
+          "enrol": 10,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 222, W1",
+              "instructor": "NIE, Qiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5210",
+      "course_title": "Advanced Robotics",
+      "course_desc": "Learning about the core principles and latest developments in Robotics is crucial for nurturing innovative students in this field. This course provides a comprehensive overview of the core concepts in robotics. Students will mainly explore the principles of robot kinematics, dynamics, planning and control. In addition, some latest advancements in robotics integrated with artificial intelligence will also be discussed, such as VLA and robot foundation models.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5400",
+      "sections": [
+        {
+          "course_code": "ROAS5400",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6761",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1900",
+              "end_time": "2150",
+              "room": "Rm 201, W1",
+              "instructor": "SONG, Jie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5400",
+      "course_title": "Learning for 3D Vision",
+      "course_desc": "This course explores the forefront of computer vision through the lens of novel neural 3D representations. Students will investigate advanced techniques that leverage deep learning to enhance the understanding and interpretation of 3D data. Key topics include the development and application of innovative neural architectures for processing point clouds, voxel grids, and implicit surfaces, as well as the integration of these representations into real-world applications such as augmented reality, autonomous navigation, and robotics. Through a blend of theoretical insights and practical projects, students will engage with state-of the-art methodologies and contribute to ongoing research in the field.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5500",
+      "sections": [
+        {
+          "course_code": "ROAS5500",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6157",
+          "quota": 40,
+          "enrol": 33,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, E1",
+              "instructor": "ZHAO, Hang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5500",
+      "course_title": "Mechatronics Design",
+      "course_desc": "This course introduces the essential fundamentals, including modeling, sensing, signal transmission and conversion, actuation, control, simulation, and implementation technologies used within the mechatronics design for robots and autonomous systems. It will give a holistic view of advanced automation technologies in industrial applications, taking electric vehicles and robots as examples. Also, this course will provide the essential skills to design intelligent mechatronics systems, and students will be allocated Arduino and STM32 development kits to participate in mechatronics design in the course project. Through this course, students can enhance their understanding of the cross-disciplinary integration and systematic optimization of mechatronics systems involving the knowledge of mechanics, electronics, control engineering, and computer science.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5700",
+      "sections": [
+        {
+          "course_code": "ROAS5700",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6158",
+          "quota": 48,
+          "enrol": 45,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W4",
+              "instructor": "MA, Jun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5700",
+      "course_title": "Robot Motion Planning and Control",
+      "course_desc": "This course introduces the advanced methodologies in the context of motion planning and control for robotics and autonomous systems. Various methodologies are introduced, including search-based methods, grid-based methods, sampling-based methods, optimization-based methods, learning-based methods, etc. In general, this course covers modern approaches, deep theory, and good practice envisions. In addition to the fundamental knowledge in motion planning and control, the students will also have the opportunity to discover and learn cutting-edge methodologies in the related field, aligning with the substantial developments in robotics, autonomous driving, UAVs, etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5810",
+      "sections": [
+        {
+          "course_code": "ROAS5810",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6762",
+          "quota": 40,
+          "enrol": 23,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, W2",
+              "instructor": "ZHU, Lei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5810",
+      "course_title": "Advanced Learning Techniques for Medical Robotics Systems",
+      "course_desc": "This course will present how to utilize many advanced learning techniques and modules to analyze and interpret diverse medical image modalities (such as ultrasound, CT, MRI, X-ray, and so on) in recent years. The techniques to be covered include supervised learning, video understanding, multi-modal learning, transformer, self supervised learning, semi-supervised learning, domain adaptation, generative models, large models, and so on. The course will cover an overview of medical image modalities, traditional medical image processing methods, deep learning techniques and their applications in medical image analysis, and advanced data-efficient learning on medical imaging.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS5910",
+      "sections": [
+        {
+          "course_code": "ROAS5910",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6160",
+          "quota": 15,
+          "enrol": 4,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "TBA",
+              "instructor": "HE, Dengbo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "5910",
+      "course_title": "Engineering Psychology and Transportation Applications",
+      "course_desc": "The course will cover a wide range of engineering psychology topics as well as how the research in these directions can affect policies and regulations in vehicle design and surface transportation. The students will gain an understanding of the characteristics and limitations of human beings from engineering psychology perspectives of view and how the design of traffic control devices, the roadway, the in-vehicle devices, regulations and traffic rules can be affected by the research in these directions.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS6800J",
+      "sections": [
+        {
+          "course_code": "ROAS6800J",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6162",
+          "quota": 100,
+          "enrol": 100,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 101, E1",
+              "instructor": "NIE, Qiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "ROAS",
+      "catalog_number": "6800J",
+      "course_title": "Seminar in Robotics and Autonomous Systems",
+      "course_desc": "Seminar topics presented by students, faculty and guest speakers. Students are expected to attend regularly and demonstrate proficiency in presentation in accordance with the program requirements. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS6900B",
+      "sections": [],
+      "subject": "ROAS",
+      "catalog_number": "6900B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "1 credit",
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS6990",
+      "sections": [],
+      "subject": "ROAS",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "ROAS7990",
+      "sections": [],
+      "subject": "ROAS",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN5060",
+      "sections": [
+        {
+          "course_code": "SEEN5060",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6109",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, W2",
+              "instructor": "ZHENG, Junyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "5060",
+      "course_title": "Greenhouse Gas, Air Pollutant Emissions and Mitigation",
+      "course_desc": "The aims of this course are to assist students understand emission characteristics of greenhouse gas and air pollutants and their sources, how to characterize and quantify emissions for diverse source sectors, and how to mitigate greenhouse gas and air pollutant emissions. The topics will include: the introduction of greenhouse gases and air pollutants; the characteristics of sector-based greenhouse gas and air pollutant emission sources, sampling and measurement techniques, and commonly used bottom-up estimation methods for major sectors such as energy, industry, transportation, households, and others; the uncertainty and validation of bottom-up emission inventory; the application of big data and innovative methodologies to emission inventory development; and major strategies and green technologies for mitigating greenhouse gas and air pollutant emissions.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN5180",
+      "sections": [
+        {
+          "course_code": "SEEN5180",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6112",
+          "quota": 20,
+          "enrol": 6,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W2",
+              "instructor": "QIU, Huihe"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "5180",
+      "course_title": "Advanced Thermal Management for Electronics and Power Batteries",
+      "course_desc": "This course introduces concepts in the thermal management of electronics systems and power batteries. Traditional and innovative methods for heat dissipation from electronic systems, and assessment of these methods over a range of applications and scales, will be covered. Novel ultrathin flexible vapor chamber heat spreaders and microchannel heat sinks will be introduced and discussed. Some special emphasis is given to industry applications to discuss thermal management trends.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN5320",
+      "sections": [
+        {
+          "course_code": "SEEN5320",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6119",
+          "quota": 15,
+          "enrol": 15,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 105, W3",
+              "instructor": "LI, Xiangyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "5320",
+      "course_title": "Machine Learning in Advanced Energy Systems",
+      "course_desc": "The course aims to introduce main machine learning techniques and their applications in energy systems. The topics will include: 1) the basic concept of machine learning, big data, and energy system; 2) both basic and the state-of-the-art techniques in machine learning; 3) the application of machine learning in energy systems, especially for power systems and smart grids. The goal of the course is to prepare the students for careers in energy and artificial intelligence related areas by teaching data-driven perspective.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6000V",
+      "sections": [
+        {
+          "course_code": "SEEN6000V",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6114",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E3",
+              "instructor": "LI, Yuheng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6000V",
+      "course_title": "Quantum Mechanical Modeling of Energy Materials",
+      "course_desc": "In the context of global decarbonization, energy materials take center stage in sustainable energy applications. Thanks to the development of theory and computation power, computational materials science is playing a more and more important role in the investigation and design of energy materials. This course equips students with the fundamental theory and practical skills in materials modeling based on the quantum-mechanical first-principles calculations. The following contents will be covered: the SchrÃ¶dinger equation; density functional theory; Hartree-Fock method; calculations of solids, surfaces, vibrations, thermodynamic phase diagrams, electronic structure, transition states, and ab initio molecular dynamics.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6000X",
+      "sections": [
+        {
+          "course_code": "SEEN6000X",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6117",
+          "quota": 20,
+          "enrol": 5,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E3",
+              "instructor": "LIANG, Yutong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6000X",
+      "course_title": "Air Pollution Control",
+      "course_desc": "Air pollution presents substantial human health risks, contributes to climate change, incurs economic costs, diminishes visibility, and exacerbates social inequalities, highlighting the urgency of effective management strategies. This course offers a quantitative overview of air pollution characterization and control, with a particular emphasis on greenhouse gases. Half of this course focuses on control technologies, exploring both their theoretical foundations and practical applications, while the other half delves into essential background topics that inform the selection of these techniques. Through this comprehensive framework, students will develop a nuanced understanding of air quality management and its critical implications for public health and environmental sustainability.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6000Y",
+      "sections": [
+        {
+          "course_code": "SEEN6000Y",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6118",
+          "quota": 20,
+          "enrol": 8,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E1",
+              "instructor": "ZENG, Jian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6000Y",
+      "course_title": "Hydrogen and Fuel Cell",
+      "course_desc": "Hydrogen energy plays a pivotal role in the transition towards a sustainable and clean future. In this course we will provide the students with fundamental knowledge of hydrogen production and utilization technologies. We will introduce the concepts, components and operational principles of hydrogen production, storage, transportation and utilization technologies. We will pay particular attention to the fuel cell technology as key converter in hydrogen energy grid, by learning thermodynamics, kinetics, fuel cell components, stacks and fuel cell economies. Upon completion of this course, students will acquire fundamental and comprehensive understanding of hydrogen production technologies for applications and innovations, as well as designing and evaluation of fuel cell systems.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6001E",
+      "sections": [
+        {
+          "course_code": "SEEN6001E",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6121",
+          "quota": 20,
+          "enrol": 6,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 201, W1",
+              "instructor": "ZHANG, Yong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6001E",
+      "course_title": "Metal Halide Perovskites: Fundamentals and Applications",
+      "course_desc": "This course provides a comprehensive introduction to metal halide perovskite materials, covering their fundamental principles, synthesis techniques, optoelectronic properties, and applications in renewable energy and optoelectronic devices. The course integrates theoretical knowledge with practical applications, focusing on perovskite solar cells, light-emitting diodes, and photodetectors.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6001F",
+      "sections": [
+        {
+          "course_code": "SEEN6001F",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6122",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W1",
+              "instructor": "YUN, Qinbai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6001F",
+      "course_title": "Characterization Techniques of Energy Materials",
+      "course_desc": "The characterization of energy materials is pivotal for understanding their structure-property relationships. This course introduces the principles and applications of various instrumental techniques used in the characterization of energy materials. It covers the fundamental theoretical frameworks that provide insights into the working principles of equipment for imaging, diffraction and spectroscopy methods to characterize structural, compositional, and surface properties of energy materials. Additionally, the course explores the applications of these techniques in studying the structures and properties of key materials for energy conversion and storage systems such as electrocatalysis, batteries and solar cells. Ultimately, this course empowers students to select suitable characterization techniques and instruments to solve problems in energy materials research.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6001G",
+      "sections": [
+        {
+          "course_code": "SEEN6001G",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6123",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 103, E1",
+              "instructor": "HE, Donglin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6001G",
+      "course_title": "Crystalline Porous Materials for Adsorption and Separation",
+      "course_desc": "This course provides an in-depth introduction to crystalline porous materials, including porous organic cages (POCs), metalâorganic cages (MOCs), metalâorganic frameworks (MOFs), hydrogen-bonded frameworks (HOFs), and other related systems. Emphasis is placed on their synthesis, structural features, and porosity, with particular focus on adsorption and separation processes relevant to energy and environmental applications. The course also covers crystal engineering, advanced characterization techniques, and emerging topics such as AI-assisted materials discovery.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6001H",
+      "sections": [
+        {
+          "course_code": "SEEN6001H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6124",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 201, W1",
+              "instructor": "WANG, Yichao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SEEN",
+      "catalog_number": "6001H",
+      "course_title": "Electrochemistry of Energy Systems",
+      "course_desc": "The course aims to develop understanding in the area of electrochemical energy systems by building on existing knowledge of thermodynamics, kinetics, and transport. The lectures are thematically organized around several modules: \n1) Introduction to Devices\n2) Thermodynamics: relating free energy and potential, concentration-dependence of potential, temperature-dependence of potential, heat engine analysis, efficiency \n3) Kinetics: Butler Volmer, mechanisms, Marcus theory, Sabatier principle, double layer \n4) Transport: electronic conductivity, ionic conductivity, concentration overpotential, liquid junctions, conservation of mass and charge, boundary conditions, boundary layer analysis, experimental methods, equivalent circuits.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6100A",
+      "sections": [],
+      "subject": "SEEN",
+      "catalog_number": "6100A",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6100B",
+      "sections": [],
+      "subject": "SEEN",
+      "catalog_number": "6100B",
+      "course_title": "Independent Study",
+      "course_desc": "An independent study on selected topics carried out under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN6990",
+      "sections": [],
+      "subject": "SEEN",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SEEN7990",
+      "sections": [],
+      "subject": "SEEN",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG2030",
+      "sections": [
+        {
+          "course_code": "SMMG2030",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6230",
+          "quota": 40,
+          "enrol": 38,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 102, E1",
+              "instructor": "CAI, Yi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "SMMG2030",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6231",
+          "quota": 40,
+          "enrol": 38,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "TBA & Rm 228, E1",
+              "instructor": "CAI, Yi"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "2030",
+      "course_title": "Introduction to Smart Manufacturing",
+      "course_desc": "This course introduces core smart manufacturing technologies through integrated lectures and hands-on labs. Aimed at developing foundational understanding of data-driven modern production systems, it covers five essential topics: Design for Smart Manufacturing explores product optimization for digital workflows; Additive Manufacturing examines different 3D Printing processes beyond prototyping; Industrial Robotics teaches programming collaborative robots for automation tasks; Industrial Internet of Things addresses sensor networks and real-time data utilization; and Virtual and Augmented Reality Applications demonstrates immersive tools for design and maintenance. Each topic is integrated with a lab session. By the end of this course, students will be able to articulate key components of smart factories, apply skills learned in labsto real-world scenarios, and critically evaluate the impact of these technologies on manufacturing productivity, flexibility, and customization.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG3020",
+      "sections": [
+        {
+          "course_code": "SMMG3020",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6232",
+          "quota": 40,
+          "enrol": 25,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, E1",
+              "instructor": "CUI, Huachen"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "3020",
+      "course_title": "Introduction to Additive Manufacturing",
+      "course_desc": "This course studies methods used in additive manufacturing, theories governing additive manufacturing. With the information on materials given, students would be explained the relations between materials to be processed and methods of additive manufacturing, The course also introduces the common machines used for the technology and its applications and business opportunities with future directions. Students will learn to manufacture a 3D part by using some of the methods of additive manufacturing.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG3060",
+      "sections": [
+        {
+          "course_code": "SMMG3060",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6233",
+          "quota": 40,
+          "enrol": 15,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 202, E3",
+              "instructor": "WANG, Yunda"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 202, E3",
+              "instructor": "WANG, Yunda"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "3060",
+      "course_title": "Micro/Nano Fabrication and Applications",
+      "course_desc": "This course introduces the fundamental principles and techniques of micro- and nanofabrication, including photolithography, etching, deposition, bonding, and packaging. These processes form the technological foundation for the design and manufacturing of microelectromechanical systems (MEMS), as well as for advanced integrated circuits and next-generation electronic devices. In addition, the course explores how micro/nanofabrication enables a wide range of applications—including sensors, actuators, advanced electronics packaging, and other emerging microsystems—highlighting its critical role in modern and future technologies.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG3820",
+      "sections": [
+        {
+          "course_code": "SMMG3820",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6235",
+          "quota": 14,
+          "enrol": 14,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Chem Lab-Nobel Lab (W2-224A)",
+              "instructor": "LIU, Shiyuan & ZHANG, Yunbo"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "3820",
+      "course_title": "Smart Manufacturing Laboratory II",
+      "course_desc": "This is the continuation of SMMG 3810 to provide students with advanced training in experimental techniques and laboratory procedures, data acquisition, analysis and presentation. The course series aims at offering students an opportunity to face real problems in real manufacturing environments through the application of smart manufacturing methods to support the engineering and management of high-value-added products, the continuous innovation of products and processes, the sustainability of products and production systems along their lifecycle.",
+      "credit": 2,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG4020",
+      "sections": [
+        {
+          "course_code": "SMMG4020",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6248",
+          "quota": 40,
+          "enrol": 14,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 202, E3",
+              "instructor": "WANG, Wenyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "4020",
+      "course_title": "Manufacturing Process and Systems",
+      "course_desc": "In this course, students will learn the fundamental engineering strategies of how products are manufactured from raw materials, including metal shaping, polymer processing, and emerging techniques such as additive manufacturing and biofabrication. Through understanding basic engineering material properties, students will explore the rationale of selecting appropriate manufacturing routes via vase studies. Finally, students will explore how manufacturing systems are optimized for performance and cost, so as to appreciate the integrated nature of design, material, processing, and management in the manufacture of products.",
+      "credit": 4,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG4660",
+      "sections": [
+        {
+          "course_code": "SMMG4660",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6249",
+          "quota": 30,
+          "enrol": 6,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 221, W1",
+              "instructor": "TANG, Kai"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 221, W1",
+              "instructor": "TANG, Kai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "4660",
+      "course_title": "Numerical Methods in Engineering",
+      "course_desc": "This course is intended for teaching numerical methods for engineering students at the senior level as well as at the beginning graduate level. The course will have three important objectives: (1) to teach the basic theories and fundamentals of numerical methods; (2) to help the students to acquire skills to implement these methods for computer solution; and finally (3) to provide an environment where the students can familiarize themselves with many today's popular commercial software systems, such as MATLAB, and their use in the solution of engineering problems.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG5110",
+      "sections": [
+        {
+          "course_code": "SMMG5110",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6164",
+          "quota": 52,
+          "enrol": 50,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 222, W1",
+              "instructor": "CHEN, Mojun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "5110",
+      "course_title": "Introduction to Precision Engineering",
+      "course_desc": "This course covers the fundamentals and capabilities in precision engineering, including tool materials, mechanics of cutting, ultra-precision machine elements, micro electro-mechanical systems (MEMS) and nanoscale additive manufacturing. Based on these accumulations, this course introduces the industry growth, global state and analyzes the future of precision engineering.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG5150",
+      "sections": [
+        {
+          "course_code": "SMMG5150",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6764",
+          "quota": 20,
+          "enrol": 6,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 105, E3",
+              "instructor": "GUO, Daqiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "5150",
+      "course_title": "System Simulation",
+      "course_desc": "Simulation is the creation of a virtual model of a real-world system or process to study and analyze its behavior under various conditions. It is widely used in industrial systems to optimize design, improve processes, and test scenarios without the cost and risk of physical experimentation. This course will cover basic concepts and theories of simulation, discuss models and applications of discrete-event simulation in manufacturing systems. Students will learn to develop and analyze simulations, and test scenarios of real-world industrial systems. Additionally, this course will introduce the emerging concept of the digital twin and reinforcement learning in Smart Manufacturing, preparing students for opportunities in the evolving industrial revolution.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG5900",
+      "sections": [
+        {
+          "course_code": "SMMG5900",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6165",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W2",
+              "instructor": "ZHANG, Kaihao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "5900",
+      "course_title": "Advanced Metal Additive Manufacturing",
+      "course_desc": "This course provides students with the latest knowledge and skills for metal additive manufacturing (AM) techniques and implications, as well as the fundamental understanding of process-structure-property relationships in material processing using AM.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6000M",
+      "sections": [
+        {
+          "course_code": "SMMG6000M",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6182",
+          "quota": 55,
+          "enrol": 45,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1830",
+              "end_time": "2120",
+              "room": "Rm 122, E1",
+              "instructor": "HU, Pengcheng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "6000M",
+      "course_title": "Robotics in Manufacturing",
+      "course_desc": "This course covers the integration of industrial robotics with modern manufacturing industries. Basic theories like structure, forward and inverse kinematics, velocities and static forces, and trajectory and motion planning of robots will be introduced in this course. For some specific manufacturing scenarios, e.g., materials handling, processing (multi-axis milling, additive manufacturing, grinding, etc.), assembly, and inspection, some essential technologies like image processing and analysis and path planning in multi-axis milling and 3D printing will also be elaborated in detail. Students interested in industrial robots, especially the kinematics, motion and trajectory control, and computer vision of industry robots in the modern manufacturing industry, are encouraged to take this course.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6000R",
+      "sections": [
+        {
+          "course_code": "SMMG6000R",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6184",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "E2-3F CMA Lab HCI Lab",
+              "instructor": "ZHANG, Yunbo"
+            },
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 201, W1",
+              "instructor": "ZHANG, Yunbo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "6000R",
+      "course_title": "AR/VR Techniques and Applications in Smart Manufacturing",
+      "course_desc": "In the era of Smart Manufacturing, manufacturing industries are undergoing transformation towards increased production efficiency, higher autonomy, and enhanced flexibility to achieve product mass customization. Modern manufacturing systems are expected to become highly automated and intelligent in handling complex tasks, empowered by integrating technical elements such as artificial intelligence (AI), the Industrial Internet of Things (IIoT), cloud computing, and industrial robots. However, certain manual operations still exist on the shop floor that are either impractical or impossible to accomplish without human intervention. To bridge humans and machines, Augmented/Virtual Reality (AR/VR) is considered a pivot to provide the immersive experience, the in-situ simulation, and a hub for other relevant techniques, such as AI and data analytics. This course aims to help graduate students understand the latest developments and critical challenges of augmented/virtual reality and their applications in smart manufacturing and provide students with related techniques and practical experience in developing applications based on AR/VR in the context of smart manufacturing. The target audience of the course is students in broad engineering/computing programs. The course will prepare the students for advanced careers related to smart manufacturing and the development of AR/VR applications.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6000X",
+      "sections": [
+        {
+          "course_code": "SMMG6000X",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6186",
+          "quota": 40,
+          "enrol": 6,
+          "avail": 34,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 201, W2",
+              "instructor": "JOHNSON, SHANE MIGUEL"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 201, W2",
+              "instructor": "JOHNSON, SHANE MIGUEL"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "6000X",
+      "course_title": "Advanced Composites: Mechanics and Manufacturing",
+      "course_desc": "The course begins with a thorough examination of various composite material types and property prediction methods, essential for material selection and engineering design. This is followed by a rigorous analysis of laminated composites, covering micromechanics, homogenization techniques for determining effective stiffness properties, and the development of damage and failure theories. Students will apply classical laminated plate theory to design and analyze composite plates under bending, tension, compression, and hygrothermal loading conditions. Furthermore, the course introduces and demonstrates advanced composite manufacturing and fabrication techniques, alongside non-destructive evaluation and repair methodologies, and relevant testing procedures.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6100B",
+      "sections": [],
+      "subject": "SMMG",
+      "catalog_number": "6100B",
+      "course_title": "Independent Study",
+      "course_desc": "Selected topics in smart manufacturing studied under the supervision of a faculty member.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[1-3 credit(s)]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6100C",
+      "sections": [],
+      "subject": "SMMG",
+      "catalog_number": "6100C",
+      "course_title": "Independent Study",
+      "course_desc": "Selected topics in smart manufacturing studied under the supervision of a faculty member.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6800K",
+      "sections": [
+        {
+          "course_code": "SMMG6800K",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6188",
+          "quota": 100,
+          "enrol": 75,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1550",
+              "room": "Rm 101, W1",
+              "instructor": "GUO, Daqiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SMMG",
+      "catalog_number": "6800K",
+      "course_title": "Seminar in Smart Manufacturing",
+      "course_desc": "Seminar topics presented by students, faculty and guest speakers. Students are expected to attend regularly and demonstrate proficiency in presentation in accordance with the program requirements. Graded P or F.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": "[0-1-0:0]",
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG6990",
+      "sections": [],
+      "subject": "SMMG",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SMMG7990",
+      "sections": [],
+      "subject": "SMMG",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "SOCH5000",
+      "sections": [
+        {
+          "course_code": "SOCH5000",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6372",
+          "quota": 100,
+          "enrol": 40,
+          "avail": 60,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1650",
+              "room": "Rm 101, W1",
+              "instructor": "HUANG, Wenjing & JIANG, Kejun & KAN, Ge Lin & KWOK, YUE KUEN & LIU, Anjie & LIU, Jingyu & WU, Xun & YANG, Jiaqi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "SOCH5000",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6374",
+          "quota": 100,
+          "enrol": 40,
+          "avail": 60,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 101, W1",
+              "instructor": "HUANG, Wenjing & JIANG, Kejun & KAN, Ge Lin & KWOK, YUE KUEN & LIU, Anjie & LIU, Jingyu & WU, Xun & YANG, Jiaqi"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "SOCH",
+      "catalog_number": "5000",
+      "course_title": "Technological Innovation and Social Entrepreneurship",
+      "course_desc": "This course discusses both opportunities and risks that technological breakthrough has brought to the human society. What would be the policy responses required to maximize its positive benefit and minimize its social costs? In particular, how could we utilize the technological advancement, entrepreneurial thinking to address the challenges our societies are facing, such as job loss/unemployment, income inequality and societal polarization, environmental degradation, health disparity, population aging, and among others. The course uses either case studies or cross-country and time-series data analyses to facilitate the discussion of various social issues and look for innovative solutions of in the real world.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-1:2]",
+      "matching": "[Matching between Lecture & Lab required]"
+    },
+    {
+      "course_code": "SOCH6780",
+      "sections": [
+        {
+          "course_code": "SOCH6780",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6378",
+          "quota": 40,
+          "enrol": 40,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 233, W1",
+              "instructor": "ZHANG, Pu & ZUO, Ruiting"
+            },
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 233, W1",
+              "instructor": "ZUO, Ruiting"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SOCH",
+      "catalog_number": "6780",
+      "course_title": "Professional Development in Innovation, Technology, and Social Responsibility",
+      "course_desc": "This one credit course is intended to provide basic professional training to research postgraduate students in the Society Hub. The course will begin with lectures and a workshop on ethics in research. Students will be asked to focus on a particular theme of their choice that links technological innovation to various social and policy issues, conduct analysis and present their findings. They will also need to work in a team and learn to effectively communicate their ideas in informal and formal settings. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "SYSH5000",
+      "sections": [
+        {
+          "course_code": "SYSH5000",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6189",
+          "quota": 80,
+          "enrol": 69,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "2030",
+              "end_time": "2120",
+              "room": "Lecture Hall C",
+              "instructor": "LEE, Shi-Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "SYSH5000",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6191",
+          "quota": 80,
+          "enrol": 69,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 102, W1 & Rm 222, W1 & Rm 233, W1 & Rm 201, E1",
+              "instructor": "LEE, Shi-Wei"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "SYSH5000",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6190",
+          "quota": 80,
+          "enrol": 69,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 222, W1 & Rm 233, W1 & Rm 102, W1 & Rm 201, E1",
+              "instructor": "LEE, Shi-Wei"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "SYSH",
+      "catalog_number": "5000",
+      "course_title": "Model-Based Systems Engineering",
+      "course_desc": "Model-based systems engineering (MBSE) is a contemporary systems engineering methodology that uses conceptual models for communication between system architects, designers, developers, and stakeholders. Object-Process Methodology (OPM) is an MBSE language and methodology for constructing domain-independent conceptual models of all kinds of systems. The course provides students with basic knowledge and tools for MBSE, focusing on conceptual modeling of systems, giving learners a competitive advantage over their peers.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[1-1-1:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "SYSH6780",
+      "sections": [
+        {
+          "course_code": "SYSH6780",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6218",
+          "quota": 100,
+          "enrol": 89,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1420",
+              "room": "Rm 101, W1",
+              "instructor": "LI, Xiaomeng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "SYSH",
+      "catalog_number": "6780",
+      "course_title": "Career Development for Systems Hub Research Students",
+      "course_desc": "This course aims at equipping research students with the skills conducive to their professional career development. Students will attend the training focusing on personality self-exploration and program-specific training at the Thrust level, and another training at the Hub level. Graded PP, P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[0-1-0:1]",
+      "matching": ""
+    },
+    {
+      "course_code": "UCMP6010",
+      "sections": [
+        {
+          "course_code": "UCMP6010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6302",
+          "quota": 350,
+          "enrol": 347,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCMP",
+      "catalog_number": "6010",
+      "course_title": "Cross-disciplinary Research Methods I",
+      "course_desc": "This course focuses on using various approaches to perform quantitative analysis through real-world examples. Students will learn how to use different tools in an interdisciplinary project and how to acquire new skills on their own. The course offers different modules that are multidisciplinary/multifunctional and generally applicable to a wide class of problems. May be graded PP.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-0:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "UCMP6030",
+      "sections": [
+        {
+          "course_code": "UCMP6030",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6304",
+          "quota": 30,
+          "enrol": 27,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1530",
+              "end_time": "1720",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Lanhui"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6030",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6305",
+          "quota": 30,
+          "enrol": 26,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1220",
+              "room": "Rm 233, W1",
+              "instructor": "WANG, Xiaoyan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6030",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6789",
+          "quota": 30,
+          "enrol": 28,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1530",
+              "end_time": "1720",
+              "room": "Rm 233, W1",
+              "instructor": "LI, Ning"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6030",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6790",
+          "quota": 30,
+          "enrol": 18,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1220",
+              "room": "Rm 202, E3",
+              "instructor": "WEI, Qianqian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCMP",
+      "catalog_number": "6030",
+      "course_title": "Cross-disciplinary Design Thinking I",
+      "course_desc": "This course focuses on user-collaborative design methods for generating inclusive product solutions that integrate stakeholder and product functionality perspectives. Students will create specified product/process/policy/protocol/plan (5P) concept models through the use of recursive user feedback engagement methods, experimental prototyping, and divergent and convergent ideation strategies. Featured topics include design thinking; stakeholder research; concept development, screening, and selection; and interaction design.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-0:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "UCMP6050A",
+      "sections": [
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6309",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Room 521H VR Room, W1",
+              "instructor": "CHAN, Man"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6310",
+          "quota": 20,
+          "enrol": 14,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, W1",
+              "instructor": "HUANG, Miaojun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6311",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 105, E3",
+              "instructor": "XUE, Ke"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6312",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Maker Space W1-521K",
+              "instructor": "WONG, FELICIA YEN MYAN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6313",
+          "quota": 20,
+          "enrol": 17,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 105, W3",
+              "instructor": "JIANG, Landu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6314",
+          "quota": 20,
+          "enrol": 19,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, E4",
+              "instructor": "CHEN, Li"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6315",
+          "quota": 25,
+          "enrol": 24,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 233, W1",
+              "instructor": "ZHOU, Jin Ni"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6316",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, W4 & Rm 223, W1",
+              "instructor": "LIN, Jing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L09",
+          "bundle": 9,
+          "semester_id": "2530",
+          "section_id": "6317",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, E4",
+              "instructor": "HU, Wenxun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L10",
+          "bundle": 10,
+          "semester_id": "2530",
+          "section_id": "6318",
+          "quota": 20,
+          "enrol": 14,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 101, W4",
+              "instructor": "HE, Qinghao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L11",
+          "bundle": 11,
+          "semester_id": "2530",
+          "section_id": "6319",
+          "quota": 25,
+          "enrol": 23,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 150, E1",
+              "instructor": "WANG, Lujia"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L12",
+          "bundle": 12,
+          "semester_id": "2530",
+          "section_id": "6320",
+          "quota": 25,
+          "enrol": 18,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, E1",
+              "instructor": "LU, Dong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L13",
+          "bundle": 13,
+          "semester_id": "2530",
+          "section_id": "6321",
+          "quota": 25,
+          "enrol": 21,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, E3",
+              "instructor": "WANG, Xiaoyan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L14",
+          "bundle": 14,
+          "semester_id": "2530",
+          "section_id": "6322",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 101, W2",
+              "instructor": "LI, Ning"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L15",
+          "bundle": 15,
+          "semester_id": "2530",
+          "section_id": "6323",
+          "quota": 25,
+          "enrol": 21,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 102, W1",
+              "instructor": "LI, Lanhui"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L16",
+          "bundle": 16,
+          "semester_id": "2530",
+          "section_id": "6324",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, E1",
+              "instructor": "YANG, Jingwei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L17",
+          "bundle": 17,
+          "semester_id": "2530",
+          "section_id": "6325",
+          "quota": 20,
+          "enrol": 15,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, W2",
+              "instructor": "LU, Xiaojie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L18",
+          "bundle": 18,
+          "semester_id": "2530",
+          "section_id": "6326",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, E3",
+              "instructor": "WANG, Yue"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L19",
+          "bundle": 19,
+          "semester_id": "2530",
+          "section_id": "6327",
+          "quota": 25,
+          "enrol": 22,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 201, W2",
+              "instructor": "HUANG, Tongge"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L20",
+          "bundle": 20,
+          "semester_id": "2530",
+          "section_id": "6328",
+          "quota": 20,
+          "enrol": 17,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, W1",
+              "instructor": "WEI, Qianqian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L21",
+          "bundle": 21,
+          "semester_id": "2530",
+          "section_id": "6329",
+          "quota": 25,
+          "enrol": 24,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 222, W1",
+              "instructor": "LI, Mei & LIN, Jing & LUO, ZHENG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L22",
+          "bundle": 22,
+          "semester_id": "2530",
+          "section_id": "6330",
+          "quota": 20,
+          "enrol": 13,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 202, W4",
+              "instructor": "LIN, ARTHUR KAR LEUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCMP6050A",
+          "section_type": "L",
+          "name": "L23",
+          "bundle": 23,
+          "semester_id": "2530",
+          "section_id": "6331",
+          "quota": 20,
+          "enrol": 12,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1950",
+              "room": "Rm 103, E1 & TBA",
+              "instructor": "LUO, ZHENG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCMP",
+      "catalog_number": "6050A",
+      "course_title": "Project-driven Collaborative Design Thinking",
+      "course_desc": "This course aims to familiarize students with the principles of design thinking and promote the adoption of a human-centered approach to problem-solving. Students will gain the ability to identify users' pain points, define problems, and develop creative and innovative solutions. By engaging in interdisciplinary collaboration, students will have the opportunity to apply their problem-solving skills to real-world projects. This course is divided into three modules, with each module being taken during one regular term. May be graded PP.",
+      "credit": 2,
+      "pg_course": true,
+      "vector": "[2-0-0:2]",
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1000",
+      "sections": [
+        {
+          "course_code": "UCUG1000",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6395",
+          "quota": 180,
+          "enrol": 17,
+          "avail": 163,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1000",
+      "course_title": "Cognitive Foundations of University Education: Critical Thinking and Data Literacy",
+      "course_desc": "This course is taught by a teaching team of a group of faculties from four Hubs to introduce the basics of critical thinking and data literacy. The course will be delivered using the problem-solving approach with interdisciplinary applications. The contents include barriers to critical thinking, characteristics of a critical thinker, argument, cognitive bias, logical fallacies, inductive reasoning, and simple probability and statistical models. Students will be equipped with critical thinking and data analyzing skills to analyze problems of reasoning, evaluate the truthfulness of evidence, examine the fallacies of thinking, construct valid arguments, and make better decisions in personal and professional life.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1001",
+      "sections": [
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6397",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Lecture Hall A & Lecture Hall C",
+              "instructor": "LUO, Moxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6713",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 228, E2",
+              "instructor": "HONG, Xuancu & REN, ZHIJUN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6714",
+          "quota": 40,
+          "enrol": 40,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 101, W4",
+              "instructor": "KUO, YI LUNG"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6715",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 122, E1",
+              "instructor": "MENG, Fanqin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6716",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 102, E4",
+              "instructor": "FANG, Bo & LYU, Dongye"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6717",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 102, W4",
+              "instructor": "GUO, Jiao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6718",
+          "quota": 60,
+          "enrol": 55,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 147, E1",
+              "instructor": "ZHANG, Mei & ZHU, Junhua"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1001",
+          "section_type": "L",
+          "name": "L08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6719",
+          "quota": 65,
+          "enrol": 47,
+          "avail": 18,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "TBA & Rm 134, E1",
+              "instructor": "JIANG, BIN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1001",
+      "course_title": "Behavioral Foundations of University Education: Habits, Mindsets, and Wellness",
+      "course_desc": "This course will help students adapt to university life through advising, sharing and discussion, and applying the science of well-being to enhance their personal and interpersonal development. It also aims to foster their self-understanding and confidence as young adults who can fully enjoy their university education and career thereafter. The course has 3 components: Lectures/Seminars, Self-Directed Experience, and Advising/Community Meetings. Lectures and Seminars will orientate students to their respective f personal enrichment. In Advising and Community Meetings, students will bring knowledge and skills together through reflection and discussion with peers and Hub/Thrust advisors. Topics such as learning and time management skills, purpose of university personal enrichment. In Advising and Community Meetings, students will bring knowledge and skills together through reflection and discussion with peers and Hub/Thrust advisors. Topics such as learning and time management skills, purpose of university education, and planning for personal and professional development will be covered. Graded P, F or PP.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1052A",
+      "sections": [
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6521",
+          "quota": 29,
+          "enrol": 29,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 150, E1",
+              "instructor": "HUANG, Yuqing"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 150, E1",
+              "instructor": "HUANG, Yuqing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6522",
+          "quota": 26,
+          "enrol": 26,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 205, C7 Library",
+              "instructor": "HUANG, Yuqing"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 205, C7 Library",
+              "instructor": "HUANG, Yuqing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6523",
+          "quota": 26,
+          "enrol": 25,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Bing & WANG, Linxiao"
+            },
+            {
+              "day": 4,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Bing & WANG, Linxiao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6524",
+          "quota": 25,
+          "enrol": 23,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 223, W1",
+              "instructor": "XING, Qingqing"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 223, W1",
+              "instructor": "XING, Qingqing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6525",
+          "quota": 25,
+          "enrol": 20,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 221, W1",
+              "instructor": "CHEN, Zehan"
+            },
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 221, W1",
+              "instructor": "CHEN, Zehan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052A",
+          "section_type": "T",
+          "name": "T06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6758",
+          "quota": 25,
+          "enrol": 23,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 205, C7 Library",
+              "instructor": "LI, Bing"
+            },
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 205, C7 Library",
+              "instructor": "LI, Bing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1052A",
+      "course_title": "Academic English for University Studies",
+      "course_desc": "",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1052I",
+      "sections": [
+        {
+          "course_code": "UCUG1052I",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6500",
+          "quota": 29,
+          "enrol": 28,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 102, E1",
+              "instructor": "LIAO, Simei"
+            },
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 102, E1",
+              "instructor": "LIAO, Simei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052I",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6501",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 102, E1",
+              "instructor": "LIAO, Simei"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 102, E1",
+              "instructor": "LIAO, Simei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1052I",
+      "course_title": "Academic English for University Studies",
+      "course_desc": "",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1052S",
+      "sections": [
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6478",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Jing"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Jing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6479",
+          "quota": 24,
+          "enrol": 24,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 223, W1",
+              "instructor": "LI, Bing"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 223, W1",
+              "instructor": "LI, Bing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6480",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Jing"
+            },
+            {
+              "day": 4,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Jing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6481",
+          "quota": 25,
+          "enrol": 25,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 221, W1",
+              "instructor": "REN, ZHIJUN"
+            },
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 221, W1",
+              "instructor": "REN, ZHIJUN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6482",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 223, W1",
+              "instructor": "HONG, Xuancu"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 223, W1",
+              "instructor": "HONG, Xuancu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6483",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 221, W1",
+              "instructor": "HONG, Xuancu"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 221, W1",
+              "instructor": "HONG, Xuancu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6484",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 223, W1",
+              "instructor": "ZHANG, Wei"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 223, W1",
+              "instructor": "ZHANG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6485",
+          "quota": 24,
+          "enrol": 24,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Wei"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T09",
+          "bundle": 9,
+          "semester_id": "2530",
+          "section_id": "6492",
+          "quota": 24,
+          "enrol": 24,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 221, W1",
+              "instructor": "LIU, Yalan & ZHANG, Jing"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 221, W1",
+              "instructor": "LIU, Yalan & ZHANG, Jing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1052S",
+          "section_type": "T",
+          "name": "T10",
+          "bundle": 10,
+          "semester_id": "2530",
+          "section_id": "6493",
+          "quota": 23,
+          "enrol": 23,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 221, W1",
+              "instructor": "CAO, Rui"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 221, W1",
+              "instructor": "CAO, Rui"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1052S",
+      "course_title": "Academic English for University Studies",
+      "course_desc": "",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1053",
+      "sections": [
+        {
+          "course_code": "UCUG1053",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6398",
+          "quota": 25,
+          "enrol": 20,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, TIEFU"
+            },
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 221, W1",
+              "instructor": "ZHANG, TIEFU"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1053",
+      "course_title": "Advanced Academic English for University Studies",
+      "course_desc": "This course puts a strong emphasis on developing university-level academic literacy and communication competence in writing, speaking, and multimodal contexts. The course introduces students to research skills using university library resources for finding and evaluating sources for academic writing and speaking tasks. It expects students to be critical readers and writers, synthesizing ideas when developing a coherent argument. The course also aims to develop students’ competence in communicating effectively in an academic community, developing the ability to collaborate both as a member of a group and assuming responsibility as a discussion facilitator in the context of student-led seminars. Throughout the course, students are expected to transfer and adapt their knowledge, attitudes and habits for autonomous lifelong learning.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1077",
+      "sections": [
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6472",
+          "quota": 50,
+          "enrol": 50,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 122, E1",
+              "instructor": "LIU, Dan"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 122, E1",
+              "instructor": "LIU, Dan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6473",
+          "quota": 50,
+          "enrol": 49,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 134, E1",
+              "instructor": "HAO, Tun"
+            },
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 134, E1",
+              "instructor": "HAO, Tun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6474",
+          "quota": 50,
+          "enrol": 50,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 134, E1",
+              "instructor": "LUO, Moxuan"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 134, E1",
+              "instructor": "LUO, Moxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6475",
+          "quota": 50,
+          "enrol": 50,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 134, E1",
+              "instructor": "HAO, Tun"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 134, E1",
+              "instructor": "HAO, Tun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6476",
+          "quota": 50,
+          "enrol": 47,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 134, E1",
+              "instructor": "LIU, Dan"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 134, E1",
+              "instructor": "LIU, Dan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1077",
+          "section_type": "L",
+          "name": "L06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6477",
+          "quota": 50,
+          "enrol": 40,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 134, E1",
+              "instructor": "LIU, Dan"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 134, E1",
+              "instructor": "LIU, Dan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1077",
+      "course_title": "Chinese Communication Essentials: Written and Oral",
+      "course_desc": "Targeting students from the Chinese mainland, Hong Kong, Macao, Taiwan, and international students with native or near-native proficiency, this course is designed to develop comprehensive communication skills in standard Chinese. This course aims to develop students' skills in both oral and written Chinese communication. It will enable students to demonstrate effective, appropriate, and persuasive oral communication skills in Putonghua and produce accurate, standard, and persuasive written communications in simplified Chinese. Students will learn to analyze and critically evaluate Chinese communications for clarity, coherence, and effectiveness. Ultimately, students will be able to apply their Putonghua and simplified Chinese communication skills effectively in multilingual environments within and beyond the Greater Bay Area for academic and professional purposes.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1500",
+      "sections": [
+        {
+          "course_code": "UCUG1500",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6486",
+          "quota": 30,
+          "enrol": 27,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 201, E1",
+              "instructor": "ZUO, Tengjia"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1500",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6487",
+          "quota": 30,
+          "enrol": 27,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "0950",
+              "room": "Rm 202, E3 & E2-3F CMA Lab HCI Lab",
+              "instructor": "ZUO, Tengjia"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1500",
+      "course_title": "Arts and Creativity",
+      "course_desc": "An introductory course blending case studies, practice, and theory to engage students in exploring contemporary visual arts and their own creative potential through a series of lectures, seminars, tutorials, and enrichment activities. Students will acquire fundamental skills to create artworks, develop processes to facilitate creativity, understand the delicate position of aesthetics in art and life, and learn reflective and interpretive methods to critically discuss art. A wide variety of artwork examples from the 1960s onwards will be shown to illustrate the diverse approaches to art and creativity today.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1501",
+      "sections": [
+        {
+          "course_code": "UCUG1501",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6488",
+          "quota": 20,
+          "enrol": 19,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 202, E1",
+              "instructor": "YIP, David Kei Man & ZHANG, Junjie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1501",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6489",
+          "quota": 20,
+          "enrol": 19,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 228, E1",
+              "instructor": "YIP, David Kei Man & ZHANG, Junjie"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1501",
+      "course_title": "Introduction to Photography and Digital Imaging",
+      "course_desc": "An introduction to the creative art and expression of photography and digital imaging and manipulation through lectures, workshop and projects. Students will learn photographic concepts, various in-camera and post-production visual effect techniques to explore creative possibilities with photography and digital imaging. Focus of this course is to facilitate students to express themselves through this powerful visual medium. Upon the completion of this course, students will combine photographic and digital imaging techniques to communicate and express their creative ideas and stories.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1503",
+      "sections": [
+        {
+          "course_code": "UCUG1503",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6490",
+          "quota": 25,
+          "enrol": 19,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1920",
+              "room": "Rm 228, E1",
+              "instructor": "ZHANG, Junjie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1503",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6491",
+          "quota": 25,
+          "enrol": 19,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1930",
+              "end_time": "2050",
+              "room": "Rm 228, E1",
+              "instructor": "ZHANG, Junjie"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1503",
+      "course_title": "Introduction to Experimental Animation",
+      "course_desc": "This introductory course aims at guiding students to explore the art of animation through producing drawing, cut-ups, roto-scoping, photographic and object animation with digital and traditional tools. By introducing techniques and mediums for creating time-based imagery, students will learn both practical skills and theories of animation as a visual art form for artistic expression and communication. Through brief lecturing, students will acquaint themselves with the history and development of experimental animation and its influences to moving image arts in general. The hands-on activities will allow students to explore freely the principles of animation starting from manual techniques such as simple flipbooks and zoetrope. Students will also learn to create animation from common computer software, such as Photoshop and Aftereffect.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1504",
+      "sections": [
+        {
+          "course_code": "UCUG1504",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6495",
+          "quota": 20,
+          "enrol": 19,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 205, C7 Library",
+              "instructor": "XING, Qingqing"
+            },
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 205, C7 Library",
+              "instructor": "XING, Qingqing"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1504",
+      "course_title": "The Art of Public Speaking",
+      "course_desc": "This course introduces students to the theory and practice of public speaking. The basic terms, concepts, and theories of public speaking will be covered. Using selected speeches, students will learn to analyze rhetorical structure and style and to understand how speakers and writers can persuade an audience. Students will write and critique their own writing and that of their peers using stories, analogies, and metaphors. They will learn to construct and defend effective arguments in a speech and to apply the rhetorical techniques they have learned. Throughout the course, students will write and deliver various types of speeches to a partner, a group, the whole class, and then to a public group, soliciting feedback from their audience. By the end of the course, students will have developed their speech making skills and become more confident in presenting their ideas.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1505",
+      "sections": [
+        {
+          "course_code": "UCUG1505",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6496",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 103, E1",
+              "instructor": "PAPATHEODOROU, Theodoros"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1505",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6497",
+          "quota": 20,
+          "enrol": 9,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 103, E1",
+              "instructor": "MINSKY, MARGARET DIANE REZVAN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1505",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6498",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 101, E4",
+              "instructor": "ZHANG, Mei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1505",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6499",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W4",
+              "instructor": "ZHANG, Mei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1505",
+      "course_title": "Creative Coding and Interactive Art",
+      "course_desc": "This course introduces students to programming graphics and interaction for computational media and arts. Students learn the principles, algorithms, and coding frameworks for creating graphics and interaction with machines while also sharpening their sense of aesthetics. Each week, the relevant computational artworks employing these techniques are introduced, analyzed, and explored in practical assignments.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1506",
+      "sections": [
+        {
+          "course_code": "UCUG1506",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6502",
+          "quota": 30,
+          "enrol": 27,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 201, E1",
+              "instructor": "MENG, Fanqin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1506",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6503",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 101, W4",
+              "instructor": "MENG, Fanqin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1506",
+      "course_title": "Enjoyment of Classical Music",
+      "course_desc": "From the power and beauty of the orchestra to masterpieces of the church and concert hall, students will gain an in-depth appreciation for the history and fundamentals of Western classical music. The listening and analytical skills demonstrated will bring about a deeper understanding of music as an art form. Previous musical training, albeit helpful, is not required.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1600",
+      "sections": [
+        {
+          "course_code": "UCUG1600",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6504",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 223, W1",
+              "instructor": "LYU, Dongye & ZHU, Junhua"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1600",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6505",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 202, W4",
+              "instructor": "MENG, Fanqin & REN, ZHIJUN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1600",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6506",
+          "quota": 30,
+          "enrol": 28,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 150, E1",
+              "instructor": "BRENNAN, SHANE & LUO, Moxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1600",
+      "course_title": "Intercultural Communication",
+      "course_desc": "Intercultural communication is an applied interdisciplinary course that covers a wide range of subjects including anthropology, sociology, linguistics, psychology, culture and folklore. Contents include the significance of intercultural communication in today’s world of globalization, the basic gateways to effective intercultural communication, how cultures differ, the complexities of cross culture communication, how culture influences communication, how different media are contributing to intercultural communication, the challenges in communicating in intercultural relationships and how to cope with intercultural interpersonal\nrelationships, different intercultural conflicts and how to cope with and manage cultural conflicts, the problems in intercultural communication brought by ethnocentrism, the correlation of cultural consciousness and identity, different forms and means of nonverbal communication, effective ways to resolve barriers in intercultural communication and cultural conflicts, and intercultural communication skills in multi-cultural environments.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1603",
+      "sections": [
+        {
+          "course_code": "UCUG1603",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6510",
+          "quota": 30,
+          "enrol": 23,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 150, E1",
+              "instructor": "LI, Qiumeng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1603",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6511",
+          "quota": 30,
+          "enrol": 23,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1920",
+              "room": "Rm 221, W1",
+              "instructor": "LI, Qiumeng"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1603",
+      "course_title": "Science-Fiction Storytelling",
+      "course_desc": "Science-Fiction (Sci-fi) Storytelling offers a creative exploration of sci-fi topics such as perception of reality, existentialism in the multiverse, and philosophical and ethical questions on identity, Artificial Intelligence (AI), genetic engineering and so on. This course not only discusses these topics, but also offers students opportunities to exercise the power of creative imagination with critical thinking to build on these themes by developing original sci-fi stories. In this analytical, creative, critical thinking and collaborative process, students will team up to develop and present their story analysis and creation. This course offers visions of the future through studying important visionary film masters and related creative sci-fi works in films, TV and animations, which stimulates thought-provoking discussion and forward thinking. Students will combine sci-fi knowledge, technique and the power of imaginative storytelling, analytical, creative and critical thinking to screen-related research, analysis, and sci-fi story creation through world, character and tension building.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1604",
+      "sections": [
+        {
+          "course_code": "UCUG1604",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6512",
+          "quota": 40,
+          "enrol": 38,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 101, E1",
+              "instructor": "JIANG, Na & REN, ZHIJUN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1604",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6513",
+          "quota": 40,
+          "enrol": 39,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 150, E1",
+              "instructor": "JIANG, Na & LUO, Moxuan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1604",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6514",
+          "quota": 40,
+          "enrol": 38,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 102, E1",
+              "instructor": "JIANG, Na & REN, ZHIJUN"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1604",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6515",
+          "quota": 40,
+          "enrol": 39,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 102, E1",
+              "instructor": "JIANG, Na & LUO, Moxuan"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1604",
+      "course_title": "History of Chinese Civilization: From Antiquity to Late Imperial",
+      "course_desc": "This course provides a comprehensive overview of the key historical events, dynasties, and cultural developments that have shaped Chinese civilization over 3000 years, spanning from the Shang dynasty to the end of imperial China. It explores the unique trajectories and general trends in Chinese social, cultural, and intellectual history, highlighting the profound influence of philosophical and religious movements such as Confucianism, Legalism, and Buddhism. Additionally, the course situates China within a global context, examining its encounters and interactions through trade, cultural exchanges, and diplomatic relations. By analyzing both \"China in the world\" and \"the world in China,\" this course offers a nuanced understanding of China's historical significance and its interconnectedness with global developments.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UCUG1702",
+      "sections": [
+        {
+          "course_code": "UCUG1702",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6517",
+          "quota": 50,
+          "enrol": 21,
+          "avail": 29,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "1920",
+              "room": "Rm 149, E1",
+              "instructor": "TAN, Chee Keong"
+            },
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "1920",
+              "room": "Rm 149, E1",
+              "instructor": "TAN, Chee Keong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1702",
+      "course_title": "Introduction to Materials Science and Applications",
+      "course_desc": "This course is to introduce the field of materials science and engineering and to survey the role that materials have played in shaping our society. This course will introduce different categories of materials and elucidate their applications. Concepts of different kinds of materials and the basic structures at different scales will be studied. Relevant design and principles will be explored to understand the structure-property relationship, with the purpose of providing a foundation for students to understand the common properties of materials and to evaluate the social, economic, and environmental impact of materials.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1800",
+      "sections": [
+        {
+          "course_code": "UCUG1800",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6518",
+          "quota": 40,
+          "enrol": 26,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 202, W4",
+              "instructor": "GUO, Jiao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1800",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6519",
+          "quota": 40,
+          "enrol": 14,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, E4",
+              "instructor": "XIE, Danyang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1800",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6520",
+          "quota": 40,
+          "enrol": 16,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 222, W1",
+              "instructor": "LU, Yangsiyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1800",
+      "course_title": "Technology and Innovation: Social and Business Perspectives",
+      "course_desc": "The development of new technology and innovation plays an increasingly important role in modern economic development. This course aims to equip students with a solid conceptual foundation to understand the dynamic process of technological innovation. Students will be introduced to the importance of technological innovation as a driver for value creation and economic growth. The dynamics of technological change will be analyzed through concepts such as technology life cycles, dominant design, network externalities, and first-mover advantage.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1807",
+      "sections": [
+        {
+          "course_code": "UCUG1807",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6526",
+          "quota": 60,
+          "enrol": 33,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1550",
+              "room": "Rm 101, E1",
+              "instructor": "REN, Qianping"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1807",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6527",
+          "quota": 60,
+          "enrol": 33,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2020",
+              "room": "Rm 148, E1",
+              "instructor": "HONG, Jihao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1807",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6528",
+          "quota": 60,
+          "enrol": 34,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2020",
+              "room": "Rm 148, E1",
+              "instructor": "CHEN, Luoye"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1807",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6529",
+          "quota": 60,
+          "enrol": 33,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 148, E1",
+              "instructor": "REN, Qianping"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1807",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6530",
+          "quota": 60,
+          "enrol": 33,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 228, E2",
+              "instructor": "HONG, Jihao"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1807",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6531",
+          "quota": 60,
+          "enrol": 34,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 228, E2",
+              "instructor": "CHEN, Luoye"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1807",
+      "course_title": "Thinking like an Economist I: Microeconomics",
+      "course_desc": "Students learn the \"economic way of thinking\" in this course. We will explore fundamental microeconomic concepts and tools such as comparative advantage and specialization, demand-supply analysis, market equilibrium, government's role in markets, game theory, and people's interactions in order to explain and analyze consumer and producer decisions and social issues. Students will develop problem-solving abilities in dealing with new social issues as well as develop their sense of community and consideration through the lens of microeconomics.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UCUG1808",
+      "sections": [
+        {
+          "course_code": "UCUG1808",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6543",
+          "quota": 30,
+          "enrol": 25,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 202, W4",
+              "instructor": "LYU, Dongye"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1808",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6544",
+          "quota": 30,
+          "enrol": 25,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 202, W4",
+              "instructor": "LYU, Dongye"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1808",
+      "course_title": "Sport in Society: Cultures, Media and Politics",
+      "course_desc": "An introductory course blending case studies, practice, and theory to engage students in exploring modern sports through a series of lectures, seminars, tutorials, and enrichment activities. The course “Sports and society” is part of the core fundamentals of the Pillar of General Education at The Hong Kong University of Science and Technology (Guangzhou). The main goal with this course is to teach the students the sport from a sociological perspective, to understand the complex, interconnected relationship between sports and society. Gender, race, social class, health, media, politics and economy will be the primary topics from which to understand sport as a social institution.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1809",
+      "sections": [
+        {
+          "course_code": "UCUG1809",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6545",
+          "quota": 30,
+          "enrol": 29,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 223, W1",
+              "instructor": "MA, Jinyuan & XIE, Ailei & ZHU, Junhua"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1809",
+      "course_title": "Understanding Yourself in University: A Sociological Perspective",
+      "course_desc": "This course explores the interplay between education and society with a particular focus on higher education. Students will examine how social forces such as culture, race, class, and gender influence educational processes and outcomes at universities. The course will cover foundational theories and concepts in the sociology of education, the role of family and community, the structure and function of educational institutions, and contemporary issues in higher education. Students will also engage in self-reflection to understand their own experiences in the university setting through a sociological lens.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1900",
+      "sections": [
+        {
+          "course_code": "UCUG1900",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6549",
+          "quota": 50,
+          "enrol": 15,
+          "avail": 35,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, W4",
+              "instructor": "JI, Qixing & ZHOU, Sheng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1900",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6550",
+          "quota": 50,
+          "enrol": 18,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 148, E1",
+              "instructor": "HE, Qiao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1900",
+      "course_title": "Chemistry in Everyday Life",
+      "course_desc": "This common core course takes students on a chemical journey, through which they will learn what is chemistry and how chemistry connects with every part of our daily life. Students will engage in an experiential learning study project and a mini-research task; they will also learn chemical concepts through many real-life case studies. The basic ideas and principles of chemistry, as well as many chemical topics of everyday relevance will be discussed in this course: such as air, water, metals, minerals, air pollution, global warming, ozone depletion, batteries, fire and fuels, food and drinks, household chemical products and plastics. Students taking this course are not required to have studied Chemistry before.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1903",
+      "sections": [
+        {
+          "course_code": "UCUG1903",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6551",
+          "quota": 60,
+          "enrol": 39,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1650",
+              "room": "Rm 134, E1",
+              "instructor": "GAO, Shijian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1903",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6552",
+          "quota": 60,
+          "enrol": 39,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1700",
+              "end_time": "1750",
+              "room": "Rm 134, E1",
+              "instructor": "GAO, Shijian"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1903",
+      "course_title": "Signals and Information Technology",
+      "course_desc": "This common core course introduces the basics of signals and information technology and their applications to daily-life consumer communication devices. Contents include the representation of signals in the time and frequency domains; digitization of information; coding for data compression and error protection; transmission of signals; five generations of cellular networks, multiple access technologies, and packet switching. Students will do a group project to address a state-of-the-art signals and information technology and present their views and findings. It is expected that through studying these technologies and how they address the problems encountered in the information technology area, students will also grasp the skills in solving problems with engineering approach and spirit and appreciate how these technologies impact the society.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1905",
+      "sections": [
+        {
+          "course_code": "UCUG1905",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6546",
+          "quota": 40,
+          "enrol": 7,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 201, W2",
+              "instructor": "YUE, Yang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1905",
+      "course_title": "The Impact and Value of Technology Innovation",
+      "course_desc": "The focus is the impact of the current technological evolution on the creation of value in the global economy, society in general, and personal lives. Students will study how science and technology developments have been transformed into innovative products and services. Case studies and examples will be drawn from well-known successes and failures of technology companies in Silicon Valley and Asia. Business issues such as marketing of disruptive innovations and ethics will be explored. Special emphasis will be given to intellectual property issues. Students will receive extensive exposure to existing and emerging technology innovations and establish the skills to analyze them from multiple perspectives.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG1907",
+      "sections": [
+        {
+          "course_code": "UCUG1907",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6547",
+          "quota": 40,
+          "enrol": 6,
+          "avail": 34,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, W1",
+              "instructor": "ZHANG, Xuning"
+            },
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, W1",
+              "instructor": "ZHANG, Xuning"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "1907",
+      "course_title": "Design Thinking for Health Innovation",
+      "course_desc": "A project-based, experiential course that exposes students to the design thinking process for health innovation to address the real-world unmet needs in the society. The goal of this course is to develop students’ communication, interpersonal, teamwork, analytical, design and project management skills through a multi-disciplinary, team-based design experience. The design thinking process modules: empathize, define, ideate, prototype and test, will be introduced and the students will learn experientially by applying these process modules to solve the health unmet needs they observe in real life. The students are required to report their progress throughout the semester. At the end of the course, they will showcase their prototype in a roadshow and submit their project report and reflection on their design journey. It is a common core course for students from different schools who have no background in design thinking or are looking for practical experience in design thinking.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG2500",
+      "sections": [
+        {
+          "course_code": "UCUG2500",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6539",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 306, C7 Library",
+              "instructor": "FANG, Bo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG2500",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6540",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Rm 102, W1",
+              "instructor": "FANG, Bo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG2500",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6541",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 306, C7 Library",
+              "instructor": "FANG, Bo"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG2500",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6542",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1530",
+              "end_time": "1620",
+              "room": "Rm 102, W1",
+              "instructor": "FANG, Bo"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "2500",
+      "course_title": "Music of China",
+      "course_desc": "This course will look at various forms of Chinese music, focusing in particular on instrumental genres. Although the aim is not to present the history of Chinese music per se, the topical organization of the course will follow a more or less chronological framework as attention is drawn to certain issues and prominent characteristics of music and musical life in China from ancient times to the present. The ability to read music or knowledge of musical notation would be helpful, but not required.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UCUG2603",
+      "sections": [
+        {
+          "course_code": "UCUG2603",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6507",
+          "quota": 45,
+          "enrol": 43,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, E1",
+              "instructor": "REN, Shaoren"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG2603",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6508",
+          "quota": 45,
+          "enrol": 43,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, E4",
+              "instructor": "REN, Shaoren"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "2603",
+      "course_title": "East Asian Popular Music",
+      "course_desc": "This course will look at various popular music genres in East Asia, namely, in China, Japan and Korea, and explore different popular music styles in each culture and issues related to the emergence of each one and their localized meanings. It will seek to understand how meanings are produced, mediated, negotiated, subverted, and celebrated in popular music. Through discussions based on a combination of selected readings, films/videos, and music recordings, students will not only get acquainted with popular music well beyond their own or what they normally listen to; they will also gain alternative perspectives on what constitutes \"popular music\" in different East Asian contexts and their significance.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UCUG3801",
+      "sections": [
+        {
+          "course_code": "UCUG3801",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6516",
+          "quota": 30,
+          "enrol": 30,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, E1",
+              "instructor": "ZHOU, Muzhi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UCUG",
+      "catalog_number": "3801",
+      "course_title": "Social Inequality and Social Mobility",
+      "course_desc": "Social stratification concerns the unequal distribution of resources/rewards/opportunities which are scarce but widely desired, and the process of status attainment or social mobility whereby some persons or groups come to receive more of these scarce things than are received by others. This course will introduce the basic concepts and theories in analyzing social and economic inequalities in the contemporary world.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1103",
+      "sections": [
+        {
+          "course_code": "UFUG1103",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6167",
+          "quota": 52,
+          "enrol": 52,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 149, E1",
+              "instructor": "RAO, Guang"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 149, E1",
+              "instructor": "RAO, Guang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6168",
+          "quota": 50,
+          "enrol": 49,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 149, E1",
+              "instructor": "RAO, Guang"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 149, E1",
+              "instructor": "RAO, Guang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6169",
+          "quota": 50,
+          "enrol": 30,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 147, E1",
+              "instructor": "KWOK, YUE KUEN"
+            },
+            {
+              "day": 3,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 147, E1",
+              "instructor": "KWOK, YUE KUEN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6170",
+          "quota": 50,
+          "enrol": 24,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 149, E1",
+              "instructor": "ZHANG, Leifu"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 149, E1",
+              "instructor": "ZHANG, Leifu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6171",
+          "quota": 52,
+          "enrol": 52,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 149, E1",
+              "instructor": "RAO, Guang"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6172",
+          "quota": 50,
+          "enrol": 49,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 147, E1",
+              "instructor": "RAO, Guang"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6173",
+          "quota": 50,
+          "enrol": 30,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 149, E1",
+              "instructor": "KWOK, YUE KUEN"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1103",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6174",
+          "quota": 50,
+          "enrol": 24,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 149, E1",
+              "instructor": "ZHANG, Leifu"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1103",
+      "course_title": "Calculus II",
+      "course_desc": "This course is the second of a year-long sequence of two introductory courses in one-variable calculus, intended for first year undergraduate students. The emphasis is on the understanding of foundational concepts and practical skills in applying calculus, which are essential for their future study in various fields. Topics include definite and indefinite integrals, numerical calculation, applications to geometry and physics, and infinite series.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UFUG1106",
+      "sections": [
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6193",
+          "quota": 55,
+          "enrol": 54,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 148, E1",
+              "instructor": "HU, Jishan"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 148, E1",
+              "instructor": "HU, Jishan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6194",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6195",
+          "quota": 50,
+          "enrol": 40,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6196",
+          "quota": 50,
+          "enrol": 25,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 149, E1",
+              "instructor": "FANG, Chao"
+            },
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 149, E1",
+              "instructor": "FANG, Chao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6197",
+          "quota": 50,
+          "enrol": 21,
+          "avail": 29,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 134, E1",
+              "instructor": "HU, Guobiao"
+            },
+            {
+              "day": 3,
+              "start_time": "1930",
+              "end_time": "2050",
+              "room": "Rm 134, E1",
+              "instructor": "HU, Guobiao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6198",
+          "quota": 50,
+          "enrol": 43,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 147, E1",
+              "instructor": "FAN, Xiaozhou & HU, Jishan"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 147, E1",
+              "instructor": "FAN, Xiaozhou & HU, Jishan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6199",
+          "quota": 50,
+          "enrol": 23,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 149, E1",
+              "instructor": "DUAN, Lingjie"
+            },
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 149, E1",
+              "instructor": "DUAN, Lingjie"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "L",
+          "name": "L08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6200",
+          "quota": 50,
+          "enrol": 47,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, W4",
+              "instructor": "HU, Jishan"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 102, W4",
+              "instructor": "HU, Jishan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6201",
+          "quota": 55,
+          "enrol": 54,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 148, E1",
+              "instructor": "HU, Jishan"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6202",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6203",
+          "quota": 50,
+          "enrol": 40,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1330",
+              "end_time": "1420",
+              "room": "Rm 102, E4",
+              "instructor": "HUANG, JUN BO"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6204",
+          "quota": 50,
+          "enrol": 25,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 149, E1",
+              "instructor": "FANG, Chao"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6205",
+          "quota": 50,
+          "enrol": 21,
+          "avail": 29,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 149, E1",
+              "instructor": "HU, Guobiao"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6206",
+          "quota": 50,
+          "enrol": 43,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 147, E1",
+              "instructor": "FAN, Xiaozhou"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6207",
+          "quota": 50,
+          "enrol": 23,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 228, E2",
+              "instructor": "DUAN, Lingjie"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1106",
+          "section_type": "T",
+          "name": "T08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6208",
+          "quota": 50,
+          "enrol": 47,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "Rm 148, E1",
+              "instructor": "HU, Jishan"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1106",
+      "course_title": "Honors Calculus II",
+      "course_desc": "This course is the second of a year-long sequence of two courses in one-variable calculus, intended for first year undergraduate students with strong mathematical background. Besides the understanding of foundational concepts and practical skills in applying calculus, the course puts emphasis on rigorous reasoning of practical facts and the proof of certain mathematical theorems. Topics include definite and indefinite integrals, numerical calculation, applications to geometry and physics, and infinite series.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UFUG1301",
+      "sections": [
+        {
+          "course_code": "UFUG1301",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6237",
+          "quota": 40,
+          "enrol": 8,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 102, E1",
+              "instructor": "FANG, Ting & YAN, Chang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1301",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6238",
+          "quota": 80,
+          "enrol": 8,
+          "avail": 72,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 102, W4",
+              "instructor": "FANG, Ting & JI, Qixing & YAN, Chang"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1301",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6243",
+          "quota": 40,
+          "enrol": 8,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Mendeleev Lab (E3-232C) & Dalton Lab (E3-232B)",
+              "instructor": "FANG, Ting"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1301",
+      "course_title": "General Chemistry",
+      "course_desc": "This course serves as a gateway to basic chemical theories and principles, demonstrating a microscopic view to the materialized world that built from atoms. Starting from chemical notation and units, lectures will introduce nuclei structure and elemental periodicity, redox reactions, basic inorganic and organic substances with associated chemical bonding and forms, fundamental properties of gases, acid/base theories, chemical kinetics and equilibrium, principles of thermodynamics, and electrochemistry. Additionally, two mini labs providing hands-on experience supplement the lecture materials.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Lab required]"
+    },
+    {
+      "course_code": "UFUG1302",
+      "sections": [
+        {
+          "course_code": "UFUG1302",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6253",
+          "quota": 40,
+          "enrol": 23,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 102, E1",
+              "instructor": "CAO, Bei & HUANG, Jiaqiang"
+            },
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 102, E1",
+              "instructor": "CAO, Bei & HUANG, Jiaqiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6254",
+          "quota": 40,
+          "enrol": 7,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 102, E1",
+              "instructor": "HE, Qiao & YUE, Liang"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 102, E1",
+              "instructor": "HE, Qiao & YUE, Liang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6259",
+          "quota": 40,
+          "enrol": 23,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 102, E1",
+              "instructor": "CAO, Bei & HUANG, Jiaqiang"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6260",
+          "quota": 40,
+          "enrol": 7,
+          "avail": 33,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 150, E1",
+              "instructor": "HE, Qiao & YUE, Liang"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6255",
+          "quota": 24,
+          "enrol": 10,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Mendeleev Lab (E3-232C) & Dalton Lab (E3-232B)",
+              "instructor": "CAO, Bei & HUANG, Jiaqiang & YUE, Liang"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6256",
+          "quota": 24,
+          "enrol": 4,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Mendeleev Lab (E3-232C) & Dalton Lab (E3-232B)",
+              "instructor": "HE, Qiao & HUANG, Jiaqiang & YUE, Liang"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6257",
+          "quota": 24,
+          "enrol": 9,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Mendeleev Lab (E3-232C) & Dalton Lab (E3-232B)",
+              "instructor": "CAO, Bei & HE, Qiao & HUANG, Jiaqiang & YUE, Liang"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1302",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6258",
+          "quota": 24,
+          "enrol": 7,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Mendeleev Lab (E3-232C) & Dalton Lab (E3-232B)",
+              "instructor": "CAO, Bei & HE, Qiao & HUANG, Jiaqiang & YUE, Liang"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1302",
+      "course_title": "Honors Chemistry I",
+      "course_desc": "This course is designed for students we have acquired solid chemistry knowledge in high school (e.g., HKDSE 1.0X Chemistry, Mainland Gaokao Chemistry, etc.) and intend to pursue a degree related to chemistry (including but not limited to materials, energy, biology, environment, manufacturing, etc.). It is Part I of the Chemistry fundamental course (Honors  Chemistry I/II). The course is modularized into 3 sections to accommodate the teaching and learning needs of students from different departments. With acquisition of this course, the students will have a deeper understanding of atomic/molecular structure and chemical bonding (Module 1), chemical reaction and thermochemistry (Module 2), and the general properties of substances (gases/liquids/solids) (Module 3).",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1303",
+      "sections": [
+        {
+          "course_code": "UFUG1303",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6265",
+          "quota": 40,
+          "enrol": 8,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 202, E3",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            },
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 202, E3",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1303",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6269",
+          "quota": 40,
+          "enrol": 8,
+          "avail": 32,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 150, E1",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1303",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6266",
+          "quota": 18,
+          "enrol": 1,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Mendeleev Lab (E3-232C)",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1303",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6267",
+          "quota": 18,
+          "enrol": 3,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Mendeleev Lab (E3-232C)",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1303",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6268",
+          "quota": 18,
+          "enrol": 4,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Mendeleev Lab (E3-232C)",
+              "instructor": "CAO, Bei & YUAN, Rongfeng"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1303",
+      "course_title": "Honors Chemistry II",
+      "course_desc": "This course is designed for students who have taken Honors Chemistry I and want to continue to expand their chemistry knowledge. It will cover topics related to chemical kinetics and equilibrium, acids and bases, acid-base equilibria, solubility and complex ion equilibria, entropy and free energy, electrochemistry, representative elements and their chemistries, transition metals and coordination chemistry, organic molecules and organic reactions.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1401",
+      "sections": [
+        {
+          "course_code": "UFUG1401",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6289",
+          "quota": 30,
+          "enrol": 16,
+          "avail": 14,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 223, W1",
+              "instructor": "CHEN, Qingquan & GU, Zhenglong & ZHANG, Xian"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 223, W1",
+              "instructor": "CHEN, Qingquan & GU, Zhenglong & ZHANG, Xian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1401",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6290",
+          "quota": 30,
+          "enrol": 6,
+          "avail": 24,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 221, W1",
+              "instructor": "CHEN, Qingquan & GU, Zhenglong & ZHANG, Xian"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 221, W1",
+              "instructor": "CHEN, Qingquan & GU, Zhenglong & ZHANG, Xian"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1401",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6291",
+          "quota": 16,
+          "enrol": 4,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Darwin Lab (E3-232E) & Li Shizhen Lab (E3-232D)",
+              "instructor": "ZHANG, Xian & CHEN, Qingquan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1401",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6292",
+          "quota": 16,
+          "enrol": 5,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Darwin Lab (E3-232E) & Li Shizhen Lab (E3-232D)",
+              "instructor": "ZHANG, Xian & CHEN, Qingquan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1401",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6293",
+          "quota": 16,
+          "enrol": 7,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Darwin Lab (E3-232E) & Li Shizhen Lab (E3-232D)",
+              "instructor": "ZHANG, Xian & CHEN, Qingquan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1401",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6294",
+          "quota": 16,
+          "enrol": 6,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Darwin Lab (E3-232E) & Li Shizhen Lab (E3-232D)",
+              "instructor": "ZHANG, Xian & CHEN, Qingquan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1401",
+      "course_title": "General Biology I",
+      "course_desc": "General Biology I is designed for students interested in understanding life processes and scientific discoveries shaping our knowledge of the natural world. It provides students with an overview of life science: basic characteristics of life, cell biology, essential concepts of genetics, evolution and ecosystems. The course consists of interactive lectures and hands-on lab activities. A special-topic seminar on biological intelligence will also be covered.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1403",
+      "sections": [
+        {
+          "course_code": "UFUG1403",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6387",
+          "quota": 45,
+          "enrol": 19,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 101, W4",
+              "instructor": "XU, JUNYU"
+            },
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 101, W4",
+              "instructor": "XU, JUNYU"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1403",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6388",
+          "quota": 16,
+          "enrol": 10,
+          "avail": 6,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1400",
+              "end_time": "1750",
+              "room": "Li Shizhen Lab (E3-232D)",
+              "instructor": "XU, JUNYU"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1403",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6389",
+          "quota": 16,
+          "enrol": 4,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1400",
+              "end_time": "1750",
+              "room": "Li Shizhen Lab (E3-232D)",
+              "instructor": "XU, JUNYU"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1403",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6390",
+          "quota": 16,
+          "enrol": 5,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1400",
+              "end_time": "1750",
+              "room": "Li Shizhen Lab (E3-232D)",
+              "instructor": "XU, JUNYU"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1403",
+      "course_title": "Introduction to Biotechnology",
+      "course_desc": "Advancement in science has enabled scientists to modify biological systems for specific purposes. Many of these technologies have been used to improve our daily life and this area of study is commonly referred to as biotechnology. This course is designed to introduce some of the major subjects in this field including the history of biotechnology, ethics in genetic modification and use of animals in experimental studies, molecular foundation of biotechnology, animal biotechnology, plant and agricultural biotechnology, and health-care applications. You will learn how different aspects of biotechnology affect our daily life and have impact on the society.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1501",
+      "sections": [
+        {
+          "course_code": "UFUG1501",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6454",
+          "quota": 45,
+          "enrol": 43,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, E4",
+              "instructor": "CHU, Xiakun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6455",
+          "quota": 45,
+          "enrol": 32,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 101, W4",
+              "instructor": "ZHONG, Bingzhuo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6466",
+          "quota": 45,
+          "enrol": 43,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 102, W4",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6467",
+          "quota": 45,
+          "enrol": 32,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6456",
+          "quota": 10,
+          "enrol": 10,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6457",
+          "quota": 10,
+          "enrol": 10,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6458",
+          "quota": 10,
+          "enrol": 9,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6459",
+          "quota": 10,
+          "enrol": 10,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6460",
+          "quota": 10,
+          "enrol": 10,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6461",
+          "quota": 10,
+          "enrol": 5,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6462",
+          "quota": 10,
+          "enrol": 6,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6463",
+          "quota": 10,
+          "enrol": 8,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1501",
+          "section_type": "LA",
+          "name": "LA09",
+          "bundle": 9,
+          "semester_id": "2530",
+          "section_id": "6464",
+          "quota": 10,
+          "enrol": 7,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "Einstein Lab(E3-231B) & Newton Lab(E3-231C)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1501",
+      "course_title": "General Physics I",
+      "course_desc": "General Physics I is designed for students who are interested in science and technology. The course is delivered based on an algebra-based approach, and it incorporates conceptual understandings and mathematical problem-solving skills. Key topics covered by General Physics I are divided into three modules. The first module covers the fundamentals of mechanics, including motion in one and two dimensions, Newton's Laws, and rotational kinematics and dynamics, etc. The second module covers energy and oscillations, including work, energy conservation, momentum conservation, oscillations, fluids, and waves, etc. The third module covers thermodynamics,including the laws of thermodynamics and ideal gases, etc.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1502",
+      "sections": [
+        {
+          "course_code": "UFUG1502",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6556",
+          "quota": 55,
+          "enrol": 14,
+          "avail": 41,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 147, E1",
+              "instructor": "HAN, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1502",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6566",
+          "quota": 55,
+          "enrol": 14,
+          "avail": 41,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 149, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1502",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6557",
+          "quota": 7,
+          "enrol": 7,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Phys Lab-Maxwell Lab (W2-223C) & Phys Lab-Fresnel Lab (W2-223B)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1502",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6558",
+          "quota": 7,
+          "enrol": 3,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Phys Lab-Maxwell Lab (W2-223C) & Phys Lab-Fresnel Lab (W2-223B)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1502",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6559",
+          "quota": 7,
+          "enrol": 4,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Phys Lab-Maxwell Lab (W2-223C) & Phys Lab-Fresnel Lab (W2-223B)",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1502",
+      "course_title": "General Physics II",
+      "course_desc": "General Physics II is designed for students who are interested in science and technology. The course consists of three modules, which are Module 1: Electrostatics and Circuit, including Coulomb’s law, Electric Fields, Gauss’s Law, Electric potential, Capacitance, Current and Resistance, and Circuits; Module 2: Magnetism and Electromagnetics, including Magnetic Fields, Magnetic Field due to Currents, Induction and Inductance, Electromagnetic Oscillations, and Maxwell’s Equations, Electromagnetic Waves; Module 3: Optics and Modern Physics, including Images, Interference, Diffraction, Photons and Matters Waves, and A toms. In addition to the lecture, students are required to take 3 experimental sections.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1503",
+      "sections": [
+        {
+          "course_code": "UFUG1503",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6570",
+          "quota": 55,
+          "enrol": 55,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 148, E1",
+              "instructor": "LIN, Yuanbao"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6571",
+          "quota": 55,
+          "enrol": 30,
+          "avail": 25,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 147, E1",
+              "instructor": "LAI, Zhilu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6572",
+          "quota": 55,
+          "enrol": 55,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 147, E1",
+              "instructor": "ZI, Yunlong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6583",
+          "quota": 55,
+          "enrol": 55,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "Lecture Hall C",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6584",
+          "quota": 55,
+          "enrol": 42,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6585",
+          "quota": 55,
+          "enrol": 43,
+          "avail": 12,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6573",
+          "quota": 20,
+          "enrol": 19,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6574",
+          "quota": 20,
+          "enrol": 17,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "TBA",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6575",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6576",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "TBA",
+              "instructor": "TBA"
+            },
+            {
+              "day": 6,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6577",
+          "quota": 20,
+          "enrol": 20,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6578",
+          "quota": 20,
+          "enrol": 10,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA07",
+          "bundle": 7,
+          "semester_id": "2530",
+          "section_id": "6579",
+          "quota": 20,
+          "enrol": 7,
+          "avail": 13,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA08",
+          "bundle": 8,
+          "semester_id": "2530",
+          "section_id": "6580",
+          "quota": 20,
+          "enrol": 11,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1503",
+          "section_type": "LA",
+          "name": "LA09",
+          "bundle": 9,
+          "semester_id": "2530",
+          "section_id": "6581",
+          "quota": 20,
+          "enrol": 16,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1330",
+              "end_time": "1520",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1503",
+      "course_title": "Honors General Physics I",
+      "course_desc": "This is a calculus-based general physics course covering topics in mechanics and thermodynamics, providing solid foundations for students to pursuit deep understandings and methods. This course will be divided into three modules: Module 1 covers fundaments of mechanics including motion, Newton’s laws, momentum conservation, rotation; Module 2 covers work and energy, energy conservation, oscillations, and waves; Module 3 covers laws of thermodynamics, kinetic theory. Understanding calculus is a preliminary to enroll in this course. This is the in-depth version of course UFUG 1501 General Physics I.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1504",
+      "sections": [
+        {
+          "course_code": "UFUG1504",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6591",
+          "quota": 55,
+          "enrol": 27,
+          "avail": 28,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1320",
+              "room": "Rm 149, E1",
+              "instructor": "ZHU, Guoyi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6592",
+          "quota": 55,
+          "enrol": 14,
+          "avail": 41,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1750",
+              "room": "Rm 147, E1",
+              "instructor": "LI, Haoxiang"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6593",
+          "quota": 55,
+          "enrol": 29,
+          "avail": 26,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 102, E4",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6594",
+          "quota": 55,
+          "enrol": 12,
+          "avail": 43,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6595",
+          "quota": 14,
+          "enrol": 13,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6596",
+          "quota": 14,
+          "enrol": 5,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6597",
+          "quota": 14,
+          "enrol": 9,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        },
+        {
+          "course_code": "UFUG1504",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6598",
+          "quota": 14,
+          "enrol": 14,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1230",
+              "end_time": "1420",
+              "room": "TBA",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 2
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1504",
+      "course_title": "Honors General Physics II",
+      "course_desc": "The UFUG 1504 is a more challenging version of UFUG 1502. It intends to provide a solid foundation to students who wish to take more advanced physics related study and research in the future. The course consists of three modules, which are Module 1: Electrostatics and Circuit, including Coulomb’s law, Electric Fields, Gauss’s Law, Electric potential, Capacitance, Current and Resistance, and Circuits; Module 2: Magnetism and Electromagnetics, including Magnetic Fields, Magnetic Filed due to Currents, Induction and Inductance, Electromagnetic Oscillations, and Maxwell’s Equations, Electromagnetic Waves; Module 3: Optics and Modern Physics, including Images, Interference, Diffraction, Photons and Matters Waves, and Atoms. In addition to the lecture, students are required to take 3 experimental sections.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1601",
+      "sections": [
+        {
+          "course_code": "UFUG1601",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6608",
+          "quota": 65,
+          "enrol": 62,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 122, E1",
+              "instructor": "LI, Wenye & ZHANG, Hongce"
+            },
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 122, E1",
+              "instructor": "LI, Wenye & ZHANG, Hongce"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6609",
+          "quota": 65,
+          "enrol": 65,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 122, E1",
+              "instructor": "ZENG, Wei"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 122, E1",
+              "instructor": "ZENG, Wei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6610",
+          "quota": 65,
+          "enrol": 29,
+          "avail": 36,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Lecture Hall C",
+              "instructor": "WANG, Zeyu"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Lecture Hall C",
+              "instructor": "WANG, Zeyu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6611",
+          "quota": 33,
+          "enrol": 32,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6612",
+          "quota": 33,
+          "enrol": 32,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6613",
+          "quota": 33,
+          "enrol": 30,
+          "avail": 3,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6614",
+          "quota": 33,
+          "enrol": 13,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6615",
+          "quota": 33,
+          "enrol": 32,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG1601",
+          "section_type": "LA",
+          "name": "LA06",
+          "bundle": 6,
+          "semester_id": "2530",
+          "section_id": "6616",
+          "quota": 33,
+          "enrol": 17,
+          "avail": 16,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1900",
+              "end_time": "1950",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1601",
+      "course_title": "Introduction to Computer Science",
+      "course_desc": "This course introduces students to the world of computer science, data analysis, and artificial intelligence. Through a series of lectures and hands-on exercises, students will learn the basics of each of these disciplines, and how they can be used to solve real-world problems. It will cover the following topics: an introduction to computer science, including an overview of its principles and concepts; the basics of data analysis, including methods for collecting, organizing, and analyzing data; an introduction to artificial intelligence, including an exploration of its various applications and capabilities; and an examination of how computer science, data analysis, and artificial intelligence can be used in combination to solve real-world problems. Upon completion of this course, students will have a strong foundation on which to build more advanced knowledge in these exciting fields.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG1811",
+      "sections": [
+        {
+          "course_code": "UFUG1811",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6623",
+          "quota": 30,
+          "enrol": 10,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 227, E1",
+              "instructor": "LI, Chaosu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG1811",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6624",
+          "quota": 30,
+          "enrol": 10,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 227, E1",
+              "instructor": "LI, Chaosu"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "1811",
+      "course_title": "Quantitative Data Analysis for Social Research",
+      "course_desc": "The goal of this course is to introduce students to data analysis methods and procedures commonly used in social sciences. During the course, students will acquire practical skills to be able to gather, generate, visualize and analyze quantitative data in social science research.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG2103",
+      "sections": [
+        {
+          "course_code": "UFUG2103",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6627",
+          "quota": 60,
+          "enrol": 22,
+          "avail": 38,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 148, E1",
+              "instructor": "JIA, Shuai"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 148, E1",
+              "instructor": "JIA, Shuai"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6629",
+          "quota": 60,
+          "enrol": 26,
+          "avail": 34,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 228, E2",
+              "instructor": "DU, Juan"
+            },
+            {
+              "day": 3,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 134, E1",
+              "instructor": "DU, Juan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6631",
+          "quota": 60,
+          "enrol": 13,
+          "avail": 47,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 228, E2",
+              "instructor": "SUN, Xiaotong"
+            },
+            {
+              "day": 3,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 228, E2",
+              "instructor": "SUN, Xiaotong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "L",
+          "name": "L05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6635",
+          "quota": 60,
+          "enrol": 19,
+          "avail": 41,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 122, E1",
+              "instructor": "DING, Ningning"
+            },
+            {
+              "day": 4,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 122, E1",
+              "instructor": "DING, Ningning"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6628",
+          "quota": 60,
+          "enrol": 22,
+          "avail": 38,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 147, E1",
+              "instructor": "JIA, Shuai"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6630",
+          "quota": 60,
+          "enrol": 26,
+          "avail": 34,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1730",
+              "end_time": "1820",
+              "room": "Rm 149, E1",
+              "instructor": "DU, Juan"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6632",
+          "quota": 60,
+          "enrol": 13,
+          "avail": 47,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "2000",
+              "end_time": "2050",
+              "room": "Rm 148, E1",
+              "instructor": "SUN, Xiaotong"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2103",
+          "section_type": "T",
+          "name": "T05",
+          "bundle": 5,
+          "semester_id": "2530",
+          "section_id": "6636",
+          "quota": 60,
+          "enrol": 19,
+          "avail": 41,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 122, E1",
+              "instructor": "DING, Ningning"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "2103",
+      "course_title": "Linear Algebra",
+      "course_desc": "Linear algebra is central to almost all areas of mathematics and is also used in most sciences and fields of engineering. This course provides a comprehensive introduction to topics of linear algebra studies, including linear systems, vector spaces, matrices, linear mappings and matrix forms, inner products, orthogonality and Gram-Schmidt process, eigenvalues and eigenvectors, symmetric matrices and diagonalization, and determinants.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UFUG2104",
+      "sections": [
+        {
+          "course_code": "UFUG2104",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6659",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 147, E1",
+              "instructor": "ZHANG, Xuning"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 147, E1",
+              "instructor": "ZHANG, Xuning"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6660",
+          "quota": 50,
+          "enrol": 50,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 148, E1",
+              "instructor": "YU, Jiadong"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 148, E1",
+              "instructor": "YU, Jiadong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6661",
+          "quota": 50,
+          "enrol": 39,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 149, E1",
+              "instructor": "XING, Hong"
+            },
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 149, E1",
+              "instructor": "XING, Hong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6662",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 149, E1",
+              "instructor": "HAN, Bingyan"
+            },
+            {
+              "day": 4,
+              "start_time": "0900",
+              "end_time": "1020",
+              "room": "Rm 149, E1",
+              "instructor": "HAN, Bingyan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6663",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "0950",
+              "room": "Rm 149, E1",
+              "instructor": "ZHANG, Xuning"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6664",
+          "quota": 50,
+          "enrol": 50,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "0900",
+              "end_time": "0950",
+              "room": "Rm 148, E1",
+              "instructor": "YU, Jiadong"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "T",
+          "name": "T03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6665",
+          "quota": 50,
+          "enrol": 39,
+          "avail": 11,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1800",
+              "end_time": "1850",
+              "room": "Rm 148, E1",
+              "instructor": "XING, Hong"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2104",
+          "section_type": "T",
+          "name": "T04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6666",
+          "quota": 50,
+          "enrol": 48,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 4,
+              "start_time": "1500",
+              "end_time": "1550",
+              "room": "Rm 148, E1",
+              "instructor": "HAN, Bingyan"
+            }
+          ],
+          "is_main": false,
+          "layer": 0
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "2104",
+      "course_title": "Applied Statistics",
+      "course_desc": "This course covers the basic concepts of Statistics and Probability Theory, gives a systematic introduction to Statistical Inference, Test Statistic, Regression, and Bayesian Statistics, and deepens the understanding of these theories and techniques through practical applications.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": "[Matching between Lecture & Tutorial required]"
+    },
+    {
+      "course_code": "UFUG2106",
+      "sections": [
+        {
+          "course_code": "UFUG2106",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6650",
+          "quota": 50,
+          "enrol": 30,
+          "avail": 20,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 149, E1",
+              "instructor": "LIN, Shiju"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2106",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6651",
+          "quota": 50,
+          "enrol": 32,
+          "avail": 18,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1450",
+              "room": "Rm 149, E1",
+              "instructor": "DING, Zishuo"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2106",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6652",
+          "quota": 50,
+          "enrol": 33,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 149, E1",
+              "instructor": "LIN, Shiju"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2106",
+          "section_type": "T",
+          "name": "T02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6653",
+          "quota": 50,
+          "enrol": 29,
+          "avail": 21,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1830",
+              "end_time": "1920",
+              "room": "Rm 147, E1",
+              "instructor": "DING, Zishuo"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "2106",
+      "course_title": "Discrete Mathematics",
+      "course_desc": "This course examines applied and theoretical mathematical implications of the mathematical concepts. These include elementary logic and set theory, functions, direct proof techniques, contradiction and contraposition, mathematical induction and recursion, elementary combinatorics, basic graph theory, minimal spanning trees, and so on. It also expands and explores symbolic, numerical, and graphical representations of mathematical concepts. Emphasis will be put on solving problems symbolically, numerically, and graphically and understanding the connections among these methods in interpreting and analyzing results. Instructor's approval is required for enrollment.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG2601",
+      "sections": [
+        {
+          "course_code": "UFUG2601",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6672",
+          "quota": 60,
+          "enrol": 50,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 101, E1",
+              "instructor": "LUO, Qiong"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 101, E1",
+              "instructor": "LUO, Qiong"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6673",
+          "quota": 60,
+          "enrol": 20,
+          "avail": 40,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Rm 148, E1",
+              "instructor": "LI, Wenye & MA, Yuzhe"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 148, E1",
+              "instructor": "LI, Wenye & MA, Yuzhe"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6674",
+          "quota": 60,
+          "enrol": 43,
+          "avail": 17,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 147, E1",
+              "instructor": "HUANG, Jiayi"
+            },
+            {
+              "day": 4,
+              "start_time": "1200",
+              "end_time": "1320",
+              "room": "Rm 147, E1",
+              "instructor": "HUANG, Jiayi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6675",
+          "quota": 45,
+          "enrol": 18,
+          "avail": 27,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Rm 228, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6676",
+          "quota": 45,
+          "enrol": 38,
+          "avail": 7,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6677",
+          "quota": 45,
+          "enrol": 35,
+          "avail": 10,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1820",
+              "room": "Rm 227, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2601",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6678",
+          "quota": 45,
+          "enrol": 22,
+          "avail": 23,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1200",
+              "end_time": "1350",
+              "room": "Rm 228, E1",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "2601",
+      "course_title": "C++ Programming",
+      "course_desc": "This course covers programming and data structures using C++. In addition to basic programming concepts such as variables, arrays, pointers, and functions, students will learn about the standard data structures in C++, such as vectors, sets, maps, and queues. This course will also introduce the basics of object-oriented programming and some useful algorithms in the standard C++ libraries. Weekly laboratory experiments will provide hands-on experiences in programming.",
+      "credit": 4,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UFUG2602",
+      "sections": [
+        {
+          "course_code": "UFUG2602",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6683",
+          "quota": 60,
+          "enrol": 60,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 149, E1",
+              "instructor": "LI, Jia"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 149, E1",
+              "instructor": "LI, Jia"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "L",
+          "name": "L02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6684",
+          "quota": 60,
+          "enrol": 58,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 228, E2",
+              "instructor": "ZHENG, Xinhu"
+            },
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1450",
+              "room": "Rm 101, W1",
+              "instructor": "ZHENG, Xinhu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "L",
+          "name": "L03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6685",
+          "quota": 60,
+          "enrol": 60,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 122, E1",
+              "instructor": "CHANG, Tengfei"
+            },
+            {
+              "day": 4,
+              "start_time": "1630",
+              "end_time": "1750",
+              "room": "Rm 122, E1",
+              "instructor": "CHANG, Tengfei"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "L",
+          "name": "L04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6766",
+          "quota": 60,
+          "enrol": 58,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1500",
+              "end_time": "1620",
+              "room": "Lecture Hall C",
+              "instructor": "GONG, Zijun"
+            },
+            {
+              "day": 5,
+              "start_time": "1030",
+              "end_time": "1150",
+              "room": "Rm 101, W1",
+              "instructor": "GONG, Zijun"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6686",
+          "quota": 60,
+          "enrol": 60,
+          "avail": 0,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1500",
+              "end_time": "1550",
+              "room": "Rm 102, W4",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "LA",
+          "name": "LA02",
+          "bundle": 2,
+          "semester_id": "2530",
+          "section_id": "6687",
+          "quota": 60,
+          "enrol": 59,
+          "avail": 1,
+          "wait": -1,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1000",
+              "end_time": "1050",
+              "room": "Lecture Hall C",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "LA",
+          "name": "LA03",
+          "bundle": 3,
+          "semester_id": "2530",
+          "section_id": "6688",
+          "quota": 60,
+          "enrol": 58,
+          "avail": 2,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1930",
+              "end_time": "2020",
+              "room": "Rm 102, W4",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        },
+        {
+          "course_code": "UFUG2602",
+          "section_type": "LA",
+          "name": "LA04",
+          "bundle": 4,
+          "semester_id": "2530",
+          "section_id": "6767",
+          "quota": 60,
+          "enrol": 59,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 5,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 102, W4",
+              "instructor": "TBA"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UFUG",
+      "catalog_number": "2602",
+      "course_title": "Data Structure and Algorithm Design",
+      "course_desc": "This course introduces common data structures and algorithms. Data structures include arrays and matrices, linked lists, stacks, priority queues, hash tables, trees, and graphs. Algorithms include sorting, hashing, searching, greedy methods, divide-and-conquer, dynamic programming, and branch-and-bound. Students will learn Python implementations of these data structures and algorithms, and solve programming problems with learned techniques.",
+      "credit": 3,
+      "pg_course": false,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5010",
+      "sections": [
+        {
+          "course_code": "UGOD5010",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6220",
+          "quota": 30,
+          "enrol": 15,
+          "avail": 15,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "0900",
+              "end_time": "1150",
+              "room": "Rm 223, W1",
+              "instructor": "CAO, Rui & KAN, Ge Lin & LIU, Xiaofeng & YUEN, Cheuk Yi Kelvin"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5010",
+      "course_title": "Science of Cities",
+      "course_desc": "The course aims to provide a comprehensive understanding of the city and the system of cities, the challenges faced by cities, especially the rapidly-developing large cities, and the key tools for interventions in response to critical pressures linked to economic development, urbanization, globalization, migration, social inclusion, climate change, resource efficiency, technology etc.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5030",
+      "sections": [
+        {
+          "course_code": "UGOD5030",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6376",
+          "quota": 15,
+          "enrol": 11,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 227, E1",
+              "instructor": "CAO, Rui & ZHAO, Wufan"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UGOD5030",
+          "section_type": "LA",
+          "name": "LA01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6377",
+          "quota": 15,
+          "enrol": 11,
+          "avail": 4,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1630",
+              "end_time": "1720",
+              "room": "Rm 227, E1",
+              "instructor": "CAO, Rui & ZHAO, Wufan"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5030",
+      "course_title": "GIS and Spatial Analysis",
+      "course_desc": "This course introduces students to the basic concepts and methods in Geographic Information System (GIS), and their applications in urban design and governance, environmental and infrastructure sustainability, and smart city management. This course integrates social science and informatics perspectives, and is suitable for students with various backgrounds. In addition to learning traditional GIS data, spatial analytical techniques, and GIS software, this course also develops skills of manipulating spatially detailed urban sensing Big Data (about urban activities, environmental qualities, and mobility patterns).",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-1:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5050",
+      "sections": [
+        {
+          "course_code": "UGOD5050",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6221",
+          "quota": 15,
+          "enrol": 6,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 103, E1",
+              "instructor": "ZHANG, Zhuoni"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5050",
+      "course_title": "Cities and Society",
+      "course_desc": "The course looks at some of the major drivers of urban inequality and poverty, and the key actions that cities are taking to reduce urban inequalities through urban design, infrastructure and policy. Students are introduced with tools to analyze the socio-demographic profile of households and neighborhoods/communities and their relation to spatial distribution and clustering in cities of both the developing and the developed world. A particular emphasis is placed on identifying spatial strategies that can alleviate the concentration of urban poverty and inequality to enhance urban social cohesion by optimizing access to jobs, housing, education, health, public space, transport and community infrastructure.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5090",
+      "sections": [
+        {
+          "course_code": "UGOD5090",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6223",
+          "quota": 15,
+          "enrol": 7,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 201, E3",
+              "instructor": "LI, Chaosu"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5090",
+      "course_title": "Urban Sustainability",
+      "course_desc": "This course provides a road map for examining the sustainability of cities through perspectives and approaches in urban governance and design. Drawing from an interdisciplinary literature, we will explore the following major themes in the context of urban sustainability: theories and assessment tools of urban sustainability, land use and transportation, urban design, energy and climate change, food and health, governance, and social ecology.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5105",
+      "sections": [
+        {
+          "course_code": "UGOD5105",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6224",
+          "quota": 15,
+          "enrol": 7,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "0900",
+              "end_time": "1050",
+              "room": "Rm 101, W2",
+              "instructor": "JIANG, BIN"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UGOD5105",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6379",
+          "quota": 15,
+          "enrol": 7,
+          "avail": 8,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 2,
+              "start_time": "1100",
+              "end_time": "1150",
+              "room": "Rm 101, W2",
+              "instructor": "JIANG, BIN"
+            }
+          ],
+          "is_main": false,
+          "layer": 1
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5105",
+      "course_title": "Urban Complexity Analysis and Modeling",
+      "course_desc": "Going beyond conventional GIS and geospatial analysis, this course delves into the realm of complexity-science methods, including fractal geometry, power law statistics, space syntax, complex networks, scaling hierarchy, and cellular automata. By embracing pivotal concepts like \"natural streets\" and \"natural cities,\" alongside the tools such as Axwoman and head/tail breaks, students will explore city structure and dynamics from a complexity-science perspective. These concepts, methods and tools will be applied to open-access geospatial big data such as OpenStreetMap, nighttime imagery, and location-based social media data for revealing insights into cities for better transforming modern cities towards a sustainable planet.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[2-1-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD5200",
+      "sections": [
+        {
+          "course_code": "UGOD5200",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6225",
+          "quota": 15,
+          "enrol": 6,
+          "avail": 9,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1330",
+              "end_time": "1620",
+              "room": "Rm 202, W1",
+              "instructor": "XIONG, Wanru"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "5200",
+      "course_title": "Applied Demography",
+      "course_desc": "This course provides an introduction to applied demography, the practical applications of demographic analysis. Students will learn about the basic principles of demographic analysis, including measures of population size, composition, and distribution, as well as methods for analyzing demographic changes and trends over time. Through hands-on instruction, students will also learn the applications of these techniques to real-world situations, such as policy-making, urban planning, and marketing.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD6000B",
+      "sections": [],
+      "subject": "UGOD",
+      "catalog_number": "6000B",
+      "course_title": "Independent Study",
+      "course_desc": "Independent study in a designated subject under direct guidance of a faculty member to provide students the advanced knowledge and research skill sets on urban governance and design related topics. Required readings, tutorial discussions, and submission of report(s) will be used for assessment. The course may be repeated for credit if different topics are studied.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD6100H",
+      "sections": [
+        {
+          "course_code": "UGOD6100H",
+          "section_type": "L",
+          "name": "L01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6381",
+          "quota": 15,
+          "enrol": 10,
+          "avail": 5,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 1,
+              "start_time": "1800",
+              "end_time": "2050",
+              "room": "Rm 103, E1",
+              "instructor": "DAI, Rushi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "6100H",
+      "course_title": "Generative AI in 3D Space",
+      "course_desc": "Generative AI in 3D Space explores how cutting-edge generative AI technologies can create and refine 3D spatial designs while respecting real-world constraints. Students will dive into AI-driven 3D modeling, generative algorithms, and multi-objective optimization techniquesâbalancing human-centered needs with practical factors like construction feasibility, energy efficiency, material limitations, and cost. Through hands-on projects, learners will build intelligent design systems that merge creativity with real-world implement ability. This course is ideal for those interested in applying AI to architecture, urban planning, game design, virtual reality, or smart infrastructureâwhere intelligent, adaptive, and sustainable 3D environments are the future. Through lectures, case studies, and hands-on projects, students will build and evaluate generative design pipelines that close the loop between AI-generated spatial proposals and real-world deployment contexts.",
+      "credit": 3,
+      "pg_course": true,
+      "vector": "[3-0-0:3]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD6102",
+      "sections": [
+        {
+          "course_code": "UGOD6102",
+          "section_type": "T",
+          "name": "T01",
+          "bundle": 1,
+          "semester_id": "2530",
+          "section_id": "6380",
+          "quota": 34,
+          "enrol": 33,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [
+            {
+              "day": 3,
+              "start_time": "1030",
+              "end_time": "1120",
+              "room": "Rm 233, W1",
+              "instructor": "ZHOU, Muzhi"
+            }
+          ],
+          "is_main": true,
+          "layer": 0
+        }
+      ],
+      "subject": "UGOD",
+      "catalog_number": "6102",
+      "course_title": "UGOD Program Seminar II",
+      "course_desc": "Selected topics in hands-on data analyses, such as statistical software (R, STATA, or SAS), data management, and visualization, will be introduced to students in urban governance and design for their research. The course is offered once a year. Graded P or F.",
+      "credit": 1,
+      "pg_course": true,
+      "vector": "[1 credit]",
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD6990",
+      "sections": [],
+      "subject": "UGOD",
+      "catalog_number": "6990",
+      "course_title": "MPhil Thesis Research",
+      "course_desc": "Master's thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    },
+    {
+      "course_code": "UGOD7990",
+      "sections": [],
+      "subject": "UGOD",
+      "catalog_number": "7990",
+      "course_title": "Doctoral Thesis Research",
+      "course_desc": "Original and independent doctoral thesis research supervised by co-advisors from different disciplines. A successful defense of the thesis leads to the grade Pass. No course credit is assigned.",
+      "credit": 0,
+      "pg_course": true,
+      "vector": null,
+      "matching": ""
+    }
+  ]
+}

--- a/app/scripts/import_scheduler_offerings.py
+++ b/app/scripts/import_scheduler_offerings.py
@@ -45,6 +45,9 @@ BUNDLED_SCHEDULER_OFFERINGS_DIR = (
 BUNDLED_25_26_FALL_OFFERINGS_FILE = BUNDLED_SCHEDULER_OFFERINGS_DIR / "25-26fall.json"
 BUNDLED_25_26_FALL_SEMESTER_ID = "2510"
 BUNDLED_25_26_FALL_SHA256 = "507853bd299c25dc9e34e6f67ebd926ea86feda095d5571493eb776d36d3bb9e"
+BUNDLED_25_26_SPRING_OFFERINGS_FILE = BUNDLED_SCHEDULER_OFFERINGS_DIR / "25-26spring.json"
+BUNDLED_25_26_SPRING_SEMESTER_ID = "2530"
+BUNDLED_25_26_SPRING_SHA256 = "e904ef4d50a2044850b002d4758620ca55b386037328aa49d5dc05a32fdd43bb"
 BUNDLED_25_26_SUMMER_OFFERINGS_FILE = (
     BUNDLED_SCHEDULER_OFFERINGS_DIR / "25-26summer.json"
 )
@@ -54,8 +57,8 @@ BUNDLED_25_26_SUMMER_SHA256 = "608eefa7520497ace53a1e6f5275ca81e99b1c7d5523ee977
 # Two-deploy switch:
 #   1. Keep "dry-run", push to main, and inspect dev logs.
 #   2. After confirming the dry-run summary, change to "apply" and push once.
-#   3. Change back to "disabled" after the dev database import succeeds.
-DEPLOY_SCHEDULER_OFFERING_UPDATE_MODE = "dry-run"
+#   3. Keep "apply"; import hashes make repeated deploys skip already-applied files.
+DEPLOY_SCHEDULER_OFFERING_UPDATE_MODE = "apply"
 
 SEASON_META = {
     "10": ("Fall", "秋"),
@@ -688,6 +691,13 @@ def bundled_scheduler_offering_updates(
             file_path=BUNDLED_25_26_FALL_OFFERINGS_FILE,
             expected_semester_id=BUNDLED_25_26_FALL_SEMESTER_ID,
             expected_sha256=BUNDLED_25_26_FALL_SHA256,
+        ),
+        BundledOfferingUpdate(
+            label="25-26 spring",
+            mode=mode,
+            file_path=BUNDLED_25_26_SPRING_OFFERINGS_FILE,
+            expected_semester_id=BUNDLED_25_26_SPRING_SEMESTER_ID,
+            expected_sha256=BUNDLED_25_26_SPRING_SHA256,
         ),
         BundledOfferingUpdate(
             label="25-26 summer",

--- a/app/services/scheduler_map_seed.py
+++ b/app/services/scheduler_map_seed.py
@@ -1,0 +1,106 @@
+import hashlib
+import json
+from pathlib import Path
+
+from sqlalchemy.exc import IntegrityError
+
+from app.extensions import db
+from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
+
+
+BUNDLED_SCHEDULER_MAP_SEED_FILE = Path(__file__).resolve().parents[1] / "data" / "scheduler_map_seed.json"
+BUNDLED_SCHEDULER_MAP_SEED_SHA256 = "6337f71e38bab1154ee2d808f90a40d0337efe6fccd14d6d2244ec0d7d2dde7a"
+
+
+def file_sha256(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_scheduler_map_seed(file_path: Path = BUNDLED_SCHEDULER_MAP_SEED_FILE) -> dict:
+    with file_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("scheduler map seed must be a JSON object")
+    components = data.get("components")
+    lines = data.get("lines")
+    if not isinstance(components, list) or not isinstance(lines, list):
+        raise ValueError("scheduler map seed requires components and lines lists")
+
+    component_ids = set()
+    for component in components:
+        component_id = component.get("id")
+        if not component_id:
+            raise ValueError("scheduler map component is missing id")
+        if component_id in component_ids:
+            raise ValueError(f"duplicate scheduler map component id: {component_id}")
+        component_ids.add(component_id)
+
+    for line in lines:
+        start_id = line.get("start_id")
+        end_id = line.get("end_id")
+        if start_id not in component_ids or end_id not in component_ids:
+            raise ValueError(f"scheduler map line references missing component: {start_id}->{end_id}")
+
+    return data
+
+
+def seed_scheduler_map_if_empty(seed: dict) -> dict:
+    existing_components = SchedulerMapComponent.query.count()
+    existing_lines = SchedulerMapLine.query.count()
+    if existing_components or existing_lines:
+        return {
+            "status": "skipped",
+            "components": existing_components,
+            "lines": existing_lines,
+        }
+
+    try:
+        for component in seed["components"]:
+            db.session.add(SchedulerMapComponent(
+                id=component["id"],
+                node_type=component.get("node_type"),
+                x_coordinate=int(component["x_coordinate"]),
+                y_coordinate=int(component["y_coordinate"]),
+                category=int(component["category"]),
+            ))
+        db.session.flush()
+
+        for line in seed["lines"]:
+            db.session.add(SchedulerMapLine(
+                start_id=line["start_id"],
+                end_id=line["end_id"],
+                line_type=line.get("line_type"),
+                x_coordinate=int(line["x_coordinate"]),
+                category=int(line["category"]),
+            ))
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return {
+            "status": "skipped",
+            "components": SchedulerMapComponent.query.count(),
+            "lines": SchedulerMapLine.query.count(),
+        }
+    except Exception:
+        db.session.rollback()
+        raise
+
+    return {
+        "status": "seeded",
+        "components": len(seed["components"]),
+        "lines": len(seed["lines"]),
+    }
+
+
+def seed_bundled_scheduler_map_if_empty() -> dict:
+    actual_hash = file_sha256(BUNDLED_SCHEDULER_MAP_SEED_FILE)
+    if actual_hash != BUNDLED_SCHEDULER_MAP_SEED_SHA256:
+        raise ValueError(
+            "Bundled scheduler map seed hash mismatch: "
+            f"{actual_hash} != {BUNDLED_SCHEDULER_MAP_SEED_SHA256}"
+        )
+    return seed_scheduler_map_if_empty(load_scheduler_map_seed())

--- a/tests/test_import_scheduler_offerings.py
+++ b/tests/test_import_scheduler_offerings.py
@@ -15,6 +15,7 @@ from app.models.scheduler_section import SchedulerSection
 from app.models.user import User
 from app.models.user_role import UserRole
 from app.scripts.import_scheduler_offerings import (
+    DEPLOY_SCHEDULER_OFFERING_UPDATE_MODE,
     OfferingValidationError,
     apply_offerings,
     build_import_plan,
@@ -138,7 +139,8 @@ def test_load_offerings_file_rejects_invalid_lecture_day(tmp_path):
 def test_bundled_scheduler_offering_updates_match_files():
     updates = bundled_scheduler_offering_updates()
 
-    assert [update.expected_semester_id for update in updates] == ["2510", "2540"]
+    assert DEPLOY_SCHEDULER_OFFERING_UPDATE_MODE == "apply"
+    assert [update.expected_semester_id for update in updates] == ["2510", "2530", "2540"]
     for update in updates:
         snapshot = load_offerings_file(update.file_path, update.expected_semester_id)
         assert snapshot.semester_id == update.expected_semester_id

--- a/tests/test_scheduler_map_seed.py
+++ b/tests/test_scheduler_map_seed.py
@@ -1,0 +1,94 @@
+import os
+
+import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
+from app.services.scheduler_map_seed import seed_scheduler_map_if_empty
+
+
+@compiles(JSONB, "sqlite")
+def compile_jsonb_sqlite(_type, _compiler, **_kw):
+    return "JSON"
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    CACHE_TYPE = "SimpleCache"
+    ENABLE_BACKGROUND_TASKS = False
+    JWT_SECRET_KEY = "test-secret"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "test-key"))
+    monkeypatch.setenv("DASHSCOPE_API_KEY", os.getenv("DASHSCOPE_API_KEY", "test-key"))
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def sample_seed():
+    return {
+        "components": [
+            {
+                "id": "AIAA2205",
+                "node_type": None,
+                "x_coordinate": 20,
+                "y_coordinate": 20,
+                "category": 0,
+            },
+            {
+                "id": "(UFUG2601|UFUG2602)",
+                "node_type": True,
+                "x_coordinate": 20,
+                "y_coordinate": 20,
+                "category": 1,
+            },
+        ],
+        "lines": [
+            {
+                "start_id": "(UFUG2601|UFUG2602)",
+                "end_id": "AIAA2205",
+                "line_type": None,
+                "x_coordinate": 10,
+                "category": 1,
+            }
+        ],
+    }
+
+
+def test_seed_scheduler_map_populates_empty_tables(app):
+    with app.app_context():
+        result = seed_scheduler_map_if_empty(sample_seed())
+
+        assert result["status"] == "seeded"
+        assert SchedulerMapComponent.query.count() == 2
+        assert SchedulerMapLine.query.count() == 1
+
+
+def test_seed_scheduler_map_does_not_overwrite_existing_tables(app):
+    with app.app_context():
+        db.session.add(SchedulerMapComponent(
+            id="KEEP",
+            node_type=None,
+            x_coordinate=1,
+            y_coordinate=1,
+            category=0,
+        ))
+        db.session.commit()
+
+        result = seed_scheduler_map_if_empty(sample_seed())
+
+        assert result["status"] == "skipped"
+        assert SchedulerMapComponent.query.count() == 1
+        assert SchedulerMapComponent.query.filter_by(id="KEEP").one().x_coordinate == 1
+        assert SchedulerMapLine.query.count() == 0


### PR DESCRIPTION
## Summary
- apply bundled scheduler offering imports on deploy using the existing import hash guard
- add the 25-26 spring offering snapshot to bundled deploy imports
- seed the course universe scheduler map from a bundled read-only snapshot only when map tables are empty

## Data safety
- does not migrate or overwrite posts, comments, reactions, post_tags, users, feedback records, or feedback collaboration test content
- preserves existing production course rows by upserting scheduler fields through the existing importer
- scheduler map seed skips if production already has map data

## Verification
- `pytest tests/test_import_scheduler_offerings.py tests/test_scheduler_map_seed.py tests/test_scheduler_routes.py tests/test_course_filters.py tests/test_course_overview_routes.py -q`
- `python -m py_compile app/services/scheduler_map_seed.py app/scripts/import_scheduler_offerings.py app/__init__.py`
- `git diff --check`