### PR TITLE
[codex] make production migrations idempotent

### DIFF
--- a/migrations/versions/20260529_academic_map.py
+++ b/migrations/versions/20260529_academic_map.py
@@ -19,84 +19,104 @@ def _json_type():
     return postgresql.JSONB(astext_type=sa.Text())
 
 
+def _table_exists(table_name):
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _index_exists(table_name, index_name):
+    return any(
+        index["name"] == index_name
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    )
+
+
 def upgrade():
-    op.create_table(
-        "curriculum_programs",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("code", sa.String(length=32), nullable=False),
-        sa.Column("name_en", sa.String(length=255), nullable=False),
-        sa.Column("name_zh", sa.String(length=255), nullable=True),
-        sa.Column("cohort", sa.String(length=20), nullable=False),
-        sa.Column("total_min_credits", sa.Integer(), nullable=False, server_default="120"),
-        sa.Column("common_core_min_credits", sa.Integer(), nullable=False, server_default="30"),
-        sa.Column("major_min_credits", sa.Integer(), nullable=True),
-        sa.Column("home_areas", _json_type(), nullable=False, server_default="[]"),
-        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("code", "cohort", name="uq_curriculum_program_code_cohort"),
-    )
-    op.create_index("idx_curriculum_programs_code_cohort", "curriculum_programs", ["code", "cohort"])
+    if not _table_exists("curriculum_programs"):
+        op.create_table(
+            "curriculum_programs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("code", sa.String(length=32), nullable=False),
+            sa.Column("name_en", sa.String(length=255), nullable=False),
+            sa.Column("name_zh", sa.String(length=255), nullable=True),
+            sa.Column("cohort", sa.String(length=20), nullable=False),
+            sa.Column("total_min_credits", sa.Integer(), nullable=False, server_default="120"),
+            sa.Column("common_core_min_credits", sa.Integer(), nullable=False, server_default="30"),
+            sa.Column("major_min_credits", sa.Integer(), nullable=True),
+            sa.Column("home_areas", _json_type(), nullable=False, server_default="[]"),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("code", "cohort", name="uq_curriculum_program_code_cohort"),
+        )
+    if not _index_exists("curriculum_programs", "idx_curriculum_programs_code_cohort"):
+        op.create_index("idx_curriculum_programs_code_cohort", "curriculum_programs", ["code", "cohort"])
 
