### PR TITLE
[production] Handle withdrawn course attempts

### DIFF
--- a/app/models/academic_map.py
+++ b/app/models/academic_map.py
@@ -139,6 +139,7 @@ class UserCourseRecord(db.Model):
     STATUS_PLANNED = "planned"
     STATUS_INTERESTED = "interested"
     STATUS_NOT_INTERESTED = "not_interested"
+    STATUS_WITHDRAWN = "withdrawn"
 
     SOURCE_PASTE = "paste"
     SOURCE_SCREENSHOT = "screenshot"

--- a/app/routes/academic_map.py
+++ b/app/routes/academic_map.py
@@ -22,6 +22,7 @@ VALID_STATUSES = {
     UserCourseRecord.STATUS_PLANNED,
     UserCourseRecord.STATUS_INTERESTED,
     UserCourseRecord.STATUS_NOT_INTERESTED,
+    UserCourseRecord.STATUS_WITHDRAWN,
 }
 
 STRONG_STATUSES = {
@@ -64,6 +65,37 @@ def _import_row_key(row: dict) -> str:
     return _compact_course_code(row.get("matched_course_code") or row.get("course_code"))
 
 
+def _status_rank(status: str | None) -> int:
+    return {
+        UserCourseRecord.STATUS_COMPLETED: 0,
+        UserCourseRecord.STATUS_IN_PROGRESS: 1,
+        UserCourseRecord.STATUS_PLANNED: 2,
+        UserCourseRecord.STATUS_INTERESTED: 3,
+        UserCourseRecord.STATUS_WITHDRAWN: 4,
+        UserCourseRecord.STATUS_NOT_INTERESTED: 5,
+    }.get(status, 6)
+
+
+def _term_rank(row: dict) -> int:
+    term_code = str(row.get("term_code") or "").strip()
+    if term_code.isdigit():
+        return int(term_code)
+    semester_id = _semester_id_from_term_label(row.get("term_label"))
+    if semester_id and semester_id.isdigit():
+        return int(semester_id)
+    return -1
+
+
+def _is_stronger_import_row(candidate: dict, existing: dict) -> bool:
+    candidate_status = candidate.get("status")
+    existing_status = existing.get("status")
+    candidate_rank = _status_rank(candidate_status)
+    existing_rank = _status_rank(existing_status)
+    if candidate_rank != existing_rank:
+        return candidate_rank < existing_rank
+    return _term_rank(candidate) >= _term_rank(existing)
+
+
 def _dedupe_import_rows(rows: list) -> list:
     rows_by_code = {}
     passthrough = []
@@ -72,10 +104,29 @@ def _dedupe_import_rows(rows: list) -> list:
             continue
         key = _import_row_key(row)
         if key:
-            rows_by_code[key] = row
+            existing = rows_by_code.get(key)
+            if existing is None or _is_stronger_import_row(row, existing):
+                rows_by_code[key] = row
         else:
             passthrough.append(row)
     return passthrough + list(rows_by_code.values())
+
+
+def _group_import_rows(rows: list) -> list[tuple[dict, list[dict]]]:
+    by_code: dict[str, dict] = {}
+    passthrough = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = _import_row_key(row)
+        if not key:
+            passthrough.append((row, [row]))
+            continue
+        group = by_code.setdefault(key, {"display": row, "attempts": []})
+        group["attempts"].append(row)
+        if _is_stronger_import_row(row, group["display"]):
+            group["display"] = row
+    return passthrough + [(group["display"], group["attempts"]) for group in by_code.values()]
 
 
 def _clear_existing_import_for_course(user_id: int, matched_course, normalized_code: str) -> None:
@@ -129,7 +180,11 @@ def _sync_domain_record(user_id: int, matched_course, row: dict, status: str, *,
             db.session.delete(state)
         return
 
-    if status not in {UserCourseRecord.STATUS_COMPLETED, UserCourseRecord.STATUS_IN_PROGRESS}:
+    if status not in {
+        UserCourseRecord.STATUS_COMPLETED,
+        UserCourseRecord.STATUS_IN_PROGRESS,
+        UserCourseRecord.STATUS_WITHDRAWN,
+    }:
         return
 
     semester_id = row.get("term_code") or _semester_id_from_term_label(row.get("term_label"))
@@ -137,7 +192,12 @@ def _sync_domain_record(user_id: int, matched_course, row: dict, status: str, *,
     if offering is None:
         return
 
-    attempt_status = "completed" if status == UserCourseRecord.STATUS_COMPLETED else "in_progress"
+    if status == UserCourseRecord.STATUS_COMPLETED:
+        attempt_status = "completed"
+    elif status == UserCourseRecord.STATUS_WITHDRAWN:
+        attempt_status = "withdrawn"
+    else:
+        attempt_status = "in_progress"
     attempt = UserCourseAttempt.query.filter_by(
         user_id=user_id,
         course_id=matched_course.id,
@@ -155,7 +215,7 @@ def _sync_domain_record(user_id: int, matched_course, row: dict, status: str, *,
     attempt.status = attempt_status
     attempt.term_label = row.get("term_label")
     attempt.raw_payload = row
-    if attempt_status == "completed" and keep_grades and row.get("grade"):
+    if attempt_status in {"completed", "failed", "withdrawn"} and keep_grades and row.get("grade"):
         attempt.grade_letter = row.get("grade")
         attempt.grade_points = grade_points_for_letter(row.get("grade"))
     else:
@@ -318,10 +378,11 @@ def save_records_bulk():
     user_id = _current_user_id()
     data = request.get_json() or {}
     keep_grades = bool(data.get("keep_grades"))
-    rows = _dedupe_import_rows(data.get("records") if isinstance(data.get("records"), list) else [])
+    rows = data.get("records") if isinstance(data.get("records"), list) else []
+    row_groups = _group_import_rows(rows)
     saved = []
 
-    for row in rows:
+    for row, attempt_rows in row_groups:
         course_code = str(row.get("course_code", "")).strip().upper()
         if not course_code:
             continue
@@ -350,7 +411,9 @@ def save_records_bulk():
         )
         db.session.add(record)
         saved.append(record)
-        _sync_domain_record(user_id, matched_course, row, status, keep_grades=keep_grades)
+        for attempt_row in attempt_rows:
+            attempt_status = attempt_row.get("status") if attempt_row.get("status") in VALID_STATUSES else UserCourseRecord.STATUS_COMPLETED
+            _sync_domain_record(user_id, matched_course, attempt_row, attempt_status, keep_grades=keep_grades)
 
     db.session.commit()
     return jsonify({"records": [record.to_dict(include_grade=True) for record in saved]}), 200

--- a/app/services/academic_map_service.py
+++ b/app/services/academic_map_service.py
@@ -25,6 +25,7 @@ STATUS_RANK = {
     UserCourseRecord.STATUS_COMPLETED: 1,
     UserCourseRecord.STATUS_INTERESTED: 3,
     UserCourseRecord.STATUS_NOT_INTERESTED: 4,
+    UserCourseRecord.STATUS_WITHDRAWN: 5,
 }
 
 GRADE_POINTS = {
@@ -329,6 +330,10 @@ def _record_from_domain_attempts(user_id: int, course_id: int, attempts: list[Us
         status = UserCourseRecord.STATUS_IN_PROGRESS
         attempt = next(attempt for attempt in attempts if attempt.status == "in_progress")
         grade = None
+    elif any(attempt.status == "withdrawn" for attempt in attempts):
+        status = UserCourseRecord.STATUS_WITHDRAWN
+        attempt = max((attempt for attempt in attempts if attempt.status == "withdrawn"), key=lambda item: item.id or 0)
+        grade = attempt.grade_letter
     else:
         return None
     return DomainCourseRecordAdapter(
@@ -351,15 +356,16 @@ def _record_from_domain_attempts(user_id: int, course_id: int, attempts: list[Us
 def _domain_records_for_user(user_id: int) -> list[DomainCourseRecordAdapter]:
     records = []
     states = UserCourseState.query.filter_by(user_id=user_id).all()
-    state_course_ids = {state.course_id for state in states}
+    represented_course_ids = set()
     for state in states:
         record = _record_from_domain_state(state)
         if record is not None:
             records.append(record)
+            represented_course_ids.add(state.course_id)
 
     attempts_by_course: dict[int, list[UserCourseAttempt]] = {}
     for attempt in UserCourseAttempt.query.filter_by(user_id=user_id).all():
-        if attempt.course_id in state_course_ids:
+        if attempt.course_id in represented_course_ids:
             continue
         attempts_by_course.setdefault(attempt.course_id, []).append(attempt)
     for course_id, attempts in attempts_by_course.items():

--- a/app/services/course_domain.py
+++ b/app/services/course_domain.py
@@ -166,6 +166,17 @@ def derive_user_course_state(user_id: int, course_id: int) -> dict:
             "source": "derived",
         }
 
+    if attempts:
+        return {
+            "user_id": user_id,
+            "course_id": course_id,
+            "status": "not_taken",
+            "best_attempt_id": None,
+            "best_grade_points": None,
+            "best_grade_letter": None,
+            "source": "derived",
+        }
+
     manual = UserCourseState.query.filter_by(user_id=user_id, course_id=course_id).first()
     if manual is not None:
         return {

--- a/app/services/course_domain_migration.py
+++ b/app/services/course_domain_migration.py
@@ -432,6 +432,8 @@ def _attempt_status(record: UserCourseRecord) -> str | None:
         return "completed"
     if record.status in {UserCourseRecord.STATUS_IN_PROGRESS, UserCourseRecord.STATUS_PLANNED}:
         return "in_progress"
+    if record.status == UserCourseRecord.STATUS_WITHDRAWN:
+        return "withdrawn"
     return None
 
 

--- a/app/services/course_history_importer.py
+++ b/app/services/course_history_importer.py
@@ -22,6 +22,8 @@ def _normalize_course_code(prefix: str, number: str) -> str:
 
 
 def _status_from_grade(grade: str | None) -> tuple[str, bool, str | None]:
+    if grade and grade.strip().upper() == "W":
+        return "withdrawn", False, None
     if grade:
         return "completed", False, None
     return "planned", True, "Missing grade; confirm whether this course is in progress or planned."

--- a/app/utils/academic_map_import_text.py
+++ b/app/utils/academic_map_import_text.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 
-STATUS_WORDS = r"not\s*taken|in\s*progress|taken|completed|complete|registered|enrolled|planned|pending"
+STATUS_WORDS = r"not\s*taken|in\s*progress|withdrawn|withdraw|dropped|drop|taken|completed|complete|registered|enrolled|planned|pending"
 STATUS_TITLE_RE = re.compile(rf"\b({STATUS_WORDS})\b", re.IGNORECASE)
 
 
@@ -18,6 +18,8 @@ def status_from_text(value: str | None) -> str | None:
         return "planned"
     if normalized == "not taken":
         return "not_interested"
+    if normalized in {"withdrawn", "withdraw", "dropped", "drop"}:
+        return "withdrawn"
     return None
 
 

--- a/tests/test_academic_map_routes.py
+++ b/tests/test_academic_map_routes.py
@@ -202,6 +202,102 @@ def test_import_matches_course_catalog_by_normalized_code(client, app):
     assert summary_records[0]["domain_attempt_id"] is not None
 
 
+def test_import_withdrawn_course_does_not_count_completed_credit(client, app):
+    user_id, headers = create_user_and_headers(app, "withdrawn_import_user")
+    with app.app_context():
+        course = Course.query.filter_by(code="AIAA2205").one()
+        seed_offering(course, "2410")
+        db.session.commit()
+
+    pasted = "AIAA 2205\tIntroduction to Artificial Intelligence\t2024-25 Fall\tW\t3.00\tWithdrawn"
+    parse_response = client.post("/academic-map/import/parse", json={"text": pasted}, headers=headers)
+
+    assert parse_response.status_code == 200
+    parsed = parse_response.get_json()["rows"]
+    assert parsed[0]["status"] == "withdrawn"
+
+    save_response = client.post(
+        "/academic-map/records/bulk",
+        json={"keep_grades": True, "records": parsed},
+        headers=headers,
+    )
+
+    assert save_response.status_code == 200
+    with app.app_context():
+        course = Course.query.filter_by(code="AIAA2205").one()
+        attempt = UserCourseAttempt.query.filter_by(user_id=user_id, course_id=course.id).one()
+        assert attempt.status == "withdrawn"
+        assert attempt.grade_letter == "W"
+        state = UserCourseState.query.filter_by(user_id=user_id, course_id=course.id).one()
+        assert state.status == "not_taken"
+        assert state.best_attempt_id is None
+
+    summary_response = client.get("/academic-map/summary", headers=headers)
+
+    assert summary_response.status_code == 200
+    summary = summary_response.get_json()
+    assert summary["credits"]["total_completed"] == 0
+    assert summary["course_counts"]["completed"] == 0
+    assert summary["records"][0]["status"] == "withdrawn"
+    assert summary["records"][0]["course_code"] == "AIAA2205"
+
+
+def test_import_withdrawn_and_retake_counts_only_completed_retake(client, app):
+    user_id, headers = create_user_and_headers(app, "withdrawn_retake_user")
+    with app.app_context():
+        course = Course.query.filter_by(code="AIAA2205").one()
+        seed_offering(course, "2410")
+        seed_offering(course, "2430")
+        db.session.commit()
+
+    rows = [
+        {
+            "course_code": "AIAA2205",
+            "matched_course_code": "AIAA2205",
+            "course_title": "Introduction to Artificial Intelligence",
+            "term_label": "2024-25 Fall",
+            "term_code": "2410",
+            "units": 3,
+            "status": "withdrawn",
+            "grade": "W",
+        },
+        {
+            "course_code": "AIAA2205",
+            "matched_course_code": "AIAA2205",
+            "course_title": "Introduction to Artificial Intelligence",
+            "term_label": "2024-25 Spring",
+            "term_code": "2430",
+            "units": 3,
+            "status": "completed",
+            "grade": "A-",
+        },
+    ]
+
+    save_response = client.post(
+        "/academic-map/records/bulk",
+        json={"keep_grades": True, "records": rows},
+        headers=headers,
+    )
+
+    assert save_response.status_code == 200
+    with app.app_context():
+        course = Course.query.filter_by(code="AIAA2205").one()
+        attempts = UserCourseAttempt.query.filter_by(user_id=user_id, course_id=course.id).all()
+        assert sorted(attempt.status for attempt in attempts) == ["completed", "withdrawn"]
+        state = UserCourseState.query.filter_by(user_id=user_id, course_id=course.id).one()
+        assert state.status == "completed"
+        assert state.best_grade_letter == "A-"
+
+    summary_response = client.get("/academic-map/summary", headers=headers)
+
+    assert summary_response.status_code == 200
+    summary = summary_response.get_json()
+    assert summary["credits"]["total_completed"] == 3
+    assert summary["course_counts"]["completed"] == 1
+    assert summary["records"][0]["status"] == "completed"
+    assert summary["records"][0]["term_code"] == "2430"
+
+
 def test_import_with_unresolved_offering_stays_visible_as_raw_record(client, app):
     _user_id, headers = create_user_and_headers(app, "import_missing_offering_user")
     with app.app_context():
@@ -306,7 +402,7 @@ def test_record_update_and_delete_keep_domain_tables_in_sync(client, app):
         assert UserCourseState.query.filter_by(user_id=user_id, course_id=course.id).count() == 0
 
 
-def test_bulk_import_overwrites_existing_course_with_last_row(client, app):
+def test_bulk_import_keeps_strongest_display_record_and_preserves_domain_attempts(client, app):
     user_id, headers = create_user_and_headers(app, "bulk_overwrite_user")
     with app.app_context():
         course = Course.query.filter_by(code="AIAA1010").one()
@@ -361,9 +457,11 @@ def test_bulk_import_overwrites_existing_course_with_last_row(client, app):
         assert len(records) == 1
         assert records[0].term_code == "2440"
         attempts = UserCourseAttempt.query.filter_by(user_id=user_id, course_id=course.id).all()
-        assert len(attempts) == 1
-        assert attempts[0].offering.semester_id == "2440"
-        assert attempts[0].grade_letter == "A"
+        assert len(attempts) == 2
+        assert sorted((attempt.offering.semester_id, attempt.grade_letter) for attempt in attempts) == [
+            ("2410", "B+"),
+            ("2440", "A"),
+        ]
         state = UserCourseState.query.filter_by(user_id=user_id, course_id=course.id).one()
         assert state.best_grade_letter == "A"
 

--- a/tests/test_course_domain_services.py
+++ b/tests/test_course_domain_services.py
@@ -144,3 +144,44 @@ def test_database_helpers_find_course_offering_and_best_attempt(app):
         assert find_course_by_code("CDOM 3300").id == course.id
         assert find_offering(course, "2530").id == offering.id
         assert best_completed_attempt([failed, passed]).id == passed.id
+
+
+def test_withdrawn_attempts_derive_not_taken_state(app):
+    from app.services.course_domain import derive_user_course_state
+
+    with app.app_context():
+        course = Course(
+            code="CDOM4400",
+            normalized_code="CDOM4400",
+            display_code="CDOM 4400",
+            name="Withdrawn Course",
+            credits=3,
+        )
+        db.session.add(course)
+        db.session.flush()
+        offering = CourseOffering(
+            course_id=course.id,
+            semester_id="2530",
+            offering_code="CDOM4400",
+            title_snapshot=course.name,
+            credits_snapshot=3,
+            source="test",
+            status="offered",
+        )
+        db.session.add(offering)
+        db.session.flush()
+        db.session.add(UserCourseAttempt(
+            user_id=1,
+            course_id=course.id,
+            offering_id=offering.id,
+            status="withdrawn",
+            grade_letter="W",
+            source="manual",
+        ))
+        db.session.commit()
+
+        state = derive_user_course_state(1, course.id)
+
+    assert state["status"] == "not_taken"
+    assert state["best_attempt_id"] is None
+    assert state["best_grade_letter"] is None

--- a/tests/test_course_history_importer.py
+++ b/tests/test_course_history_importer.py
@@ -40,3 +40,21 @@ def test_parse_course_history_assigns_scheduler_term_code():
 
     assert rows[0]["term_label"] == "2024-25 Summer"
     assert rows[0]["term_code"] == "2440"
+
+
+def test_parse_course_history_marks_withdrawn_rows_without_completed_credit():
+    pasted = """Course\tDescription\tTerm\tGrade\tUnits\tStatus
+AIAA 2205\tIntroduction to AI\t2024-25 Fall\tW\t3.00\tWithdrawn
+DSAA 2011\tPython Programming\t2024-25 Fall\t\t3.00\tDropped
+"""
+
+    rows = parse_course_history_text(pasted)
+
+    assert rows[0]["grade"] == "W"
+    assert rows[0]["status"] == "withdrawn"
+    assert rows[0]["needs_review"] is False
+    assert rows[0]["course_title"] == "Introduction to AI"
+    assert rows[1]["grade"] is None
+    assert rows[1]["status"] == "withdrawn"
+    assert rows[1]["needs_review"] is False
+    assert rows[1]["course_title"] == "Python Programming"


### PR DESCRIPTION
## Summary
- Add withdrawn as a supported academic-map course record status.
- Preserve withdrawn attempts in the course-domain attempt history while deriving aggregate state as not_taken unless a stronger completed/in-progress attempt exists.
- Parse transcript rows with grade W / Withdrawn / Dropped as withdrawn and avoid counting them as completed credits.

## Verification
- python -m pytest -q (306 passed)
- Dev backend deploy succeeded: Actions run 27495665193
- Dev API smoke: W/Withdrawn parsed and saved as withdrawn; completed credits stayed 0
