### PR TITLE
[codex] fix production migration deploy step

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -67,10 +67,9 @@ jobs:
           # Use sudo to run pg_dump as postgres user
           sudo -u postgres pg_dump prod_unikorn > /data/prod_unikorn/db_backup_$(date +%Y%m%d_%H%M%S).sql || echo "Backup skipped - database may not exist yet"
           
-          echo "performing database migrations..."
-          flask db migrate
+          echo "applying database migrations..."
           flask db upgrade
-          echo "database migrations completed."
+          echo "database migrations applied."
           
           echo "initializing database with predefined data..."
           python -m app.scripts.init_db


### PR DESCRIPTION
## Summary
- stop running `flask db migrate` during production deploy
- keep `flask db upgrade` as the production migration step

## Why
The production deploy failed with `Target database is not up to date` because `flask db migrate` was run before upgrading the DB. Production deploys should apply committed migrations, not autogenerate new ones on the server.

## Verification
- `git diff --check`