### PR TITLE
Add academic map Common Core requirements

### DIFF
--- a/app/data/curriculum_requirements.json
+++ b/app/data/curriculum_requirements.json
@@ -18,6 +18,231 @@
       "source_file": "AI 25.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -197,6 +422,231 @@
       ],
       "source_file": "AI 23 24.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -385,6 +835,231 @@
       ],
       "source_file": "DSA 25.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -612,6 +1287,231 @@
       ],
       "source_file": "DSA 24.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -851,6 +1751,231 @@
       "source_file": "Curriculum Requirements - DSBD - 2023 cohort.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -1066,6 +2191,231 @@
       "source_file": "AMAT Curriculum Updated.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -1267,6 +2617,231 @@
       ],
       "source_file": "Curriculum Requirement - MSE - 2024 cohort - updated on May 19.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -1489,6 +3064,231 @@
       ],
       "source_file": "SMMG 25.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -1735,6 +3535,231 @@
       "source_file": "SMMG 23 24.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -1954,6 +3979,219 @@
       "source_file": "FTEC 25.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_science",
+                  "label_en": "Broadening: Science",
+                  "label_zh": "拓宽课程：科学",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1702",
+                    "UCUG1900"
+                  ],
+                  "area": "S",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "S",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1702",
+                    "UCUG1900"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "T",
+                        "SA"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1702",
+                    "UCUG1900"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "T",
+                        "SA"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -2118,6 +4356,214 @@
       ],
       "source_file": "ROAS 25.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_science",
