### PR TITLE
[codex] upgrade all production migration heads

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -68,7 +68,7 @@ jobs:
           sudo -u postgres pg_dump prod_unikorn > /data/prod_unikorn/db_backup_$(date +%Y%m%d_%H%M%S).sql || echo "Backup skipped - database may not exist yet"
           
           echo "applying database migrations..."
-          flask db upgrade
+          flask db upgrade heads
           echo "database migrations applied."
           
           echo "initializing database with predefined data..."


### PR DESCRIPTION
## Summary
- use `flask db upgrade heads` in production deploy because the migration directory currently has multiple Alembic heads

## Why
The previous deploy passed the migrate/autogenerate step but failed with `Multiple head revisions are present`. Upgrading to `heads` applies all committed migration branches.

## Verification
- `git diff --check`