-    op.create_table(
-        "curriculum_requirement_groups",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("program_id", sa.Integer(), nullable=False),
-        sa.Column("key", sa.String(length=80), nullable=False),
-        sa.Column("name_en", sa.String(length=255), nullable=False),
-        sa.Column("name_zh", sa.String(length=255), nullable=True),
-        sa.Column("category", sa.String(length=40), nullable=False),
-        sa.Column("min_credits", sa.Integer(), nullable=True),
-        sa.Column("min_courses", sa.Integer(), nullable=True),
-        sa.Column("rule", _json_type(), nullable=False, server_default="{}"),
-        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
-        sa.ForeignKeyConstraint(["program_id"], ["curriculum_programs.id"]),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("program_id", "key", name="uq_curriculum_requirement_group_key"),
-    )
+    if not _table_exists("curriculum_requirement_groups"):
+        op.create_table(
+            "curriculum_requirement_groups",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("program_id", sa.Integer(), nullable=False),
+            sa.Column("key", sa.String(length=80), nullable=False),
+            sa.Column("name_en", sa.String(length=255), nullable=False),
+            sa.Column("name_zh", sa.String(length=255), nullable=True),
+            sa.Column("category", sa.String(length=40), nullable=False),
+            sa.Column("min_credits", sa.Integer(), nullable=True),
+            sa.Column("min_courses", sa.Integer(), nullable=True),
+            sa.Column("rule", _json_type(), nullable=False, server_default="{}"),
+            sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+            sa.ForeignKeyConstraint(["program_id"], ["curriculum_programs.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("program_id", "key", name="uq_curriculum_requirement_group_key"),
+        )
 
-    op.create_table(
-        "user_academic_profiles",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("cohort", sa.String(length=20), nullable=True),
-        sa.Column("target_majors", _json_type(), nullable=False, server_default="[]"),
-        sa.Column("grade_policy", sa.String(length=30), nullable=False, server_default="keep_private"),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("user_id"),
-    )
-    op.create_index("idx_user_academic_profiles_user_id", "user_academic_profiles", ["user_id"])
+    if not _table_exists("user_academic_profiles"):
+        op.create_table(
+            "user_academic_profiles",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("cohort", sa.String(length=20), nullable=True),
+            sa.Column("target_majors", _json_type(), nullable=False, server_default="[]"),
+            sa.Column("grade_policy", sa.String(length=30), nullable=False, server_default="keep_private"),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id"),
+        )
+    if not _index_exists("user_academic_profiles", "idx_user_academic_profiles_user_id"):
+        op.create_index("idx_user_academic_profiles_user_id", "user_academic_profiles", ["user_id"])
 
-    op.create_table(
-        "user_course_records",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("course_id", sa.Integer(), nullable=True),
-        sa.Column("course_code", sa.String(length=32), nullable=False),
-        sa.Column("course_title", sa.String(length=255), nullable=True),
-        sa.Column("term_label", sa.String(length=80), nullable=True),
-        sa.Column("term_code", sa.String(length=20), nullable=True),
-        sa.Column("units", sa.Numeric(precision=5, scale=2), nullable=True),
-        sa.Column("status", sa.String(length=30), nullable=False, server_default="completed"),
-        sa.Column("grade", sa.String(length=12), nullable=True),
-        sa.Column("keep_grade", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("import_source", sa.String(length=30), nullable=False, server_default="manual"),
-        sa.Column("needs_review", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("review_reason", sa.String(length=255), nullable=True),
-        sa.Column("raw_payload", _json_type(), nullable=False, server_default="{}"),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
-        sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
-        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("idx_user_course_records_user_id", "user_course_records", ["user_id"])
-    op.create_index("idx_user_course_records_code", "user_course_records", ["course_code"])
-    op.create_index("idx_user_course_records_status", "user_course_records", ["status"])
+    if not _table_exists("user_course_records"):
+        op.create_table(
+            "user_course_records",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("course_id", sa.Integer(), nullable=True),
+            sa.Column("course_code", sa.String(length=32), nullable=False),
+            sa.Column("course_title", sa.String(length=255), nullable=True),
+            sa.Column("term_label", sa.String(length=80), nullable=True),
+            sa.Column("term_code", sa.String(length=20), nullable=True),
+            sa.Column("units", sa.Numeric(precision=5, scale=2), nullable=True),
+            sa.Column("status", sa.String(length=30), nullable=False, server_default="completed"),
+            sa.Column("grade", sa.String(length=12), nullable=True),
+            sa.Column("keep_grade", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("import_source", sa.String(length=30), nullable=False, server_default="manual"),
+            sa.Column("needs_review", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("review_reason", sa.String(length=255), nullable=True),
+            sa.Column("raw_payload", _json_type(), nullable=False, server_default="{}"),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["course_id"], ["courses.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    if not _index_exists("user_course_records", "idx_user_course_records_user_id"):
+        op.create_index("idx_user_course_records_user_id", "user_course_records", ["user_id"])
+    if not _index_exists("user_course_records", "idx_user_course_records_code"):
+        op.create_index("idx_user_course_records_code", "user_course_records", ["course_code"])
+    if not _index_exists("user_course_records", "idx_user_course_records_status"):
+        op.create_index("idx_user_course_records_status", "user_course_records", ["status"])
 
 
 def downgrade():

--- a/migrations/versions/20260531_add_scheduler_fields.py
+++ b/migrations/versions/20260531_add_scheduler_fields.py
@@ -15,15 +15,24 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("courses", sa.Column("subject", sa.String(length=4), nullable=True))
-    op.add_column("courses", sa.Column("catalog_number", sa.String(length=16), nullable=True))
-    op.add_column("courses", sa.Column("course_title_abbr", sa.String(length=48), nullable=True))
-    op.add_column("courses", sa.Column("pre_requirement", sa.Text(), nullable=True))
-    op.add_column("courses", sa.Column("co_requirement", sa.Text(), nullable=True))
-    op.add_column("courses", sa.Column("exclusion", sa.Text(), nullable=True))
-    op.add_column("courses", sa.Column("pg_course", sa.Boolean(), nullable=True, server_default=sa.text("false")))
-    op.add_column("courses", sa.Column("klms_course", sa.Boolean(), nullable=True, server_default=sa.text("false")))
-    op.add_column("courses", sa.Column("vector", sa.String(length=16), nullable=True))
+    existing = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns("courses")
+    }
+    columns = [
+        sa.Column("subject", sa.String(length=4), nullable=True),
+        sa.Column("catalog_number", sa.String(length=16), nullable=True),
+        sa.Column("course_title_abbr", sa.String(length=48), nullable=True),
+        sa.Column("pre_requirement", sa.Text(), nullable=True),
+        sa.Column("co_requirement", sa.Text(), nullable=True),
+        sa.Column("exclusion", sa.Text(), nullable=True),
+        sa.Column("pg_course", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column("klms_course", sa.Boolean(), nullable=True, server_default=sa.text("false")),
+        sa.Column("vector", sa.String(length=16), nullable=True),
+    ]
+    for column in columns:
+        if column.name not in existing:
+            op.add_column("courses", column)
 
 
 def downgrade():

--- a/migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py
+++ b/migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py
@@ -15,92 +15,106 @@ depends_on = None
 
 
 def upgrade():
+    inspector = sa.inspect(op.get_bind())
+
     # scheduler_sections
-    op.create_table(
-        "scheduler_sections",
-        sa.Column("semester_id", sa.String(length=16), nullable=False),
-        sa.Column("section_id", sa.String(length=16), nullable=False),
-        sa.Column("course_id", sa.Integer(), sa.ForeignKey("courses.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("name", sa.String(length=256), nullable=False),
-        sa.Column("bundle", sa.Integer(), nullable=False),
-        sa.Column("layer", sa.Integer(), server_default=sa.text("0"), nullable=False),
-        sa.Column("quota", sa.Integer(), nullable=False),
-        sa.Column("section_type", sa.String(length=16), nullable=False),
-        sa.Column("is_main", sa.Boolean(), server_default=sa.text("false"), nullable=False),
-        sa.PrimaryKeyConstraint("semester_id", "section_id"),
-    )
-    op.create_index("idx_scheduler_sections_course", "scheduler_sections", ["course_id", "semester_id"])
+    if not inspector.has_table("scheduler_sections"):
+        op.create_table(
+            "scheduler_sections",
+            sa.Column("semester_id", sa.String(length=16), nullable=False),
+            sa.Column("section_id", sa.String(length=16), nullable=False),
+            sa.Column("course_id", sa.Integer(), sa.ForeignKey("courses.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("name", sa.String(length=256), nullable=False),
+            sa.Column("bundle", sa.Integer(), nullable=False),
+            sa.Column("layer", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("quota", sa.Integer(), nullable=False),
+            sa.Column("section_type", sa.String(length=16), nullable=False),
+            sa.Column("is_main", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+            sa.PrimaryKeyConstraint("semester_id", "section_id"),
+        )
+    indexes = {index["name"] for index in inspector.get_indexes("scheduler_sections")}
+    if "idx_scheduler_sections_course" not in indexes:
+        op.create_index("idx_scheduler_sections_course", "scheduler_sections", ["course_id", "semester_id"])
 
     # scheduler_lectures
-    op.create_table(
-        "scheduler_lectures",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("semester_id", sa.String(length=32), nullable=False),
-        sa.Column("section_id", sa.String(length=16), nullable=False),
-        sa.Column("day", sa.Integer(), nullable=False),
-        sa.Column("start_time", sa.Integer(), nullable=False),
-        sa.Column("end_time", sa.Integer(), nullable=False),
-        sa.Column("room", sa.String(length=255), nullable=False),
-        sa.Column("instructor", sa.String(length=255), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-        sa.ForeignKeyConstraint(
-            ["semester_id", "section_id"],
-            ["scheduler_sections.semester_id", "scheduler_sections.section_id"],
-            ondelete="CASCADE",
-        ),
-    )
-    op.create_index("idx_scheduler_lectures_section", "scheduler_lectures", ["semester_id", "section_id"])
+    if not inspector.has_table("scheduler_lectures"):
+        op.create_table(
+            "scheduler_lectures",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("semester_id", sa.String(length=32), nullable=False),
+            sa.Column("section_id", sa.String(length=16), nullable=False),
+            sa.Column("day", sa.Integer(), nullable=False),
+            sa.Column("start_time", sa.Integer(), nullable=False),
+            sa.Column("end_time", sa.Integer(), nullable=False),
+            sa.Column("room", sa.String(length=255), nullable=False),
+            sa.Column("instructor", sa.String(length=255), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["semester_id", "section_id"],
+                ["scheduler_sections.semester_id", "scheduler_sections.section_id"],
+                ondelete="CASCADE",
+            ),
+        )
+    indexes = {index["name"] for index in inspector.get_indexes("scheduler_lectures")}
+    if "idx_scheduler_lectures_section" not in indexes:
+        op.create_index("idx_scheduler_lectures_section", "scheduler_lectures", ["semester_id", "section_id"])
 
     # scheduler_map_components
-    op.create_table(
-        "scheduler_map_components",
-        sa.Column("id", sa.String(length=255), nullable=False),
-        sa.Column("node_type", sa.Boolean(), nullable=True),
-        sa.Column("x_coordinate", sa.Integer(), nullable=False),
-        sa.Column("y_coordinate", sa.Integer(), nullable=False),
-        sa.Column("category", sa.Integer(), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-    )
+    if not inspector.has_table("scheduler_map_components"):
+        op.create_table(
+            "scheduler_map_components",
+            sa.Column("id", sa.String(length=255), nullable=False),
+            sa.Column("node_type", sa.Boolean(), nullable=True),
+            sa.Column("x_coordinate", sa.Integer(), nullable=False),
+            sa.Column("y_coordinate", sa.Integer(), nullable=False),
+            sa.Column("category", sa.Integer(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
 
     # scheduler_map_lines
-    op.create_table(
-        "scheduler_map_lines",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("start_id", sa.String(length=255), sa.ForeignKey("scheduler_map_components.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("end_id", sa.String(length=255), sa.ForeignKey("scheduler_map_components.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("line_type", sa.Boolean(), nullable=True),
-        sa.Column("x_coordinate", sa.Integer(), nullable=False),
-        sa.Column("category", sa.Integer(), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-    )
+    if not inspector.has_table("scheduler_map_lines"):
+        op.create_table(
+            "scheduler_map_lines",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("start_id", sa.String(length=255), sa.ForeignKey("scheduler_map_components.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("end_id", sa.String(length=255), sa.ForeignKey("scheduler_map_components.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("line_type", sa.Boolean(), nullable=True),
+            sa.Column("x_coordinate", sa.Integer(), nullable=False),
+            sa.Column("category", sa.Integer(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
 
     # scheduler_user_course_carts
-    op.create_table(
-        "scheduler_user_course_carts",
-        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("semester_id", sa.String(length=32), nullable=False),
-        sa.Column("course_code", sa.String(length=16), nullable=False),
-        sa.Column("enabled", sa.Boolean(), server_default=sa.text("false"), nullable=False),
-        sa.PrimaryKeyConstraint("user_id", "semester_id", "course_code"),
-    )
-    op.create_index("idx_scheduler_cart_user_semester", "scheduler_user_course_carts", ["user_id", "semester_id"])
+    if not inspector.has_table("scheduler_user_course_carts"):
+        op.create_table(
+            "scheduler_user_course_carts",
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("semester_id", sa.String(length=32), nullable=False),
+            sa.Column("course_code", sa.String(length=16), nullable=False),
+            sa.Column("enabled", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+            sa.PrimaryKeyConstraint("user_id", "semester_id", "course_code"),
+        )
+    indexes = {index["name"] for index in inspector.get_indexes("scheduler_user_course_carts")}
+    if "idx_scheduler_cart_user_semester" not in indexes:
+        op.create_index("idx_scheduler_cart_user_semester", "scheduler_user_course_carts", ["user_id", "semester_id"])
 
     # scheduler_user_bundle_carts
-    op.create_table(
-        "scheduler_user_bundle_carts",
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("semester_id", sa.String(length=32), nullable=False),
-        sa.Column("course_code", sa.String(length=16), nullable=False),
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("layer", sa.Integer(), server_default=sa.text("0"), nullable=False),
-        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
-        sa.PrimaryKeyConstraint("user_id", "semester_id", "course_code", "id", "layer"),
-        sa.ForeignKeyConstraint(
-            ["user_id", "semester_id", "course_code"],
-            ["scheduler_user_course_carts.user_id", "scheduler_user_course_carts.semester_id", "scheduler_user_course_carts.course_code"],
-            ondelete="CASCADE",
-        ),
-    )
+    if not inspector.has_table("scheduler_user_bundle_carts"):
+        op.create_table(
+            "scheduler_user_bundle_carts",
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("semester_id", sa.String(length=32), nullable=False),
+            sa.Column("course_code", sa.String(length=16), nullable=False),
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("layer", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+            sa.PrimaryKeyConstraint("user_id", "semester_id", "course_code", "id", "layer"),
+            sa.ForeignKeyConstraint(
+                ["user_id", "semester_id", "course_code"],
+                ["scheduler_user_course_carts.user_id", "scheduler_user_course_carts.semester_id", "scheduler_user_course_carts.course_code"],
+                ondelete="CASCADE",
+            ),
+        )
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- make the academic-map and scheduler schema migrations idempotent for production
- skip creating tables, columns, and indexes that already exist when `flask db upgrade heads` runs
- preserve existing production data by only guarding schema creation operations

## Root cause
Production already had these tables from app startup schema initialization, but Alembic was not stamped at the corresponding revisions. The deploy workflow now correctly runs migrations, so Alembic tried to create tables that were already present and failed with `DuplicateTable`.

## Validation
- `python -m py_compile migrations/versions/20260529_academic_map.py migrations/versions/20260531_add_scheduler_fields.py migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py`
- `pytest tests/test_scheduler_schema_support.py tests/test_academic_map_models.py tests/test_scheduler_models.py -q`
- `git diff --check`
