### PR TITLE
[codex] shorten scheduler migration revision

### DIFF
--- a/migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py
+++ b/migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py
@@ -1,6 +1,6 @@
 """add scheduler section, lecture, map, and cart tables
 
-Revision ID: 20260531_add_scheduler_section_lecture_map_cart
+Revision ID: 20260531_scheduler_map_cart
 Revises: 20260531_add_scheduler_fields
 Create Date: 2026-05-31
 """
@@ -8,7 +8,7 @@ Create Date: 2026-05-31
 from alembic import op
 import sqlalchemy as sa
 
-revision = "20260531_add_scheduler_section_lecture_map_cart"
+revision = "20260531_scheduler_map_cart"
 down_revision = "20260531_add_scheduler_fields"
 branch_labels = None
 depends_on = None

--- a/tests/test_migration_revision_ids.py
+++ b/tests/test_migration_revision_ids.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def _load_revision(path):
+    namespace = {}
+    exec(path.read_text(encoding="utf-8"), namespace)
+    return namespace["revision"]
+
+
+def test_alembic_revision_ids_fit_default_version_column():
+    version_dir = Path(__file__).resolve().parents[1] / "migrations" / "versions"
+
+    revisions = {
+        path.name: _load_revision(path)
+        for path in version_dir.glob("*.py")
+    }
+
+    assert revisions
+    assert {
+        name: revision
+        for name, revision in revisions.items()
+        if len(revision) > 32
+    } == {}


### PR DESCRIPTION
## Summary
- shorten the scheduler schema migration revision id so it fits Alembic's default `version_num varchar(32)` column
- keep the down-revision as `20260531_add_scheduler_fields`, matching the version production reached before the failed deploy
- add a regression test that fails if future migration revision ids exceed 32 characters

## Root cause
The production deploy reached `20260531_add_scheduler_fields`, then failed while updating `alembic_version` to `20260531_add_scheduler_section_lecture_map_cart` because that revision id is longer than 32 characters.

## Validation
- `python -m py_compile migrations/versions/20260531_add_scheduler_section_lecture_map_cart.py tests/test_migration_revision_ids.py`
- `pytest tests/test_migration_revision_ids.py tests/test_scheduler_schema_support.py tests/test_scheduler_models.py -q`
- `git diff --check`