+                  "label_en": "Broadening: Science",
+                  "label_zh": "拓宽课程：科学",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1702",
+                    "UCUG1900"
+                  ],
+                  "area": "S",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "S",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1702",
+                    "UCUG1900",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
@@ -2307,6 +4753,231 @@
       "source_file": "MICS 25.pdf",
       "requirement_groups": [
         {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
+        {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",
           "name_zh": "基础课程",
@@ -2486,6 +5157,231 @@
       ],
       "source_file": "SEEN 26.pdf",
       "requirement_groups": [
+        {
+          "key": "common_core",
+          "name_en": "University Common Core Courses",
+          "name_zh": "大学通识课程",
+          "category": "common_core",
+          "min_credits": 30,
+          "rule": {
+            "rule_tree": {
+              "type": "all_of",
+              "children": [
+                {
+                  "type": "choose",
+                  "key": "foundation_ctdl",
+                  "label_en": "CTDL",
+                  "label_zh": "批判思维与数据素养",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1000"
+                  ],
+                  "area": "CTDL"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_hmw",
+                  "label_en": "HMW",
+                  "label_zh": "习惯、心态与身心健康",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1001"
+                  ],
+                  "area": "HMW"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_e_comm",
+                  "label_en": "English Communication",
+                  "label_zh": "英语沟通",
+                  "min_courses": 2,
+                  "min_credits": 6,
+                  "courses": [
+                    "UCUG1050",
+                    "UCUG1051",
+                    "UCUG1052",
+                    "UCUG1052A",
+                    "UCUG1052I",
+                    "UCUG1052S",
+                    "UCUG1053"
+                  ],
+                  "area": "E-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "foundation_c_comm",
+                  "label_en": "Chinese Communication",
+                  "label_zh": "中文沟通",
+                  "min_courses": 1,
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1070",
+                    "UCUG1071",
+                    "UCUG1072",
+                    "UCUG1073",
+                    "UCUG1074",
+                    "UCUG1077"
+                  ],
+                  "area": "C-Comm"
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_arts",
+                  "label_en": "Broadening: Arts",
+                  "label_zh": "拓宽课程：艺术",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603"
+                  ],
+                  "area": "A",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "A",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_humanities",
+                  "label_en": "Broadening: Humanities",
+                  "label_zh": "拓宽课程：人文",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604"
+                  ],
+                  "area": "H",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "H",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_social_analysis",
+                  "label_en": "Broadening: Social Analysis",
+                  "label_zh": "拓宽课程：社会分析",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "area": "SA",
+                  "constraints": [
+                    {
+                      "type": "course_area",
+                      "value": "SA",
+                      "min_credits": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "broadening_elective",
+                  "label_en": "Broadening elective",
+                  "label_zh": "拓宽选修",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "choose",
+                  "key": "experiencing_uxop",
+                  "label_en": "Experiencing: UxOP or Broadening substitute",
+                  "label_zh": "体验课程：UxOP 或拓宽课程替代",
+                  "kind": "elective",
+                  "min_credits": 3,
+                  "courses": [
+                    "UCUG2304",
+                    "UCUG1500",
+                    "UCUG1501",
+                    "UCUG1502",
+                    "UCUG1503",
+                    "UCUG1504",
+                    "UCUG1505",
+                    "UCUG1506",
+                    "UCUG1507",
+                    "UCUG2500",
+                    "UCUG2603",
+                    "UCUG1600",
+                    "UCUG1603",
+                    "UCUG1604",
+                    "UCUG1800",
+                    "UCUG1804",
+                    "UCUG1807",
+                    "UCUG1808",
+                    "UCUG1809",
+                    "UCUG3801"
+                  ],
+                  "allow_reuse": false,
+                  "constraints": [
+                    {
+                      "type": "exclude_course_areas",
+                      "values": [
+                        "S",
+                        "T"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sort_order": 5
+        },
         {
           "key": "fundamental_courses",
           "name_en": "Fundamental Courses",

--- a/app/scripts/init_db.py
+++ b/app/scripts/init_db.py
@@ -3,6 +3,7 @@ from app.extensions import db
 from app.models.tag import TagType
 from app.models.user_role import UserRole
 from app.models.identity_type import IdentityType
+from app.services.academic_curriculum_sync import sync_curriculum_requirements_from_file
 from sqlalchemy import text
 
 def init_tag_types():
@@ -115,11 +116,19 @@ def init_identity_types():
         db.session.commit()
         print("Identity types initialization completed")
 
+def init_curriculum_requirements():
+    """Synchronize bundled academic map curriculum requirements"""
+    app = create_app()
+    with app.app_context():
+        result = sync_curriculum_requirements_from_file()
+        print(f"Curriculum requirements synchronized: {result}")
+
 def init_db():
     """Initialize database with all required predefined data"""
     init_tag_types()
     init_user_roles()
     init_identity_types()  # Back to just populating data, not creating tables
+    init_curriculum_requirements()
     print("Database initialization completed")
 
 if __name__ == '__main__':

--- a/app/services/academic_curriculum_evaluator.py
+++ b/app/services/academic_curriculum_evaluator.py
@@ -115,8 +115,23 @@ def _candidate_codes(leaf: dict[str, Any], courses_by_code: dict[str, dict]) -> 
             normalize_code(code)
             for code in leaf.get("courses", [])
             if normalize_code(code) in courses_by_code
+            and _course_allowed_for_leaf(leaf, courses_by_code[normalize_code(code)])
         }
     )
+
+
+def _course_allowed_for_leaf(leaf: dict[str, Any], course: dict[str, Any]) -> bool:
+    course_area = course.get("area")
+    for constraint in leaf.get("constraints", []):
+        if constraint.get("type") == "course_area":
+            required_area = normalize_code(constraint.get("value"))
+            if normalize_code(course_area) != required_area:
+                return False
+        if constraint.get("type") == "exclude_course_areas":
+            excluded = {normalize_code(value) for value in constraint.get("values", [])}
+            if normalize_code(course_area) in excluded:
+                return False
+    return True
 
 
 def _constraints_satisfied(
@@ -138,6 +153,21 @@ def _constraints_satisfied(
             count = len([code for code in selected if code.startswith(prefix)])
             if count < int(constraint.get("min_courses") or 0):
                 return False
+        if constraint.get("type") == "course_area":
+            area = normalize_code(constraint.get("value"))
+            area_courses = [
+                code
+                for code in selected
+                if normalize_code(courses_by_code[code].get("area")) == area
+            ]
+            min_courses = constraint.get("min_courses")
+            if min_courses is not None and len(area_courses) < int(min_courses or 0):
+                return False
+            min_credits = constraint.get("min_credits")
+            if min_credits is not None:
+                area_credits = [courses_by_code[code].get("credits") for code in area_courses]
+                if any(value is None for value in area_credits) or sum(area_credits) < int(min_credits or 0):
+                    return False
     return True
 
 
@@ -155,6 +185,15 @@ def _leaf_progress_score(
             prefix = normalize_code(constraint.get("value"))
             required = int(constraint.get("min_courses") or 0)
             prefix_progress += min(len([code for code in selected if code.startswith(prefix)]), required)
+        if constraint.get("type") == "course_area":
+            area = normalize_code(constraint.get("value"))
+            area_codes = [
+                code
+                for code in selected
+                if normalize_code(courses_by_code[code].get("area")) == area
+            ]
+            required_courses = int(constraint.get("min_courses") or 0)
+            prefix_progress += min(len(area_codes), required_courses)
     return (
         min(len(selected), required_courses) if required_courses else 0,
         min(known_credits, required_credits) if required_credits is not None else 0,
@@ -374,6 +413,8 @@ def _merge_sections(
                     "counted_toward": allocated_elsewhere.get(code),
                     "credits": course.get("credits"),
                     "credit_source": course.get("credit_source"),
+                    "area": course.get("area"),
+                    "section_area": leaf.get("area"),
                     "shared_majors": course.get("shared_majors", []),
                 }
             )

--- a/app/services/academic_curriculum_evaluator.py
+++ b/app/services/academic_curriculum_evaluator.py
@@ -8,6 +8,7 @@ from typing import Any
 CURRENT_STATUSES = {"completed", "in_progress"}
 PROJECTED_STATUSES = CURRENT_STATUSES | {"planned"}
 MAX_COMBINATIONS_PER_SIZE = 1024
+MAX_OPTIONS_PER_LEAF = 8
 
 
 def normalize_code(value: Any) -> str:
@@ -275,9 +276,8 @@ def _choose_options(
     for size in sorted(size for size in sizes if size > 0):
         for option in islice(combinations(prioritized, size), MAX_COMBINATIONS_PER_SIZE):
             option_set.add(tuple(sorted(option)))
-    options = list(option_set)
-    return sorted(
-        options,
+    options = sorted(
+        option_set,
         key=lambda option: (
             _constraints_satisfied(leaf, option, courses_by_code),
             _leaf_progress_score(leaf, option, courses_by_code),
@@ -285,6 +285,11 @@ def _choose_options(
         ),
         reverse=True,
     )
+    if options and options[0] != ():
+        empty = [option for option in options if option == ()]
+        non_empty = [option for option in options if option != ()]
+        return non_empty[:MAX_OPTIONS_PER_LEAF] + empty[:1]
+    return options[:1]
 
 
 def _expand_satisfied_allocations(
@@ -395,45 +400,21 @@ def _evaluate_view(leaves: list[dict[str, Any]], courses_by_code: dict[str, dict
             item[0],
         ),
     )
-    best_allocations = dict(allocations)
-    best_score: tuple[Any, ...] | None = None
-    max_possible_satisfied = len(required_leaves) + sum(
-        1
-        for _index, leaf in ordered_choose_leaves
-        if any(
-            _constraints_satisfied(leaf, option, courses_by_code)
-            for option in _choose_options(leaf, _candidate_codes(leaf, courses_by_code), courses_by_code)
-        )
-    )
-
-    def assign(index: int, used_codes: set[str]) -> None:
-        nonlocal best_allocations, best_score
-        if best_score is not None and best_score[0] >= max_possible_satisfied:
-            return
-        if index == len(ordered_choose_leaves):
-            score = _assignment_score(leaves, allocations, courses_by_code)
-            if best_score is None or score > best_score:
-                best_score = score
-                best_allocations = dict(allocations)
-            return
-
-        _original_index, leaf = ordered_choose_leaves[index]
+    used_codes = set(reserved)
+    for _original_index, leaf in ordered_choose_leaves:
         candidates = _candidate_codes(leaf, courses_by_code)
         available = [
             code
             for code in candidates
             if leaf.get("allow_reuse") or code not in used_codes
         ]
-        for selected in _choose_options(leaf, available, courses_by_code):
-            allocations[leaf["_allocation_key"]] = selected
-            assign(
-                index + 1,
-                used_codes if leaf.get("allow_reuse") else used_codes | set(selected),
-            )
-        allocations.pop(leaf["_allocation_key"], None)
+        options = _choose_options(leaf, available, courses_by_code)
+        selected = options[0] if options else ()
+        allocations[leaf["_allocation_key"]] = selected
+        if not leaf.get("allow_reuse"):
+            used_codes.update(selected)
 
-    assign(0, reserved)
-    allocations = _expand_satisfied_allocations(leaves, best_allocations, courses_by_code)
+    allocations = _expand_satisfied_allocations(leaves, allocations, courses_by_code)
     satisfied_by_leaf = {
         leaf["_allocation_key"]: _constraints_satisfied(
             leaf,

--- a/app/services/academic_curriculum_evaluator.py
+++ b/app/services/academic_curriculum_evaluator.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from itertools import combinations
+from itertools import combinations, islice
 from typing import Any
 
 
 CURRENT_STATUSES = {"completed", "in_progress"}
 PROJECTED_STATUSES = CURRENT_STATUSES | {"planned"}
+MAX_COMBINATIONS_PER_SIZE = 1024
 
 
 def normalize_code(value: Any) -> str:
@@ -201,16 +202,80 @@ def _leaf_progress_score(
     )
 
 
+def _constraint_match_score(leaf: dict[str, Any], code: str, courses_by_code: dict[str, dict]) -> int:
+    course = courses_by_code[code]
+    score = 0
+    for constraint in leaf.get("constraints", []):
+        if constraint.get("type") == "course_prefix":
+            if code.startswith(normalize_code(constraint.get("value"))):
+                score += 1
+        if constraint.get("type") == "course_area":
+            if normalize_code(course.get("area")) == normalize_code(constraint.get("value")):
+                score += 1
+    return score
+
+
+def _prioritized_codes(
+    leaf: dict[str, Any],
+    available_codes: list[str],
+    courses_by_code: dict[str, dict],
+) -> list[str]:
+    return sorted(
+        available_codes,
+        key=lambda code: (
+            -_constraint_match_score(leaf, code, courses_by_code),
+            -(courses_by_code[code].get("credits") or 0),
+            code,
+        ),
+    )
+
+
+def _target_option_size(
+    leaf: dict[str, Any],
+    available_codes: list[str],
+    courses_by_code: dict[str, dict],
+) -> int:
+    required_courses = _required_courses(leaf)
+    required_credits = _required_credits(leaf)
+    target = required_courses
+    for constraint in leaf.get("constraints", []):
+        target = max(target, int(constraint.get("min_courses") or 0))
+    if required_credits is not None:
+        credits = sorted(
+            [
+                courses_by_code[code].get("credits") or 0
+                for code in available_codes
+            ],
+            reverse=True,
+        )
+        running = 0
+        credit_target = len(available_codes)
+        for index, credit in enumerate(credits, start=1):
+            running += credit
+            if index >= required_courses and running >= required_credits:
+                credit_target = index
+                break
+        target = max(target, credit_target)
+    if target <= 0:
+        target = len(available_codes)
+    return min(target, len(available_codes))
+
+
 def _choose_options(
     leaf: dict[str, Any],
     available_codes: list[str],
     courses_by_code: dict[str, dict],
 ) -> list[tuple[str, ...]]:
-    options = [
-        option
-        for size in range(len(available_codes) + 1)
-        for option in combinations(available_codes, size)
-    ]
+    prioritized = _prioritized_codes(leaf, available_codes, courses_by_code)
+    target_size = _target_option_size(leaf, prioritized, courses_by_code)
+    option_set: set[tuple[str, ...]] = {()}
+    sizes = {target_size}
+    if target_size <= 4:
+        sizes.update(range(1, target_size + 1))
+    for size in sorted(size for size in sizes if size > 0):
+        for option in islice(combinations(prioritized, size), MAX_COMBINATIONS_PER_SIZE):
+            option_set.add(tuple(sorted(option)))
+    options = list(option_set)
     return sorted(
         options,
         key=lambda option: (
@@ -220,6 +285,37 @@ def _choose_options(
         ),
         reverse=True,
     )
+
+
+def _expand_satisfied_allocations(
+    leaves: list[dict[str, Any]],
+    allocations: dict[str, tuple[str, ...]],
+    courses_by_code: dict[str, dict],
+) -> dict[str, tuple[str, ...]]:
+    expanded = dict(allocations)
+    allocated_codes = {
+        code
+        for leaf in leaves
+        if not leaf.get("allow_reuse")
+        for code in expanded.get(leaf["_allocation_key"], ())
+    }
+    for leaf in leaves:
+        allocation_key = leaf["_allocation_key"]
+        selected = tuple(expanded.get(allocation_key, ()))
+        if not selected or not _constraints_satisfied(leaf, selected, courses_by_code):
+            continue
+        extras = []
+        for code in _candidate_codes(leaf, courses_by_code):
+            if code in selected:
+                continue
+            if not leaf.get("allow_reuse") and code in allocated_codes:
+                continue
+            extras.append(code)
+        if extras:
+            expanded[allocation_key] = tuple(sorted(set(selected) | set(extras)))
+            if not leaf.get("allow_reuse"):
+                allocated_codes.update(extras)
+    return expanded
 
 
 def _assignment_score(
@@ -301,9 +397,19 @@ def _evaluate_view(leaves: list[dict[str, Any]], courses_by_code: dict[str, dict
     )
     best_allocations = dict(allocations)
     best_score: tuple[Any, ...] | None = None
+    max_possible_satisfied = len(required_leaves) + sum(
+        1
+        for _index, leaf in ordered_choose_leaves
+        if any(
+            _constraints_satisfied(leaf, option, courses_by_code)
+            for option in _choose_options(leaf, _candidate_codes(leaf, courses_by_code), courses_by_code)
+        )
+    )
 
     def assign(index: int, used_codes: set[str]) -> None:
         nonlocal best_allocations, best_score
+        if best_score is not None and best_score[0] >= max_possible_satisfied:
+            return
         if index == len(ordered_choose_leaves):
             score = _assignment_score(leaves, allocations, courses_by_code)
             if best_score is None or score > best_score:
@@ -327,7 +433,7 @@ def _evaluate_view(leaves: list[dict[str, Any]], courses_by_code: dict[str, dict
         allocations.pop(leaf["_allocation_key"], None)
 
     assign(0, reserved)
-    allocations = best_allocations
+    allocations = _expand_satisfied_allocations(leaves, best_allocations, courses_by_code)
     satisfied_by_leaf = {
         leaf["_allocation_key"]: _constraints_satisfied(
             leaf,

--- a/app/services/academic_map_service.py
+++ b/app/services/academic_map_service.py
@@ -44,6 +44,49 @@ GRADE_POINTS = {
 
 NON_GPA_GRADES = {"AU", "DI", "I", "P", "PA", "PP", "T", "W"}
 
+UCUG_AREAS = {
+    "UCUG1000": "CTDL",
+    "UCUG1001": "HMW",
+    "UCUG1050": "E-Comm",
+    "UCUG1051": "E-Comm",
+    "UCUG1052": "E-Comm",
+    "UCUG1052A": "E-Comm",
+    "UCUG1052I": "E-Comm",
+    "UCUG1052S": "E-Comm",
+    "UCUG1053": "E-Comm",
+    "UCUG1070": "C-Comm",
+    "UCUG1071": "C-Comm",
+    "UCUG1072": "C-Comm",
+    "UCUG1073": "C-Comm",
+    "UCUG1074": "C-Comm",
+    "UCUG1077": "C-Comm",
+    "UCUG1500": "A",
+    "UCUG1501": "A",
+    "UCUG1502": "A",
+    "UCUG1503": "A",
+    "UCUG1504": "A",
+    "UCUG1505": "A",
+    "UCUG1506": "A",
+    "UCUG1507": "A",
+    "UCUG2500": "A",
+    "UCUG2603": "A",
+    "UCUG1600": "H",
+    "UCUG1603": "H",
+    "UCUG1604": "H",
+    "UCUG1702": "S",
+    "UCUG1900": "S",
+    "UCUG1903": "T",
+    "UCUG1905": "T",
+    "UCUG1907": "T",
+    "UCUG1800": "SA",
+    "UCUG1804": "SA",
+    "UCUG1807": "SA",
+    "UCUG1808": "SA",
+    "UCUG1809": "SA",
+    "UCUG3801": "SA",
+    "UCUG2304": "UxOP",
+}
+
 
 class DomainCourseRecordAdapter:
     import_source = "course_domain"
@@ -434,6 +477,7 @@ def _evaluation_courses(
             "record_status": record.status if record else None,
             "credits": credits,
             "credit_source": credit_source,
+            "area": UCUG_AREAS.get(code),
             "shared_majors": shared_map.get(code, []),
         }
     return result

--- a/tests/test_academic_curriculum_evaluator.py
+++ b/tests/test_academic_curriculum_evaluator.py
@@ -1,7 +1,7 @@
 from app.services.academic_curriculum_evaluator import evaluate_requirement_group, evaluate_requirement_program
 
 
-def _course(code, status, credits=3, source="catalog"):
+def _course(code, status, credits=3, source="catalog", area=None):
     return {
         "course_code": code,
         "title": code,
@@ -9,6 +9,7 @@ def _course(code, status, credits=3, source="catalog"):
         "credits": credits,
         "credit_source": source,
         "shared_majors": [],
+        "area": area,
     }
 
 
@@ -271,3 +272,57 @@ def test_evaluator_allows_explicit_leaf_reuse():
 
     assert result[0]["current"]["satisfied"] is True
     assert result[1]["current"]["satisfied"] is True
+
+
+def test_evaluator_enforces_common_core_course_area_constraints():
+    rule = {
+        "rule_tree": {
+            "type": "choose",
+            "key": "broadening_arts",
+            "kind": "elective",
+            "min_credits": 3,
+            "courses": ["UCUG1500", "UCUG1600"],
+            "constraints": [{"type": "course_area", "value": "A", "min_credits": 3}],
+        }
+    }
+    courses = {
+        "UCUG1500": _course("UCUG1500", "completed", area="A"),
+        "UCUG1600": _course("UCUG1600", "completed", area="H"),
+    }
+
+    result = evaluate_requirement_group(rule, courses)
+
+    assert result["current"]["satisfied"] is True
+    counted = [
+        cell["course_code"]
+        for cell in result["sections"][0]["cells"]
+        if cell["allocation_status"] == "counted"
+    ]
+    assert counted == ["UCUG1500"]
+
+
+def test_evaluator_excludes_home_areas_from_common_core_broadening_electives():
+    rule = {
+        "rule_tree": {
+            "type": "choose",
+            "key": "broadening_elective",
+            "kind": "elective",
+            "min_credits": 3,
+            "courses": ["UCUG1702", "UCUG1807"],
+            "constraints": [{"type": "exclude_course_areas", "values": ["S", "T"]}],
+        }
+    }
+    courses = {
+        "UCUG1702": _course("UCUG1702", "completed", area="S"),
+        "UCUG1807": _course("UCUG1807", "completed", area="SA"),
+    }
+
+    result = evaluate_requirement_group(rule, courses)
+
+    assert result["current"]["satisfied"] is True
+    counted = [
+        cell["course_code"]
+        for cell in result["sections"][0]["cells"]
+        if cell["allocation_status"] == "counted"
+    ]
+    assert counted == ["UCUG1807"]

--- a/tests/test_academic_curriculum_evaluator.py
+++ b/tests/test_academic_curriculum_evaluator.py
@@ -1,3 +1,7 @@
+import signal
+
+import pytest
+
 from app.services.academic_curriculum_evaluator import evaluate_requirement_group, evaluate_requirement_program
 
 
@@ -326,3 +330,66 @@ def test_evaluator_excludes_home_areas_from_common_core_broadening_electives():
         if cell["allocation_status"] == "counted"
     ]
     assert counted == ["UCUG1807"]
+
+
+def test_evaluator_handles_large_common_core_choice_pools_quickly():
+    courses = {
+        **{f"UCUG15{i:02d}": _course(f"UCUG15{i:02d}", "completed", area="A") for i in range(10)},
+        **{f"UCUG16{i:02d}": _course(f"UCUG16{i:02d}", "completed", area="H") for i in range(5)},
+        **{f"UCUG18{i:02d}": _course(f"UCUG18{i:02d}", "completed", area="SA") for i in range(10)},
+        **{f"UCUG23{i:02d}": _course(f"UCUG23{i:02d}", "completed", area="UxOP") for i in range(10)},
+    }
+    rule = {
+        "rule_tree": {
+            "type": "all_of",
+            "children": [
+                {
+                    "type": "choose",
+                    "key": "arts",
+                    "kind": "elective",
+                    "min_credits": 3,
+                    "courses": [code for code, course in courses.items() if course["area"] == "A"],
+                    "constraints": [{"type": "course_area", "value": "A", "min_credits": 3}],
+                },
+                {
+                    "type": "choose",
+                    "key": "humanities",
+                    "kind": "elective",
+                    "min_credits": 3,
+                    "courses": [code for code, course in courses.items() if course["area"] == "H"],
+                    "constraints": [{"type": "course_area", "value": "H", "min_credits": 3}],
+                },
+                {
+                    "type": "choose",
+                    "key": "social_analysis",
+                    "kind": "elective",
+                    "min_credits": 3,
+                    "courses": [code for code, course in courses.items() if course["area"] == "SA"],
+                    "constraints": [{"type": "course_area", "value": "SA", "min_credits": 3}],
+                },
+                {
+                    "type": "choose",
+                    "key": "experiencing",
+                    "kind": "elective",
+                    "min_credits": 3,
+                    "courses": list(courses),
+                },
+            ],
+        }
+    }
+
+    def timeout_handler(_signum, _frame):
+        raise TimeoutError("common core evaluation timed out")
+
+    previous = signal.signal(signal.SIGALRM, timeout_handler)
+    signal.setitimer(signal.ITIMER_REAL, 1.0)
+    try:
+        result = evaluate_requirement_group(rule, courses)
+    except TimeoutError as exc:
+        pytest.fail(str(exc))
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+    assert result["current"]["satisfied"] is True
+    assert result["current"]["counted_credits"] >= 12

--- a/tests/test_academic_map_routes.py
+++ b/tests/test_academic_map_routes.py
@@ -1,4 +1,5 @@
 import pytest
+import signal
 from flask_jwt_extended import create_access_token
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
@@ -12,6 +13,7 @@ from app.models.course_domain import CourseOffering, UserCourseAttempt, UserCour
 from app.services.course_catalog_matcher import find_course_by_normalized_code
 from app.models.user import User
 from app.models.user_role import UserRole
+from app.services.academic_curriculum_sync import sync_curriculum_requirements_from_file
 
 
 @compiles(JSONB, "sqlite")
@@ -106,6 +108,57 @@ def test_update_profile_and_get_summary(client, app):
     summary = client.get("/academic-map/summary", headers=headers)
     assert summary.status_code == 200
     assert summary.get_json()["profile"]["cohort"] == "2025"
+
+
+def test_summary_route_handles_common_core_many_records_and_targets_quickly(client, app):
+    user_id, headers = create_user_and_headers(app, "common_core_perf_user")
+    ucug_codes = [
+        "UCUG1000", "UCUG1001", "UCUG1050", "UCUG1051", "UCUG1052", "UCUG1052A",
+        "UCUG1052I", "UCUG1052S", "UCUG1053", "UCUG1070", "UCUG1071", "UCUG1072",
+        "UCUG1073", "UCUG1074", "UCUG1077", "UCUG1500", "UCUG1501", "UCUG1502",
+        "UCUG1503", "UCUG1504", "UCUG1505", "UCUG1506", "UCUG1507", "UCUG2500",
+        "UCUG2603", "UCUG1600", "UCUG1603", "UCUG1604", "UCUG1702", "UCUG1900",
+        "UCUG1903", "UCUG1905", "UCUG1907", "UCUG1800", "UCUG1804", "UCUG1807",
+        "UCUG1808", "UCUG1809", "UCUG3801", "UCUG2304",
+    ]
+    with app.app_context():
+        sync_curriculum_requirements_from_file()
+        profile = UserAcademicProfile.get_or_create_for_user(user_id)
+        profile.cohort = "2025"
+        profile.target_majors = ["AI", "DSA", "AMAT", "SMMG", "FTEC", "ROAS", "MICS"]
+        for code in ucug_codes:
+            course = Course.query.filter_by(code=code).first()
+            if course is None:
+                course = Course(code=code, normalized_code=code, display_code=code, name=code, credits=3)
+                db.session.add(course)
+                db.session.flush()
+            db.session.add(UserCourseRecord(
+                user_id=user_id,
+                course_id=course.id,
+                course_code=code,
+                course_title=course.name,
+                units=3,
+                status=UserCourseRecord.STATUS_COMPLETED,
+            ))
+        db.session.commit()
+
+    def timeout_handler(_signum, _frame):
+        raise TimeoutError("academic map summary timed out")
+
+    previous = signal.signal(signal.SIGALRM, timeout_handler)
+    signal.setitimer(signal.ITIMER_REAL, 2.0)
+    try:
+        summary = client.get("/academic-map/summary", headers=headers)
+    except TimeoutError as exc:
+        pytest.fail(str(exc))
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+    assert summary.status_code == 200
+    payload = summary.get_json()
+    assert len(payload["requirement_matrix"]) == 7
+    assert len(payload["records"]) == len(ucug_codes)
 
 
 def test_update_profile_normalizes_legacy_major_aliases(client, app):

--- a/tests/test_academic_map_summary.py
+++ b/tests/test_academic_map_summary.py
@@ -266,6 +266,67 @@ def test_requirement_matrix_uses_catalog_title_for_unimported_courses(app):
     assert cell["title"] == "Calculus I"
 
 
+def test_requirement_matrix_returns_common_core_progress(app):
+    with app.app_context():
+        create_user(115, "common_core_progress")
+        program = CurriculumProgram(code="AI", name_en="Artificial Intelligence", cohort="2025", total_min_credits=120)
+        db.session.add(program)
+        db.session.flush()
+        db.session.add(CurriculumRequirementGroup(
+            program_id=program.id,
+            key="common_core",
+            name_en="University Common Core Courses",
+            category="common_core",
+            min_credits=30,
+            rule={
+                "rule_tree": {
+                    "type": "all_of",
+                    "children": [
+                        {
+                            "type": "choose",
+                            "key": "foundation_ctdl",
+                            "label_en": "CTDL",
+                            "min_courses": 1,
+                            "min_credits": 3,
+                            "courses": ["UCUG1000"],
+                            "area": "CTDL",
+                        },
+                        {
+                            "type": "choose",
+                            "key": "broadening_arts",
+                            "label_en": "Broadening: Arts",
+                            "kind": "elective",
+                            "min_credits": 3,
+                            "courses": ["UCUG1500", "UCUG1600"],
+                            "area": "A",
+                            "constraints": [{"type": "course_area", "value": "A", "min_credits": 3}],
+                        },
+                    ],
+                }
+            },
+            sort_order=1,
+        ))
+        db.session.add(UserAcademicProfile(user_id=115, cohort="2025", target_majors=["AI"]))
+        add_record(115, "UCUG1000", status="completed", units=3)
+        add_record(115, "UCUG1500", status="completed", units=3)
+        add_record(115, "UCUG1600", status="completed", units=3)
+        db.session.commit()
+
+        summary = build_academic_map_summary(115)
+
+    row = summary["requirement_matrix"][0]["rows"][0]
+    assert row["key"] == "common_core"
+    assert row["category"] == "common_core"
+    assert row["current"]["counted_credits"] == 6
+    assert row["current"]["required_credits"] == 6
+    assert [section["key"] for section in row["sections"]] == ["foundation_ctdl", "broadening_arts"]
+    broadening_cells = {cell["course_code"]: cell for cell in row["sections"][1]["cells"]}
+    assert broadening_cells["UCUG1500"]["allocation_status"] == "counted"
+    assert broadening_cells["UCUG1500"]["area"] == "A"
+    assert broadening_cells["UCUG1600"]["allocation_status"] == "candidate"
+    assert broadening_cells["UCUG1600"]["area"] == "H"
+
+
 def test_requirement_matrix_uses_choice_minimum_for_progress(app):
     with app.app_context():
         create_user(108, "matrix_choice")

--- a/tests/test_bundled_curriculum_requirements.py
+++ b/tests/test_bundled_curriculum_requirements.py
@@ -41,6 +41,57 @@ def _leaf_keys(group):
     return [leaf["key"] for leaf in group["rule"]["rule_tree"]["children"]]
 
 
+def test_bundled_payload_includes_common_core_for_every_program():
+    missing = [
+        (program["code"], program.get("cohorts") or [program.get("cohort")])
+        for program in PAYLOAD["programs"]
+        if not any(group["key"] == "common_core" for group in program["requirement_groups"])
+    ]
+    assert missing == []
+
+
+def test_ai_2025_common_core_matches_broadening_table():
+    common_core = _group("AI", "2025", "common_core")
+    leaves = {leaf["key"]: leaf for leaf in common_core["rule"]["rule_tree"]["children"]}
+
+    assert leaves["broadening_arts"]["min_credits"] == 3
+    assert leaves["broadening_humanities"]["min_credits"] == 3
+    assert leaves["broadening_social_analysis"]["min_credits"] == 3
+    assert leaves["broadening_elective"]["min_credits"] == 3
+    assert "broadening_science" not in leaves
+    assert "broadening_technology" not in leaves
+    assert leaves["broadening_elective"]["constraints"] == [
+        {"type": "exclude_course_areas", "values": ["S", "T"]}
+    ]
+
+
+def test_ftec_2025_common_core_matches_broadening_table():
+    common_core = _group("FTEC", "2025", "common_core")
+    leaves = {leaf["key"]: leaf for leaf in common_core["rule"]["rule_tree"]["children"]}
+
+    assert leaves["broadening_arts"]["min_credits"] == 3
+    assert leaves["broadening_humanities"]["min_credits"] == 3
+    assert leaves["broadening_science"]["min_credits"] == 3
+    assert leaves["broadening_elective"]["min_credits"] == 3
+    assert "broadening_technology" not in leaves
+    assert "broadening_social_analysis" not in leaves
+    assert leaves["broadening_elective"]["constraints"] == [
+        {"type": "exclude_course_areas", "values": ["T", "SA"]}
+    ]
+
+
+def test_roas_2025_common_core_matches_broadening_table():
+    common_core = _group("ROAS", "2025", "common_core")
+    leaves = {leaf["key"]: leaf for leaf in common_core["rule"]["rule_tree"]["children"]}
+
+    assert leaves["broadening_arts"]["min_credits"] == 3
+    assert leaves["broadening_humanities"]["min_credits"] == 3
+    assert leaves["broadening_science"]["min_credits"] == 3
+    assert leaves["broadening_social_analysis"]["min_credits"] == 3
+    assert "broadening_technology" not in leaves
+    assert "broadening_elective" not in leaves
+
+
 def test_ai_2025_linear_algebra_is_not_fixed():
     group = _group("AI", "2025", "fundamental_courses")
     fixed = _leaf(group, "fixed_courses")

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -93,6 +93,13 @@ def test_deploy_workflows_fail_on_migration_errors_and_use_committed_revisions()
         assert "flask db migrate" not in deploy_workflow
 
 
+def test_dev_database_initialization_syncs_curriculum_requirements():
+    init_script = (ROOT / "app" / "scripts" / "init_db.py").read_text(encoding="utf-8")
+
+    assert "sync_curriculum_requirements_from_file" in init_script
+    assert init_script.index("init_identity_types()") < init_script.index("init_curriculum_requirements()")
+
+
 def test_production_deploy_backfills_2024_25_scheduler_offerings():
     deploy_workflow = (ROOT / ".github" / "workflows" / "deploy-backend-prod.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary\n- Add UCUG Common Core requirement groups to academic map curriculum payload\n- Sync bundled curriculum requirements during deploy initialization\n- Add area-aware requirement evaluation and cap allocation search so summary stays responsive with many UCUG records\n\n## Migration / data scope\n- Source: bundled curriculum requirements from updated Common Core materials\n- Target: production curriculum_programs and curriculum_requirement_groups via existing deploy init sync\n- Type: add/update curriculum requirement groups only\n- User course records, grades, posts, scheduler records, and runtime data are not changed\n- Rollback: revert backend production deploy; bundled sync is authoritative and removes groups absent from payload\n\n## Verification\n- pytest tests/test_deploy_health.py tests/test_academic_curriculum_evaluator.py tests/test_academic_curriculum_sync.py tests/test_bundled_curriculum_requirements.py tests/test_academic_map_summary.py tests/test_academic_map_routes.py tests/test_academic_map_models.py -q\n- 118 passed\n- Dev deploy verified and localhost route-level summary regression tested