### PR TITLE
Backfill 2024-25 scheduler offerings

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -74,6 +74,10 @@ jobs:
           echo "initializing database with predefined data..."
           python -m app.scripts.init_db
           echo "database initialization completed."
+
+          echo "backfilling 2024-25 legacy scheduler offerings..."
+          python -m app.scripts.backfill_legacy_scheduler_offerings --semesters 2430 2440 --apply
+          echo "2024-25 legacy scheduler offerings backfilled."
           
           # Graceful restart
           echo "Restarting production service..."

--- a/app/scripts/backfill_legacy_scheduler_offerings.py
+++ b/app/scripts/backfill_legacy_scheduler_offerings.py
@@ -1,0 +1,44 @@
+import argparse
+import json
+from dataclasses import asdict
+
+from app import create_app
+from app.extensions import db
+from app.services.course_domain_migration import migrate_offerings
+
+
+DEFAULT_SEMESTERS = ("2430", "2440")
+
+
+def run_backfill(*, semesters: list[str], apply: bool):
+    summary = migrate_offerings(apply=apply, semester_ids=semesters)
+    if apply:
+        db.session.commit()
+    else:
+        db.session.rollback()
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill selected legacy scheduler sections into course-domain offerings."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Inspect and report without committing changes.")
+    mode.add_argument("--apply", action="store_true", help="Apply the backfill.")
+    parser.add_argument(
+        "--semesters",
+        nargs="+",
+        default=list(DEFAULT_SEMESTERS),
+        help="Semester ids to backfill from legacy scheduler sections.",
+    )
+    args = parser.parse_args()
+
+    app = create_app()
+    with app.app_context():
+        summary = run_backfill(semesters=args.semesters, apply=args.apply)
+        print(json.dumps(asdict(summary), ensure_ascii=False, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/course_domain_migration.py
+++ b/app/services/course_domain_migration.py
@@ -4,7 +4,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from app.extensions import db
 from app.models.academic_map import UserCourseRecord
@@ -345,9 +345,14 @@ def _current_version_for_course(course_id: int) -> CourseCatalogVersion | None:
     )
 
 
-def migrate_offerings(*, apply: bool) -> MigrationSummary:
+def migrate_offerings(*, apply: bool, semester_ids: Iterable[str] | None = None) -> MigrationSummary:
     summary = MigrationSummary()
-    sections = SchedulerSection.query.all()
+    section_query = SchedulerSection.query
+    if semester_ids is not None:
+        normalized_semester_ids = [str(semester_id) for semester_id in semester_ids]
+        section_query = section_query.filter(SchedulerSection.semester_id.in_(normalized_semester_ids))
+
+    sections = section_query.all()
     groups: dict[tuple[int, str], list[SchedulerSection]] = {}
     for section in sections:
         groups.setdefault((section.course_id, section.semester_id), []).append(section)

--- a/tests/test_course_domain_migration.py
+++ b/tests/test_course_domain_migration.py
@@ -293,6 +293,63 @@ def test_offering_user_cart_and_review_migrations(app, tmp_path):
         assert anomaly_data["items"][0]["record_id"] == unresolved.id
 
 
+def test_migrate_offerings_can_limit_to_legacy_semesters(app):
+    from app.services.course_domain_migration import migrate_offerings
+
+    with app.app_context():
+        target_course = Course(code="CDOM2430", name="Target Legacy Course", credits=3)
+        ignored_course = Course(code="CDOM2530", name="Ignored Legacy Course", credits=3)
+        db.session.add_all([target_course, ignored_course])
+        db.session.flush()
+        db.session.add_all([
+            SchedulerSection(
+                semester_id="2430",
+                section_id="CDOM2430-L01",
+                course_id=target_course.id,
+                name="L01",
+                bundle=1,
+                layer=0,
+                quota=40,
+                section_type="L",
+                is_main=True,
+            ),
+            SchedulerLecture(
+                semester_id="2430",
+                section_id="CDOM2430-L01",
+                day=2,
+                start_time=900,
+                end_time=1020,
+                room="Room 2430",
+                instructor="Prof. Spring",
+            ),
+            SchedulerSection(
+                semester_id="2530",
+                section_id="CDOM2530-L01",
+                course_id=ignored_course.id,
+                name="L01",
+                bundle=1,
+                layer=0,
+                quota=40,
+                section_type="L",
+                is_main=True,
+            ),
+        ])
+        db.session.commit()
+
+        dry_run = migrate_offerings(apply=False, semester_ids=["2430"])
+        assert dry_run.scanned == 1
+        assert CourseOffering.query.count() == 0
+
+        summary = migrate_offerings(apply=True, semester_ids=["2430"])
+        db.session.commit()
+
+        assert summary.scanned == 1
+        offering = CourseOffering.query.filter_by(course_id=target_course.id, semester_id="2430").one()
+        assert CourseSection.query.filter_by(offering_id=offering.id).count() == 1
+        assert CourseMeeting.query.join(CourseSection).filter(CourseSection.offering_id == offering.id).count() == 1
+        assert CourseOffering.query.filter_by(course_id=ignored_course.id, semester_id="2530").count() == 0
+
+
 def test_full_migration_dry_run_uses_transactional_staging_then_rolls_back(app, tmp_path, monkeypatch):
     from app.scripts import migrate_course_domain
     from app.services.course_domain_migration import MigrationSummary

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -93,6 +93,15 @@ def test_deploy_workflows_fail_on_migration_errors_and_use_committed_revisions()
         assert "flask db migrate" not in deploy_workflow
 
 
+def test_production_deploy_backfills_2024_25_scheduler_offerings():
+    deploy_workflow = (ROOT / ".github" / "workflows" / "deploy-backend-prod.yml").read_text(encoding="utf-8")
+
+    assert "python -m app.scripts.backfill_legacy_scheduler_offerings --semesters 2430 2440 --apply" in deploy_workflow
+    assert deploy_workflow.index("python -m app.scripts.init_db") < deploy_workflow.index(
+        "python -m app.scripts.backfill_legacy_scheduler_offerings"
+    )
+
+
 def test_course_domain_migration_workflows_support_dry_run_and_apply():
     workflow_paths = [
         ROOT / ".github" / "workflows" / "migrate-course-domain-dev.yml",


### PR DESCRIPTION
## Summary
- add a targeted legacy scheduler offering backfill script for selected semesters
- run the 2024-25 backfill for 2430/2440 during production deployment after init_db
- cover semester-scoped legacy offering migration and production deploy wiring with tests

## Verification
- pytest tests/test_course_domain_migration.py -q
- pytest tests/test_import_scheduler_offerings.py -q
- pytest tests/test_deploy_health.py -q
- pytest -q