### PR TITLE
Add verified scheduler popularity signals

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -15,20 +15,20 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@v3
 
-    - name: Run tests locally (if available)
+    - name: Run scheduler integration tests
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        # Check if pytest is in requirements, if not skip tests
-        if grep -q "pytest" requirements.txt; then
-          python -m pytest tests/ || exit 1
-        else
-          echo "No pytest in requirements, skipping tests"
-          # Set minimal env vars for import test
-          export OSS_BUCKET_NAME="dummy"
-          export OSS_ENDPOINT="dummy.endpoint.com"
-          python -c "import sys; sys.path.append('.'); print('Basic import test passed')" || echo "Import test skipped"
-        fi
+        pip install -r requirements-dev.txt
+        python -m pytest \
+          tests/test_scheduler_models.py \
+          tests/test_scheduler_routes.py \
+          tests/test_scheduler_schema_support.py \
+          tests/test_scheduler_data_import.py \
+          tests/test_import_scheduler_offerings.py \
+          tests/test_scheduler_map_seed.py \
+          tests/test_course_domain_migration.py \
+          tests/test_course_domain_routes.py \
+          -q
 
     - name: Deploy via SSH
       uses: appleboy/ssh-action@master

--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -15,20 +15,11 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@v3
 
-    - name: Run scheduler integration tests
+    - name: Run backend tests
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        python -m pytest \
-          tests/test_scheduler_models.py \
-          tests/test_scheduler_routes.py \
-          tests/test_scheduler_schema_support.py \
-          tests/test_scheduler_data_import.py \
-          tests/test_import_scheduler_offerings.py \
-          tests/test_scheduler_map_seed.py \
-          tests/test_course_domain_migration.py \
-          tests/test_course_domain_routes.py \
-          -q
+        python -m pytest tests/ -q
 
     - name: Deploy via SSH
       uses: appleboy/ssh-action@master

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -225,6 +225,7 @@ def _auto_init_course_domain_support():
         UserSectionSelection,
         CoursePostOfferingTarget,
     )
+    from app.models.scheduler_popularity import SchedulerPopularityEvent
 
     db.metadata.create_all(bind=db.engine, tables=[Course.__table__], checkfirst=True)
 
@@ -259,6 +260,7 @@ def _auto_init_course_domain_support():
             UserOfferingCart.__table__,
             UserSectionSelection.__table__,
             CoursePostOfferingTarget.__table__,
+            SchedulerPopularityEvent.__table__,
         ],
         checkfirst=True,
     )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -34,6 +34,7 @@ from .scheduler_section import SchedulerSection
 from .scheduler_lecture import SchedulerLecture
 from .scheduler_map import SchedulerMapComponent, SchedulerMapLine
 from .scheduler_cart import SchedulerUserCourseCart, SchedulerUserBundleCart
+from .scheduler_popularity import SchedulerPopularityEvent
 from .course_domain import (
     CourseCatalogVersion,
     CourseCatalogRequirement,

--- a/app/models/course_domain.py
+++ b/app/models/course_domain.py
@@ -277,6 +277,12 @@ class UserOfferingCart(db.Model):
     __table_args__ = (
         db.UniqueConstraint("user_id", "offering_id", name="uq_user_offering_cart"),
         db.Index("idx_user_offering_carts_user", "user_id"),
+        db.Index(
+            "idx_user_offering_carts_popularity",
+            "offering_id",
+            "enabled",
+            "user_id",
+        ),
     )
 
 
@@ -303,6 +309,13 @@ class UserSectionSelection(db.Model):
             name="valid_user_section_selection_source",
         ),
         db.Index("idx_user_section_selections_user_offering", "user_id", "offering_id"),
+        db.Index(
+            "idx_user_section_selections_popularity",
+            "offering_id",
+            "enabled",
+            "section_id",
+            "user_id",
+        ),
     )
 
 

--- a/app/models/scheduler_popularity.py
+++ b/app/models/scheduler_popularity.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from app.extensions import db
+
+
+def utcnow():
+    return datetime.now(timezone.utc)
+
+
+class SchedulerPopularityEvent(db.Model):
+    """Anonymous transition log for scheduler popularity trends.
+
+    Current popularity is always computed from cart and section-selection state.
+    These events intentionally contain no user identifier and are not exposed by
+    a public API.
+    """
+
+    __tablename__ = "scheduler_popularity_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    offering_id = db.Column(
+        db.Integer,
+        db.ForeignKey("course_offerings.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    section_id = db.Column(
+        db.Integer,
+        db.ForeignKey("course_sections.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    section_source_id = db.Column(db.String(32), nullable=True)
+    from_state = db.Column(db.String(16), nullable=True)
+    to_state = db.Column(db.String(16), nullable=True)
+    reason = db.Column(db.String(32), nullable=False)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        default=utcnow,
+        nullable=False,
+    )
+
+    offering = db.relationship("CourseOffering", backref=db.backref("popularity_events", lazy="dynamic"))
+    section = db.relationship("CourseSection", backref=db.backref("popularity_events", lazy="dynamic"))
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "from_state IS NULL OR from_state IN ('looking', 'scheduling')",
+            name="valid_scheduler_popularity_from_state",
+        ),
+        db.CheckConstraint(
+            "to_state IS NULL OR to_state IN ('looking', 'scheduling')",
+            name="valid_scheduler_popularity_to_state",
+        ),
+        db.CheckConstraint(
+            "(from_state IS NOT NULL OR to_state IS NOT NULL) "
+            "AND (from_state IS NULL OR to_state IS NULL OR from_state <> to_state)",
+            name="valid_scheduler_popularity_transition",
+        ),
+        db.CheckConstraint(
+            "reason IN ('cart_added', 'cart_removed', 'course_toggled', "
+            "'bundle_toggled', 'layer_toggled')",
+            name="valid_scheduler_popularity_reason",
+        ),
+        db.Index(
+            "idx_scheduler_popularity_offering_created",
+            "offering_id",
+            "created_at",
+        ),
+        db.Index(
+            "idx_scheduler_popularity_section_created",
+            "section_id",
+            "created_at",
+        ),
+        db.Index(
+            "idx_scheduler_popularity_source_created",
+            "offering_id",
+            "section_source_id",
+            "created_at",
+        ),
+    )

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,12 +1,21 @@
 # app/routes/auth.py
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, current_app, request, jsonify
 from app.models.user import User
 from app.models.token import TokenBlacklist
 from app.models.user_role import UserRole
-from app.extensions import db, jwt
+from app.extensions import cache, db, jwt
 from app.services.email_service import EmailService
 from app.services.content_moderation_service import content_moderation
+from app.services.institutional_email import (
+    acquire_email_transaction_lock,
+    active_email_owner,
+    active_users_with_email,
+    canonical_email_account,
+    is_institutional_email,
+    normalize_email,
+)
 import re
+import secrets
 from flask_jwt_extended import (
     create_access_token, 
     create_refresh_token,
@@ -18,6 +27,98 @@ from flask_jwt_extended import (
 from datetime import datetime, timezone
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+EMAIL_VERIFICATION_FAILURE_LIMIT = 5
+EMAIL_VERIFICATION_FAILURE_WINDOW_SECONDS = 15 * 60
+EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS = 60
+
+
+def _verification_attempt_key(user_id):
+    return f"email-verification:failures:{user_id}"
+
+
+def _verification_resend_key(user_id):
+    return f"email-verification:resend:{user_id}"
+
+
+def _verification_failure_count(user_id):
+    """Read the failure counter, failing open if the cache is unavailable."""
+    try:
+        return int(cache.get(_verification_attempt_key(user_id)) or 0)
+    except Exception as exc:
+        current_app.logger.warning(
+            "Email verification attempt cache unavailable for user %s: %s",
+            user_id,
+            exc,
+        )
+        return 0
+
+
+def _record_verification_failure(user_id):
+    """Increment the bounded failure counter without making cache a dependency."""
+    key = _verification_attempt_key(user_id)
+    try:
+        if cache.add(key, 1, timeout=EMAIL_VERIFICATION_FAILURE_WINDOW_SECONDS):
+            return 1
+        backend_increment = getattr(cache.cache, "inc", None)
+        if callable(backend_increment):
+            return int(backend_increment(key))
+
+        # Some custom Flask-Caching backends expose only the portable facade.
+        # This branch is not atomic, but still preserves throttling rather than
+        # disabling it; Redis and SimpleCache both use the atomic branch above.
+        failures = int(cache.get(key) or 0) + 1
+        cache.set(key, failures, timeout=EMAIL_VERIFICATION_FAILURE_WINDOW_SECONDS)
+        return failures
+    except Exception as exc:
+        current_app.logger.warning(
+            "Could not record email verification failure for user %s: %s",
+            user_id,
+            exc,
+        )
+        return None
+
+
+def _clear_verification_failures(user_id):
+    try:
+        cache.delete(_verification_attempt_key(user_id))
+    except Exception as exc:
+        current_app.logger.warning(
+            "Could not clear email verification failures for user %s: %s",
+            user_id,
+            exc,
+        )
+
+
+def _claim_resend_window(user_id):
+    """Atomically claim a resend slot where the cache backend supports add()."""
+    try:
+        return bool(cache.add(
+            _verification_resend_key(user_id),
+            1,
+            timeout=EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+        ))
+    except Exception as exc:
+        current_app.logger.warning(
+            "Email verification resend cache unavailable for user %s: %s",
+            user_id,
+            exc,
+        )
+        return True
+
+
+def _verification_code_matches(user, submitted_code):
+    expires_at = user.email_verification_expires_at
+    if not user.email_verification_code or not expires_at:
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if datetime.now(timezone.utc) > expires_at:
+        return False
+    return secrets.compare_digest(
+        str(user.email_verification_code),
+        str(submitted_code),
+    )
 
 # Setup the JWT loaders
 @jwt.user_lookup_loader
@@ -43,7 +144,7 @@ def register():
         return jsonify({"msg": "Username, password, and email are required"}), 400
     
     username = data['username'].strip()
-    email = data['email'].strip().lower()
+    email = normalize_email(data['email'])
     password = data['password']
     
     # Basic validation
@@ -56,7 +157,7 @@ def register():
     if not is_email(email):
         return jsonify({"msg": "Invalid email format"}), 400
     
-    if not is_hkust_email(email):
+    if not is_institutional_email(email):
         return jsonify({"msg": "Only HKUST-GZ email addresses are allowed (connect.hkust-gz.edu.cn or hkust-gz.edu.cn)"}), 400
     
     # Content moderation check for username
@@ -78,11 +179,16 @@ def register():
     if User.query.filter_by(username=username, is_deleted=False).first():
         return jsonify({"msg": "Username already exists"}), 400
     
-    # Check if email already exists
-    if User.query.filter_by(email=email, is_deleted=False).first():
-        return jsonify({"msg": "Email already registered"}), 400
-    
     try:
+        acquire_email_transaction_lock(email)
+
+        # Email identity is case-insensitive throughout the application. The
+        # transaction lock prevents two PostgreSQL requests passing this check
+        # concurrently before either account is committed.
+        if active_email_owner(email):
+            db.session.rollback()
+            return jsonify({"msg": "Email already registered"}), 400
+
         # Get default user role
         user_role = UserRole.query.filter_by(name=UserRole.USER).first()
         if not user_role:
@@ -149,12 +255,54 @@ def verify_email():
     
     if user.email_verified:
         return jsonify({"msg": "Email already verified"}), 400
-    
-    if user.verify_email_code(verification_code):
+
+    normalized_email = normalize_email(user.email)
+    if not is_institutional_email(normalized_email):
+        return jsonify({"msg": "Only HKUST-GZ email addresses can be verified"}), 400
+
+    if _verification_failure_count(user.id) >= EMAIL_VERIFICATION_FAILURE_LIMIT:
+        response = jsonify({"msg": "Too many failed verification attempts. Please try again later."})
+        response.headers["Retry-After"] = str(EMAIL_VERIFICATION_FAILURE_WINDOW_SECONDS)
+        return response, 429
+
+    try:
+        acquire_email_transaction_lock(normalized_email)
+
+        # Re-query after taking the per-address lock so the ownership decision
+        # observes any account committed by a concurrent request.
+        user = User.query.get(user_id)
+        canonical_account = canonical_email_account(normalized_email)
+        other_verified_account = active_users_with_email(normalized_email).filter(
+            User.id != user.id,
+            User.email_verified.is_(True),
+        ).first()
+
+        if not canonical_account or canonical_account.id != user.id or other_verified_account:
+            db.session.rollback()
+            return jsonify({
+                "msg": "This email address belongs to another active account"
+            }), 409
+
+        if not _verification_code_matches(user, verification_code):
+            db.session.rollback()
+            _record_verification_failure(user.id)
+            return jsonify({"msg": "Invalid or expired verification code"}), 400
+
+        user.email = normalized_email
+        user.email_verified = True
+        user.email_verification_code = None
+        user.email_verification_expires_at = None
         db.session.commit()
+        _clear_verification_failures(user.id)
         return jsonify({"msg": "Email verified successfully"}), 200
-    else:
-        return jsonify({"msg": "Invalid or expired verification code"}), 400
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.exception(
+            "Email verification failed for user %s: %s",
+            user_id,
+            exc,
+        )
+        return jsonify({"msg": "Email verification failed"}), 500
 
 @bp.route('/resend-verification', methods=['POST'])
 def resend_verification():
@@ -171,11 +319,33 @@ def resend_verification():
     
     if user.email_verified:
         return jsonify({"msg": "Email already verified"}), 400
+
+    normalized_email = normalize_email(user.email)
+    if not is_institutional_email(normalized_email):
+        return jsonify({"msg": "Only HKUST-GZ email addresses can be verified"}), 400
+
+    if not _claim_resend_window(user.id):
+        response = jsonify({"msg": "Please wait before requesting another verification email"})
+        response.headers["Retry-After"] = str(EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS)
+        return response, 429
     
     try:
+        acquire_email_transaction_lock(normalized_email)
+        canonical_account = canonical_email_account(normalized_email)
+        other_verified_account = active_users_with_email(normalized_email).filter(
+            User.id != user.id,
+            User.email_verified.is_(True),
+        ).first()
+        if not canonical_account or canonical_account.id != user.id or other_verified_account:
+            db.session.rollback()
+            return jsonify({
+                "msg": "This email address belongs to another active account"
+            }), 409
+
         # Generate new verification code
         email_service = EmailService.from_app_config()
         verification_code = email_service.generate_verification_code()
+        user.email = normalized_email
         user.set_email_verification_code(verification_code)
         
         # Send verification email
@@ -208,14 +378,14 @@ def forgot_password():
     if not email:
         return jsonify({"msg": "Email is required"}), 400
     
-    email = email.strip().lower()
+    email = normalize_email(email)
     if not is_email(email):
         return jsonify({"msg": "Invalid email format"}), 400
     
     if not is_hkust_email(email):
         return jsonify({"msg": "Only HKUST-GZ email addresses are allowed"}), 400
     
-    user = User.query.filter_by(email=email, is_deleted=False).first()
+    user = active_email_owner(email)
     if not user:
         # Don't reveal if email exists for security
         return jsonify({"msg": "If the email exists, a password reset link has been sent"}), 200
@@ -319,26 +489,8 @@ def is_email(text):
     return re.match(email_text, text) is not None
 
 def is_hkust_email(email):
-    """Check if email belongs to HKUST-GZ domains"""
-    if not email:
-        return False
-    
-    email = email.lower().strip()
-    
-    # Basic email format check first
-    if not is_email(email):
-        return False
-    
-    allowed_domains = ['connect.hkust-gz.edu.cn', 'hkust-gz.edu.cn']
-    
-    for domain in allowed_domains:
-        if email.endswith('@' + domain):
-            # Additional check to ensure it's exactly the domain, not a subdomain
-            email_parts = email.split('@')
-            if len(email_parts) == 2 and email_parts[1] == domain:
-                return True
-    
-    return False
+    """Backward-compatible HKUST-GZ email validation API."""
+    return is_institutional_email(email)
 
 @bp.route('/login', methods=['POST'])
 def login():

--- a/app/routes/scheduler.py
+++ b/app/routes/scheduler.py
@@ -368,7 +368,11 @@ def get_cart(semester):
     domain_items = (
         UserOfferingCart.query
         .join(CourseOffering)
-        .filter(UserOfferingCart.user_id == user_id, CourseOffering.semester_id == semester)
+        .filter(
+            UserOfferingCart.user_id == user_id,
+            CourseOffering.semester_id == semester,
+            CourseOffering.status == 'offered',
+        )
         .all()
     )
     result = []

--- a/app/routes/scheduler.py
+++ b/app/routes/scheduler.py
@@ -8,10 +8,19 @@ from app.models.course_domain import (
     UserSectionSelection,
 )
 from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
+from app.models.user import User
 from app.extensions import db
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from sqlalchemy import func, or_
 from app.services.course_domain import current_catalog_version, find_offering, normalize_course_code
+from app.services.scheduler_popularity import (
+    build_popularity_snapshot,
+    is_canonical_popularity_user,
+    is_eligible_popularity_user,
+    normalize_popularity_course_codes,
+    popularity_state,
+    record_popularity_transition,
+)
 
 bp = Blueprint('scheduler', __name__, url_prefix='/scheduler')
 
@@ -29,6 +38,35 @@ def _json_body():
     if not isinstance(data, dict):
         return None, (jsonify({'error': 'Invalid JSON body'}), 400)
     return data, None
+
+
+def _requested_enabled(data, default):
+    if 'enabled' not in data:
+        return default, None
+    enabled = data['enabled']
+    if not isinstance(enabled, bool):
+        return None, (jsonify({'error': 'enabled must be a boolean'}), 400)
+    return enabled, None
+
+
+def _offered_offering(course, semester):
+    offering = find_offering(course, semester) if course else None
+    if offering is None or offering.status != 'offered':
+        return None
+    return offering
+
+
+def _request_user():
+    try:
+        user_id = int(get_jwt_identity())
+    except (TypeError, ValueError):
+        return None
+    return db.session.get(User, user_id)
+
+
+def _eligible_popularity_contributor(user_id):
+    user = db.session.get(User, user_id)
+    return is_eligible_popularity_user(user) and is_canonical_popularity_user(user)
 
 
 def _find_course_by_code(code):
@@ -297,6 +335,37 @@ def get_course_detail(code):
     })
 
 
+# --- Popularity ---
+
+@bp.route('/popularity/<semester>', methods=['GET'])
+@jwt_required()
+def get_popularity(semester):
+    """Return anonymous current planner counts for courses in the viewer's cart."""
+    viewer = _request_user()
+    if viewer is None or viewer.is_deleted:
+        return jsonify({'error': 'Authenticated user not found'}), 401
+    if not is_eligible_popularity_user(viewer) or not is_canonical_popularity_user(viewer):
+        return jsonify({'error': 'verified_institutional_account_required'}), 403
+
+    try:
+        course_codes = normalize_popularity_course_codes(
+            request.args.getlist('course_codes'),
+            limit=30,
+        )
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    payload = build_popularity_snapshot(
+        viewer_id=viewer.id,
+        semester_id=str(semester).strip(),
+        course_codes=course_codes,
+    )
+    response = jsonify(payload)
+    response.headers['Cache-Control'] = 'private, no-store'
+    response.headers['Vary'] = 'Authorization'
+    return response
+
+
 # --- Cart CRUD ---
 
 def _serialize_cart_item(cart_item):
@@ -401,7 +470,7 @@ def add_to_cart(semester):
     if not course:
         return jsonify({'error': 'Course not found'}), 404
 
-    offering = find_offering(course, semester)
+    offering = _offered_offering(course, semester)
     if offering:
         existing = UserOfferingCart.query.filter_by(user_id=user_id, offering_id=offering.id).first()
         if existing:
@@ -413,6 +482,14 @@ def add_to_cart(semester):
 
         cart = UserOfferingCart(user_id=user_id, offering_id=offering.id, enabled=False)
         db.session.add(cart)
+        contributor_is_eligible = _eligible_popularity_contributor(user_id)
+        record_popularity_transition(
+            contributor_is_eligible=contributor_is_eligible,
+            offering_id=offering.id,
+            from_state=None,
+            to_state='looking',
+            reason='cart_added',
+        )
         for section in sections:
             db.session.add(UserSectionSelection(
                 user_id=user_id,
@@ -421,6 +498,14 @@ def add_to_cart(semester):
                 enabled=True,
                 source="cart",
             ))
+            record_popularity_transition(
+                contributor_is_eligible=contributor_is_eligible,
+                offering_id=offering.id,
+                section=section,
+                from_state=None,
+                to_state='looking',
+                reason='cart_added',
+            )
         db.session.commit()
         return jsonify(_serialize_cart_item(cart))
 
@@ -433,10 +518,45 @@ def remove_from_cart(semester, code):
     """Remove a course from the cart."""
     user_id = int(get_jwt_identity())
     course = _find_course_by_code(code)
-    offering = find_offering(course, semester) if course else None
+    offering = _offered_offering(course, semester)
     if offering:
-        cart = UserOfferingCart.query.filter_by(user_id=user_id, offering_id=offering.id).first()
+        cart = (
+            UserOfferingCart.query
+            .filter_by(user_id=user_id, offering_id=offering.id)
+            .with_for_update()
+            .first()
+        )
         if cart:
+            selected = (
+                UserSectionSelection.query
+                .join(CourseSection, CourseSection.id == UserSectionSelection.section_id)
+                .filter(
+                    UserSectionSelection.user_id == user_id,
+                    UserSectionSelection.offering_id == offering.id,
+                    UserSectionSelection.enabled.is_(True),
+                    CourseSection.offering_id == offering.id,
+                )
+                .with_for_update()
+                .all()
+            )
+            contributor_is_eligible = _eligible_popularity_contributor(user_id)
+            state = popularity_state(cart.enabled)
+            record_popularity_transition(
+                contributor_is_eligible=contributor_is_eligible,
+                offering_id=offering.id,
+                from_state=state,
+                to_state=None,
+                reason='cart_removed',
+            )
+            for selection in selected:
+                record_popularity_transition(
+                    contributor_is_eligible=contributor_is_eligible,
+                    offering_id=offering.id,
+                    section=selection.section,
+                    from_state=state,
+                    to_state=None,
+                    reason='cart_removed',
+                )
             UserSectionSelection.query.filter_by(user_id=user_id, offering_id=offering.id).delete()
             db.session.delete(cart)
             db.session.commit()
@@ -454,12 +574,53 @@ def toggle_course_enabled(semester, code):
     if error:
         return error
     course = _find_course_by_code(code)
-    offering = find_offering(course, semester) if course else None
+    offering = _offered_offering(course, semester)
     if offering:
-        cart = UserOfferingCart.query.filter_by(user_id=user_id, offering_id=offering.id).first()
+        cart = (
+            UserOfferingCart.query
+            .filter_by(user_id=user_id, offering_id=offering.id)
+            .with_for_update()
+            .first()
+        )
         if not cart:
             return jsonify({'error': 'Not in cart'}), 404
-        cart.enabled = data.get('enabled', not cart.enabled)
+        new_state, state_error = _requested_enabled(data, not cart.enabled)
+        if state_error:
+            return state_error
+        old_state = bool(cart.enabled)
+        if old_state != new_state:
+            selected = (
+                UserSectionSelection.query
+                .join(CourseSection, CourseSection.id == UserSectionSelection.section_id)
+                .filter(
+                    UserSectionSelection.user_id == user_id,
+                    UserSectionSelection.offering_id == offering.id,
+                    UserSectionSelection.enabled.is_(True),
+                    CourseSection.offering_id == offering.id,
+                )
+                .with_for_update()
+                .all()
+            )
+            contributor_is_eligible = _eligible_popularity_contributor(user_id)
+            old_popularity = popularity_state(old_state)
+            new_popularity = popularity_state(new_state)
+            record_popularity_transition(
+                contributor_is_eligible=contributor_is_eligible,
+                offering_id=offering.id,
+                from_state=old_popularity,
+                to_state=new_popularity,
+                reason='course_toggled',
+            )
+            for selection in selected:
+                record_popularity_transition(
+                    contributor_is_eligible=contributor_is_eligible,
+                    offering_id=offering.id,
+                    section=selection.section,
+                    from_state=old_popularity,
+                    to_state=new_popularity,
+                    reason='course_toggled',
+                )
+        cart.enabled = new_state
         db.session.commit()
         return jsonify({'course_code': course.code, 'enabled': cart.enabled})
 
@@ -475,9 +636,14 @@ def toggle_bundle_enabled(semester, code, bundle_id, layer):
     if error:
         return error
     course = _find_course_by_code(code)
-    offering = find_offering(course, semester) if course else None
+    offering = _offered_offering(course, semester)
     if offering:
-        cart = UserOfferingCart.query.filter_by(user_id=user_id, offering_id=offering.id).first()
+        cart = (
+            UserOfferingCart.query
+            .filter_by(user_id=user_id, offering_id=offering.id)
+            .with_for_update()
+            .first()
+        )
         sections = CourseSection.query.filter_by(
             offering_id=offering.id,
             bundle=bundle_id,
@@ -485,20 +651,27 @@ def toggle_bundle_enabled(semester, code, bundle_id, layer):
         ).all()
         if not cart or not sections:
             return jsonify({'error': 'Bundle not found'}), 404
-        new_state = data.get('enabled')
-        if new_state is None:
-            existing = UserSectionSelection.query.filter_by(
-                user_id=user_id,
-                offering_id=offering.id,
-                section_id=sections[0].id,
-            ).first()
-            new_state = not (existing.enabled if existing else True)
+        existing_selections = (
+            UserSectionSelection.query
+            .filter(
+                UserSectionSelection.user_id == user_id,
+                UserSectionSelection.offering_id == offering.id,
+                UserSectionSelection.section_id.in_([section.id for section in sections]),
+            )
+            .with_for_update()
+            .all()
+        )
+        selection_map = {selection.section_id: selection for selection in existing_selections}
+        first = selection_map.get(sections[0].id)
+        implicit_state = not (first.enabled if first else True)
+        new_state, state_error = _requested_enabled(data, implicit_state)
+        if state_error:
+            return state_error
+        contributor_is_eligible = _eligible_popularity_contributor(user_id)
+        selected_state = popularity_state(cart.enabled)
         for section in sections:
-            selection = UserSectionSelection.query.filter_by(
-                user_id=user_id,
-                offering_id=offering.id,
-                section_id=section.id,
-            ).first()
+            selection = selection_map.get(section.id)
+            was_enabled = bool(selection.enabled) if selection is not None else False
             if selection is None:
                 selection = UserSectionSelection(
                     user_id=user_id,
@@ -507,9 +680,18 @@ def toggle_bundle_enabled(semester, code, bundle_id, layer):
                     source="cart",
                 )
                 db.session.add(selection)
-            selection.enabled = bool(new_state)
+            selection.enabled = new_state
+            if was_enabled != new_state:
+                record_popularity_transition(
+                    contributor_is_eligible=contributor_is_eligible,
+                    offering_id=offering.id,
+                    section=section,
+                    from_state=selected_state if was_enabled else None,
+                    to_state=selected_state if new_state else None,
+                    reason='bundle_toggled',
+                )
         db.session.commit()
-        return jsonify({'id': bundle_id, 'layer': layer, 'enabled': bool(new_state)})
+        return jsonify({'id': bundle_id, 'layer': layer, 'enabled': new_state})
 
     return jsonify({'error': 'Bundle not found'}), 404
 
@@ -523,24 +705,38 @@ def toggle_layer_enabled(semester, code, layer):
     if error:
         return error
     course = _find_course_by_code(code)
-    offering = find_offering(course, semester) if course else None
+    offering = _offered_offering(course, semester)
     if offering:
-        cart = UserOfferingCart.query.filter_by(user_id=user_id, offering_id=offering.id).first()
+        cart = (
+            UserOfferingCart.query
+            .filter_by(user_id=user_id, offering_id=offering.id)
+            .with_for_update()
+            .first()
+        )
         sections = CourseSection.query.filter_by(offering_id=offering.id, layer=layer).all()
         if not cart or not sections:
             return jsonify({'error': 'No bundles found'}), 404
-        existing = UserSectionSelection.query.filter_by(
-            user_id=user_id,
-            offering_id=offering.id,
-            section_id=sections[0].id,
-        ).first()
-        new_state = data.get('enabled', not (existing.enabled if existing else True))
+        existing_selections = (
+            UserSectionSelection.query
+            .filter(
+                UserSectionSelection.user_id == user_id,
+                UserSectionSelection.offering_id == offering.id,
+                UserSectionSelection.section_id.in_([section.id for section in sections]),
+            )
+            .with_for_update()
+            .all()
+        )
+        selection_map = {selection.section_id: selection for selection in existing_selections}
+        first = selection_map.get(sections[0].id)
+        implicit_state = not (first.enabled if first else True)
+        new_state, state_error = _requested_enabled(data, implicit_state)
+        if state_error:
+            return state_error
+        contributor_is_eligible = _eligible_popularity_contributor(user_id)
+        selected_state = popularity_state(cart.enabled)
         for section in sections:
-            selection = UserSectionSelection.query.filter_by(
-                user_id=user_id,
-                offering_id=offering.id,
-                section_id=section.id,
-            ).first()
+            selection = selection_map.get(section.id)
+            was_enabled = bool(selection.enabled) if selection is not None else False
             if selection is None:
                 selection = UserSectionSelection(
                     user_id=user_id,
@@ -549,9 +745,18 @@ def toggle_layer_enabled(semester, code, layer):
                     source="cart",
                 )
                 db.session.add(selection)
-            selection.enabled = bool(new_state)
+            selection.enabled = new_state
+            if was_enabled != new_state:
+                record_popularity_transition(
+                    contributor_is_eligible=contributor_is_eligible,
+                    offering_id=offering.id,
+                    section=section,
+                    from_state=selected_state if was_enabled else None,
+                    to_state=selected_state if new_state else None,
+                    reason='layer_toggled',
+                )
         db.session.commit()
-        return jsonify({'ok': True, 'enabled': bool(new_state), 'count': len(sections)})
+        return jsonify({'ok': True, 'enabled': new_state, 'count': len(sections)})
 
     return jsonify({'error': 'No bundles found'}), 404
 

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -9,6 +9,12 @@ from app.models.oauth_client import OAuthClient
 import re
 from app.extensions import db
 from app.services.content_moderation_service import content_moderation
+from app.services.institutional_email import (
+    acquire_email_transaction_lock,
+    active_email_owner,
+    is_institutional_email,
+    normalize_email,
+)
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from datetime import datetime, timezone
 from sqlalchemy.sql import func
@@ -196,15 +202,33 @@ def update_user(user_id):
         user.username = data['username']
         
     if 'email' in data:
+        normalized_email = normalize_email(data['email'])
+
         # Validate email format
-        is_valid, error_msg = validate_email(data['email'])
+        is_valid, error_msg = validate_email(normalized_email)
         if not is_valid:
             return jsonify({"msg": error_msg}), 400
-            
-        user.email = data['email']
-        # Reset email verification if email changed
-        if data['email'] != user.email:
+
+        if not is_institutional_email(normalized_email):
+            return jsonify({
+                "msg": "Only HKUST-GZ email addresses are allowed (connect.hkust-gz.edu.cn or hkust-gz.edu.cn)"
+            }), 400
+
+        current_normalized_email = normalize_email(user.email)
+        if normalized_email != current_normalized_email:
+            acquire_email_transaction_lock(normalized_email)
+            if active_email_owner(normalized_email, exclude_user_id=user.id):
+                db.session.rollback()
+                return jsonify({"msg": "Email already registered by another user"}), 400
+
+            user.email = normalized_email
             user.email_verified = False
+            user.email_verification_code = None
+            user.email_verification_expires_at = None
+        elif user.email != normalized_email:
+            # Canonicalize legacy mixed-case storage without invalidating an
+            # already verified principal when the identity did not change.
+            user.email = normalized_email
             
     if 'phone_number' in data:
         # Validate phone format
@@ -361,7 +385,7 @@ def add_email_to_existing_user(user_id):
         return jsonify({"msg": "User not found"}), 404
     
     data = request.get_json() or {}
-    email = data.get('email', '').strip().lower()
+    email = normalize_email(data.get('email'))
     
     if not email:
         return jsonify({"msg": "Email is required"}), 400
@@ -371,17 +395,15 @@ def add_email_to_existing_user(user_id):
     if not is_valid:
         return jsonify({"msg": error_msg}), 400
     
-    # Check HKUST domain requirement (reuse from auth.py)
-    from app.routes.auth import is_hkust_email
-    if not is_hkust_email(email):
+    if not is_institutional_email(email):
         return jsonify({"msg": "Only HKUST-GZ email addresses are allowed (connect.hkust-gz.edu.cn or hkust-gz.edu.cn)"}), 400
     
-    # Check if email already exists
-    existing_user = User.query.filter_by(email=email, is_deleted=False).first()
-    if existing_user and existing_user.id != user_id:
-        return jsonify({"msg": "Email already registered by another user"}), 400
-    
     try:
+        acquire_email_transaction_lock(email)
+        if active_email_owner(email, exclude_user_id=user_id):
+            db.session.rollback()
+            return jsonify({"msg": "Email already registered by another user"}), 400
+
         # Update email and reset verification status
         user.email = email
         user.email_verified = False

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, request, jsonify
 from app.models.user import User
-from app.models.user_role import UserRole as UserRoleModel
 from app.models.post import Post
 from app.models.comment import Comment
 from app.models.reaction import Reaction
@@ -60,73 +59,17 @@ def validate_phone(phone):
         return False, "Phone number must be 10-15 digits, optionally with a + prefix"
     return True, ""
 
-# Add a try-except block to the create_user function
 @bp.route('', methods=['POST'])
 def create_user():
-    try:
-        data = request.get_json() or {}
-        
-        # Required fields
-        if not data.get('username'):
-            return jsonify({"msg": "Username is required"}), 400
-        if not data.get('password'):  # Changed from password_hash
-            return jsonify({"msg": "Password is required"}), 400
-        
-        # Validate username format
-        is_valid, error_msg = validate_username(data['username'])
-        if not is_valid:
-            return jsonify({"msg": error_msg}), 400
-        
-        # Content moderation check for username
-        moderation_result = content_moderation.moderate_text(
-            content=data['username'],
-            data_id=f"username_create_{datetime.now().timestamp()}"
-        )
-        
-        if not moderation_result['is_safe']:
-            from flask import current_app
-            current_app.logger.warning(f"Content moderation blocked username creation: {data['username']} - {moderation_result['reason']}")
-            return jsonify({
-                "msg": "Username violates community guidelines and cannot be used",
-                "details": moderation_result['reason'],
-                "risk_level": moderation_result['risk_level']
-            }), 400
-        
-        # Validate email format if provided
-        is_valid, error_msg = validate_email(data.get('email', ''))
-        if not is_valid:
-            return jsonify({"msg": error_msg}), 400
-        
-        # Validate phone format if provided
-        is_valid, error_msg = validate_phone(data.get('phone_number', ''))
-        if not is_valid:
-            return jsonify({"msg": error_msg}), 400
-        
-        # Check if username already exists
-        if User.query.filter_by(username=data['username'], is_deleted=False).first():
-            return jsonify({"msg": "Username already exists"}), 400
-        
-        # Get default role_id (regular user)
-        default_role = UserRoleModel.query.filter_by(name=UserRoleModel.USER).first()
-        if not default_role:
-            return jsonify({"msg": "Default user role not found in database"}), 500
-        
-        # Create new user (no avatar on creation, must be uploaded separately)
-        user = User(
-            username=data['username'],
-            email=data.get('email', ''),
-            phone_number=data.get('phone_number', ''),
-            role_id=data.get('role_id', default_role.id)  # Use role_id from role table
-        )
-        user.set_password(data['password'])  # Changed from password_hash
-        
-        db.session.add(user)
-        db.session.commit()
-        
-        return jsonify(user.to_dict(include_contact=True)), 201
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({"msg": f"An error occurred: {str(e)}"}), 500
+    """Compatibility alias for the canonical public registration endpoint.
+
+    Keeping all unauthenticated account creation on one code path prevents this
+    legacy endpoint from bypassing institutional-email ownership, verification
+    setup, or the forced default user role.
+    """
+    from app.routes.auth import register
+
+    return register()
 
 @bp.route('/<int:user_id>', methods=['GET'])
 @jwt_required()

--- a/app/scripts/import_scheduler_offerings.py
+++ b/app/scripts/import_scheduler_offerings.py
@@ -32,11 +32,12 @@ from app.config import Config, normalize_database_config
 from app.extensions import db
 from app import models as _models  # noqa: F401
 from app.models.course import Course
-from app.models.course_domain import CourseCatalogVersion, CourseMeeting, CourseOffering, CourseSection
+from app.models.course_domain import CourseCatalogVersion, CourseOffering
 from app.models.scheduler_cart import SchedulerUserCourseCart
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_section import SchedulerSection
 from app.services.course_domain import display_course_code, normalize_course_code
+from app.services.scheduler_domain_sync import sync_offering_sections
 
 
 logger = logging.getLogger(__name__)
@@ -430,29 +431,6 @@ def apply_offerings(snapshot: OfferingSnapshot) -> ImportPlan:
     plan = build_import_plan(snapshot)
 
     try:
-        target_offering_ids = [
-            offering_id for (offering_id,) in (
-                db.session.query(CourseOffering.id)
-                .filter_by(semester_id=snapshot.semester_id)
-                .all()
-            )
-        ]
-        if target_offering_ids:
-            target_section_ids = [
-                section_id for (section_id,) in (
-                    db.session.query(CourseSection.id)
-                    .filter(CourseSection.offering_id.in_(target_offering_ids))
-                    .all()
-                )
-            ]
-            if target_section_ids:
-                CourseMeeting.query.filter(CourseMeeting.section_id.in_(target_section_ids)).delete(
-                    synchronize_session=False
-                )
-            CourseSection.query.filter(CourseSection.offering_id.in_(target_offering_ids)).delete(
-                synchronize_session=False
-            )
-
         SchedulerLecture.query.filter_by(semester_id=snapshot.semester_id).delete(
             synchronize_session=False
         )
@@ -532,10 +510,15 @@ def apply_offerings(snapshot: OfferingSnapshot) -> ImportPlan:
             version_by_code[item.course_code] = version
         db.session.flush()
 
-        offered_course_codes = {item.course_code for item in snapshot.courses if item.sections}
+        offered_course_codes = {
+            normalize_course_code(item.course_code)
+            for item in snapshot.courses
+            if item.sections
+        }
         for offering in CourseOffering.query.filter_by(semester_id=snapshot.semester_id).all():
             if normalize_course_code(offering.course.code) not in offered_course_codes:
                 offering.status = "archived"
+                sync_offering_sections(offering, [])
 
         for item in snapshot.courses:
             course = course_by_code[item.course_code]
@@ -562,30 +545,9 @@ def apply_offerings(snapshot: OfferingSnapshot) -> ImportPlan:
                 offering.source = "scheduler_offerings"
                 offering.status = "offered"
                 db.session.flush()
+                sync_offering_sections(offering, item.sections)
 
             for section in item.sections:
-                domain_section = CourseSection(
-                    offering_id=offering.id,
-                    source_section_id=section.section_id,
-                    name=section.name,
-                    section_type=section.section_type,
-                    bundle=section.bundle,
-                    layer=section.layer,
-                    quota=section.quota,
-                    is_main=section.is_main,
-                )
-                db.session.add(domain_section)
-                db.session.flush()
-                for lecture in section.lectures:
-                    db.session.add(CourseMeeting(
-                        section_id=domain_section.id,
-                        day=lecture.day,
-                        start_time=lecture.start_time,
-                        end_time=lecture.end_time,
-                        room=lecture.room,
-                        instructor_text=lecture.instructor,
-                    ))
-
                 db.session.add(SchedulerSection(
                     semester_id=section.semester_id,
                     section_id=section.section_id,

--- a/app/scripts/migrate_scheduler_data.py
+++ b/app/scripts/migrate_scheduler_data.py
@@ -22,6 +22,7 @@ from app.models.course import Course
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
 from app.models.scheduler_section import SchedulerSection
+from app.services.course_domain_migration import migrate_offerings
 
 
 class SnapshotValidationError(RuntimeError):
@@ -197,6 +198,14 @@ def import_snapshot(source_conn):
                 x_coordinate=row[3],
                 category=row[4],
             ))
+        db.session.flush()
+
+        semester_ids = sorted({row[0] for row in snapshot.sections})
+        migrate_offerings(
+            apply=True,
+            semester_ids=semester_ids,
+            archive_missing=True,
+        )
         db.session.flush()
 
         summary = {

--- a/app/services/course_domain_migration.py
+++ b/app/services/course_domain_migration.py
@@ -36,6 +36,7 @@ from app.services.course_domain import (
     normalize_course_code,
     subject_for_code,
 )
+from app.services.scheduler_domain_sync import sync_offering_sections
 from app.utils.semester import normalize_offering_identifier
 
 
@@ -345,9 +346,15 @@ def _current_version_for_course(course_id: int) -> CourseCatalogVersion | None:
     )
 
 
-def migrate_offerings(*, apply: bool, semester_ids: Iterable[str] | None = None) -> MigrationSummary:
+def migrate_offerings(
+    *,
+    apply: bool,
+    semester_ids: Iterable[str] | None = None,
+    archive_missing: bool = False,
+) -> MigrationSummary:
     summary = MigrationSummary()
     section_query = SchedulerSection.query
+    normalized_semester_ids = None
     if semester_ids is not None:
         normalized_semester_ids = [str(semester_id) for semester_id in semester_ids]
         section_query = section_query.filter(SchedulerSection.semester_id.in_(normalized_semester_ids))
@@ -357,6 +364,17 @@ def migrate_offerings(*, apply: bool, semester_ids: Iterable[str] | None = None)
     for section in sections:
         groups.setdefault((section.course_id, section.semester_id), []).append(section)
         summary.scanned += 1
+
+    if apply and archive_missing and normalized_semester_ids:
+        incoming_keys = set(groups)
+        existing_offerings = CourseOffering.query.filter(
+            CourseOffering.semester_id.in_(normalized_semester_ids)
+        ).all()
+        for offering in existing_offerings:
+            if (offering.course_id, offering.semester_id) in incoming_keys:
+                continue
+            offering.status = "archived"
+            sync_offering_sections(offering, [])
 
     for (course_id, semester_id), group_sections in groups.items():
         course = db.session.get(Course, course_id)
@@ -382,45 +400,15 @@ def migrate_offerings(*, apply: bool, semester_ids: Iterable[str] | None = None)
             db.session.add(offering)
             db.session.flush()
         elif apply:
-            section_ids = [
-                section_id for (section_id,) in (
-                    db.session.query(CourseSection.id)
-                    .filter_by(offering_id=offering.id)
-                    .all()
-                )
-            ]
-            if section_ids:
-                CourseMeeting.query.filter(CourseMeeting.section_id.in_(section_ids)).delete(synchronize_session=False)
-            CourseSection.query.filter_by(offering_id=offering.id).delete(synchronize_session=False)
+            offering.catalog_version_id = version.id if version else offering.catalog_version_id
+            offering.offering_code = course.normalized_code or normalize_course_code(course.code)
+            offering.title_snapshot = version.title if version else course.name
+            offering.credits_snapshot = version.credits if version else course.credits
+            offering.status = "offered"
 
         if not apply:
             continue
-        for legacy_section in group_sections:
-            section = CourseSection(
-                offering_id=offering.id,
-                source_section_id=legacy_section.section_id,
-                name=legacy_section.name,
-                section_type=legacy_section.section_type,
-                bundle=legacy_section.bundle,
-                layer=legacy_section.layer,
-                quota=legacy_section.quota,
-                is_main=legacy_section.is_main,
-            )
-            db.session.add(section)
-            db.session.flush()
-            lectures = SchedulerLecture.query.filter_by(
-                semester_id=legacy_section.semester_id,
-                section_id=legacy_section.section_id,
-            ).all()
-            for lecture in lectures:
-                db.session.add(CourseMeeting(
-                    section_id=section.id,
-                    day=lecture.day,
-                    start_time=lecture.start_time,
-                    end_time=lecture.end_time,
-                    room=lecture.room,
-                    instructor_text=lecture.instructor,
-                ))
+        sync_offering_sections(offering, group_sections)
 
     return summary
 

--- a/app/services/institutional_email.py
+++ b/app/services/institutional_email.py
@@ -1,0 +1,92 @@
+"""Institutional email normalization and active-account ownership helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from sqlalchemy import func, text
+
+from app.extensions import db
+from app.models.user import User
+
+
+INSTITUTIONAL_EMAIL_DOMAINS = frozenset({
+    "connect.hkust-gz.edu.cn",
+    "hkust-gz.edu.cn",
+})
+
+_EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+
+def normalize_email(email: object) -> str:
+    """Return the application's canonical representation for an email address."""
+    if not isinstance(email, str):
+        return ""
+    return email.strip().lower()
+
+
+def is_institutional_email(email: object) -> bool:
+    """Return whether *email* is a syntactically valid HKUST-GZ address."""
+    normalized = normalize_email(email)
+    if not normalized or not _EMAIL_PATTERN.fullmatch(normalized):
+        return False
+
+    local_part, separator, domain = normalized.rpartition("@")
+    return bool(local_part and separator and domain in INSTITUTIONAL_EMAIL_DOMAINS)
+
+
+def acquire_email_transaction_lock(email: object) -> None:
+    """Serialize ownership decisions for one email on PostgreSQL.
+
+    SQLite is used by the test suite and does not provide transaction advisory
+    locks, so the helper intentionally becomes a no-op there.
+    """
+    normalized = normalize_email(email)
+    if not normalized:
+        return
+
+    bind = db.session.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    digest = hashlib.blake2b(normalized.encode("utf-8"), digest_size=8).digest()
+    lock_key = int.from_bytes(digest, byteorder="big", signed=True)
+    db.session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_key)"),
+        {"lock_key": lock_key},
+    )
+
+
+def active_users_with_email(email: object):
+    """Build a deterministic query for active users sharing an email principal."""
+    normalized = normalize_email(email)
+    return User.query.filter(
+        User.is_deleted.is_(False),
+        func.lower(func.trim(User.email)) == normalized,
+    ).order_by(User.created_at.asc(), User.id.asc())
+
+
+def active_email_owner(email: object, *, exclude_user_id: int | None = None):
+    """Return the oldest active account using a normalized email, if any."""
+    query = active_users_with_email(email)
+    if exclude_user_id is not None:
+        query = query.filter(User.id != exclude_user_id)
+    return query.first()
+
+
+def canonical_email_account(email: object):
+    """Return the oldest active account allowed to claim a legacy duplicate."""
+    return active_users_with_email(email).first()
+
+
+def canonical_verified_email_account(email: object):
+    """Return the canonical verified institutional principal for an email."""
+    normalized = normalize_email(email)
+    if not is_institutional_email(normalized):
+        return None
+    return active_users_with_email(normalized).filter(User.email_verified.is_(True)).first()
+
+
+# Explicit alias for callers that benefit from the more descriptive name.
+normalize_institutional_email = normalize_email

--- a/app/services/scheduler_domain_sync.py
+++ b/app/services/scheduler_domain_sync.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from app.extensions import db
+from app.models.course_domain import CourseMeeting, CourseOffering, CourseSection
+
+
+def _lectures_for_section(source_section: Any) -> list[Any]:
+    lectures = source_section.lectures
+    if hasattr(lectures, "all"):
+        return lectures.all()
+    return list(lectures)
+
+
+def sync_offering_sections(
+    offering: CourseOffering,
+    source_sections: Iterable[Any],
+) -> dict[str, int]:
+    """Synchronize an offering without replacing stable CourseSection rows.
+
+    UserSectionSelection points at CourseSection.id. Updating matching sections
+    in place preserves those choices across timetable imports, while sections
+    that genuinely disappeared are removed normally.
+    """
+    incoming = list(source_sections)
+    existing = {
+        section.source_section_id: section
+        for section in CourseSection.query.filter_by(offering_id=offering.id).all()
+    }
+    incoming_ids = {section.section_id for section in incoming}
+    created = 0
+    updated = 0
+
+    for source in incoming:
+        section = existing.get(source.section_id)
+        if section is None:
+            section = CourseSection(
+                offering_id=offering.id,
+                source_section_id=source.section_id,
+            )
+            db.session.add(section)
+            created += 1
+        else:
+            updated += 1
+
+        section.name = source.name
+        section.section_type = source.section_type
+        section.bundle = source.bundle
+        section.layer = source.layer
+        section.quota = source.quota
+        section.is_main = source.is_main
+        db.session.flush()
+
+        CourseMeeting.query.filter_by(section_id=section.id).delete(
+            synchronize_session=False
+        )
+        for lecture in _lectures_for_section(source):
+            db.session.add(CourseMeeting(
+                section_id=section.id,
+                day=lecture.day,
+                start_time=lecture.start_time,
+                end_time=lecture.end_time,
+                room=lecture.room,
+                instructor_text=lecture.instructor,
+            ))
+
+    removed = 0
+    for source_section_id, section in existing.items():
+        if source_section_id in incoming_ids:
+            continue
+        db.session.delete(section)
+        removed += 1
+
+    return {"created": created, "updated": updated, "removed": removed}

--- a/app/services/scheduler_domain_sync.py
+++ b/app/services/scheduler_domain_sync.py
@@ -4,7 +4,13 @@ from collections.abc import Iterable
 from typing import Any
 
 from app.extensions import db
-from app.models.course_domain import CourseMeeting, CourseOffering, CourseSection
+from app.models.course_domain import (
+    CourseMeeting,
+    CourseOffering,
+    CourseSection,
+    UserOfferingCart,
+    UserSectionSelection,
+)
 
 
 def _lectures_for_section(source_section: Any) -> list[Any]:
@@ -32,6 +38,43 @@ def sync_offering_sections(
     incoming_ids = {section.section_id for section in incoming}
     created = 0
     updated = 0
+    cart_user_ids = [
+        user_id
+        for (user_id,) in (
+            db.session.query(UserOfferingCart.user_id)
+            .filter_by(offering_id=offering.id)
+            .all()
+        )
+    ]
+    incoming_groups = {
+        section.section_id: (section.bundle, section.layer)
+        for section in incoming
+    }
+    inherited_by_group_user = {}
+    existing_selection_keys = set()
+    if cart_user_ids:
+        existing_selection_rows = (
+            db.session.query(
+                UserSectionSelection.user_id,
+                CourseSection.id,
+                CourseSection.source_section_id,
+                CourseSection.bundle,
+                CourseSection.layer,
+                UserSectionSelection.enabled,
+            )
+            .join(CourseSection, CourseSection.id == UserSectionSelection.section_id)
+            .filter(
+                UserSectionSelection.offering_id == offering.id,
+                UserSectionSelection.user_id.in_(cart_user_ids),
+                CourseSection.offering_id == offering.id,
+            )
+            .order_by(CourseSection.source_section_id)
+            .all()
+        )
+        for user_id, section_id, source_section_id, bundle, layer, enabled in existing_selection_rows:
+            existing_selection_keys.add((user_id, section_id))
+            target_group = incoming_groups.get(source_section_id, (bundle, layer))
+            inherited_by_group_user.setdefault((*target_group, user_id), enabled)
 
     for source in incoming:
         section = existing.get(source.section_id)
@@ -52,6 +95,23 @@ def sync_offering_sections(
         section.quota = source.quota
         section.is_main = source.is_main
         db.session.flush()
+
+        if cart_user_ids:
+            for user_id in cart_user_ids:
+                selection_key = (user_id, section.id)
+                if selection_key in existing_selection_keys:
+                    continue
+                db.session.add(UserSectionSelection(
+                    user_id=user_id,
+                    offering_id=offering.id,
+                    section_id=section.id,
+                    enabled=inherited_by_group_user.get(
+                        (section.bundle, section.layer, user_id),
+                        True,
+                    ),
+                    source="cart",
+                ))
+                existing_selection_keys.add(selection_key)
 
         CourseMeeting.query.filter_by(section_id=section.id).delete(
             synchronize_session=False

--- a/app/services/scheduler_popularity.py
+++ b/app/services/scheduler_popularity.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from sqlalchemy import and_, func, or_
+
+from app.extensions import db
+from app.models.course import Course
+from app.models.course_domain import (
+    CourseOffering,
+    CourseSection,
+    UserOfferingCart,
+    UserSectionSelection,
+)
+from app.models.scheduler_popularity import SchedulerPopularityEvent
+from app.models.user import User
+from app.services.course_domain import normalize_course_code
+from app.services.institutional_email import (
+    canonical_verified_email_account,
+    is_institutional_email,
+    normalize_email,
+)
+
+
+POPULARITY_STATES = {"looking", "scheduling"}
+
+
+def is_eligible_popularity_user(user: User | None) -> bool:
+    return bool(
+        user
+        and not user.is_deleted
+        and user.email_verified
+        and normalize_email(user.email)
+        and is_institutional_email(user.email)
+    )
+
+
+def is_canonical_popularity_user(user: User | None) -> bool:
+    """Return whether user is the oldest eligible account for its email."""
+    if not is_eligible_popularity_user(user):
+        return False
+    canonical = canonical_verified_email_account(user.email)
+    return canonical is not None and canonical.id == user.id
+
+
+def _canonical_contributor_ids(offering_ids: list[int]) -> set[int]:
+    if not offering_ids:
+        return set()
+
+    relevant_users = (
+        User.query
+        .join(UserOfferingCart, UserOfferingCart.user_id == User.id)
+        .filter(
+            UserOfferingCart.offering_id.in_(offering_ids),
+            User.is_deleted.is_(False),
+            User.email_verified.is_(True),
+        )
+        .all()
+    )
+    normalized_emails = {
+        normalize_email(user.email)
+        for user in relevant_users
+        if normalize_email(user.email) and is_institutional_email(user.email)
+    }
+    if not normalized_emails:
+        return set()
+
+    eligible_candidates = (
+        User.query
+        .filter(
+            User.is_deleted.is_(False),
+            User.email_verified.is_(True),
+            func.lower(func.trim(User.email)).in_(normalized_emails),
+        )
+        .order_by(User.created_at.asc(), User.id.asc())
+        .all()
+    )
+    canonical_by_email: dict[str, User] = {}
+    for candidate in eligible_candidates:
+        normalized = normalize_email(candidate.email)
+        if normalized not in normalized_emails or not is_institutional_email(candidate.email):
+            continue
+        canonical_by_email.setdefault(normalized, candidate)
+
+    return {candidate.id for candidate in canonical_by_email.values()}
+
+
+def normalize_popularity_course_codes(values: Iterable[str], *, limit: int = 30) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        for token in str(raw_value or "").split(","):
+            code = normalize_course_code(token)
+            if not code or code in seen:
+                continue
+            if len(code) > 32:
+                raise ValueError("Invalid course code")
+            seen.add(code)
+            normalized.append(code)
+    if len(normalized) > limit:
+        raise ValueError(f"At most {limit} course codes are allowed")
+    return normalized
+
+
+def build_popularity_snapshot(
+    *,
+    viewer_id: int,
+    semester_id: str,
+    course_codes: list[str],
+) -> dict:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    empty = {
+        "semester_id": semester_id,
+        "generated_at": generated_at,
+        "courses": [],
+    }
+    if not course_codes:
+        return empty
+
+    target_rows = (
+        db.session.query(UserOfferingCart, CourseOffering, Course)
+        .join(CourseOffering, CourseOffering.id == UserOfferingCart.offering_id)
+        .join(Course, Course.id == CourseOffering.course_id)
+        .filter(
+            UserOfferingCart.user_id == viewer_id,
+            CourseOffering.semester_id == semester_id,
+            CourseOffering.status == "offered",
+            Course.is_deleted.is_(False),
+            or_(
+                Course.normalized_code.in_(course_codes),
+                func.upper(func.replace(Course.code, " ", "")).in_(course_codes),
+            ),
+        )
+        .order_by(Course.code, CourseOffering.id)
+        .all()
+    )
+    if not target_rows:
+        return empty
+
+    offering_ids = [offering.id for _, offering, _ in target_rows]
+    sections = (
+        CourseSection.query
+        .filter(CourseSection.offering_id.in_(offering_ids))
+        .order_by(CourseSection.offering_id, CourseSection.layer, CourseSection.bundle, CourseSection.source_section_id)
+        .all()
+    )
+    sections_by_offering: dict[int, list[CourseSection]] = {}
+    for section in sections:
+        sections_by_offering.setdefault(section.offering_id, []).append(section)
+
+    output_by_offering: dict[int, dict] = {}
+    section_output_by_id: dict[int, dict] = {}
+    courses = []
+    for _, offering, course in target_rows:
+        output = {
+            "course_code": course.code,
+            "looking_count": 0,
+            "scheduling_count": 0,
+            "sections": [],
+        }
+        for section in sections_by_offering.get(offering.id, []):
+            section_output = {
+                "section_id": section.source_section_id,
+                "looking_count": 0,
+                "scheduling_count": 0,
+            }
+            output["sections"].append(section_output)
+            section_output_by_id[section.id] = section_output
+        courses.append(output)
+        output_by_offering[offering.id] = output
+
+    canonical_ids = _canonical_contributor_ids(offering_ids)
+    if canonical_ids:
+        course_counts = (
+            db.session.query(
+                UserOfferingCart.offering_id,
+                UserOfferingCart.enabled,
+                func.count(func.distinct(UserOfferingCart.user_id)),
+            )
+            .filter(
+                UserOfferingCart.offering_id.in_(offering_ids),
+                UserOfferingCart.user_id.in_(canonical_ids),
+            )
+            .group_by(UserOfferingCart.offering_id, UserOfferingCart.enabled)
+            .all()
+        )
+        for offering_id, enabled, count in course_counts:
+            output = output_by_offering.get(offering_id)
+            if output is not None:
+                key = "scheduling_count" if enabled else "looking_count"
+                output[key] = count
+
+        section_counts = (
+            db.session.query(
+                UserSectionSelection.section_id,
+                UserOfferingCart.enabled,
+                func.count(func.distinct(UserSectionSelection.user_id)),
+            )
+            .join(
+                UserOfferingCart,
+                and_(
+                    UserOfferingCart.user_id == UserSectionSelection.user_id,
+                    UserOfferingCart.offering_id == UserSectionSelection.offering_id,
+                ),
+            )
+            .join(
+                CourseSection,
+                and_(
+                    CourseSection.id == UserSectionSelection.section_id,
+                    CourseSection.offering_id == UserSectionSelection.offering_id,
+                ),
+            )
+            .filter(
+                UserSectionSelection.offering_id.in_(offering_ids),
+                UserSectionSelection.user_id.in_(canonical_ids),
+                UserSectionSelection.enabled.is_(True),
+            )
+            .group_by(UserSectionSelection.section_id, UserOfferingCart.enabled)
+            .all()
+        )
+        for section_id, enabled, count in section_counts:
+            output = section_output_by_id.get(section_id)
+            if output is not None:
+                key = "scheduling_count" if enabled else "looking_count"
+                output[key] = count
+
+    return {
+        "semester_id": semester_id,
+        "generated_at": generated_at,
+        "courses": courses,
+    }
+
+
+def popularity_state(enabled: bool) -> str:
+    return "scheduling" if enabled else "looking"
+
+
+def record_popularity_transition(
+    *,
+    contributor_is_eligible: bool,
+    offering_id: int,
+    from_state: str | None,
+    to_state: str | None,
+    reason: str,
+    section: CourseSection | None = None,
+) -> None:
+    if not contributor_is_eligible or from_state == to_state:
+        return
+    if from_state not in POPULARITY_STATES | {None} or to_state not in POPULARITY_STATES | {None}:
+        raise ValueError("Invalid popularity transition")
+    if from_state is None and to_state is None:
+        return
+
+    db.session.add(SchedulerPopularityEvent(
+        offering_id=offering_id,
+        section_id=section.id if section else None,
+        section_source_id=section.source_section_id if section else None,
+        from_state=from_state,
+        to_state=to_state,
+        reason=reason,
+    ))

--- a/migrations/versions/20260807_scheduler_popularity.py
+++ b/migrations/versions/20260807_scheduler_popularity.py
@@ -1,0 +1,187 @@
+"""add anonymous scheduler popularity support
+
+Revision ID: 20260807_sched_popularity
+Revises: 20260610_gugu_soft_delete
+Create Date: 2026-08-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260807_sched_popularity"
+down_revision = "20260610_gugu_soft_delete"
+branch_labels = None
+depends_on = None
+
+
+def _index_names(inspector, table_name):
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    if "scheduler_popularity_events" not in inspector.get_table_names():
+        op.create_table(
+            "scheduler_popularity_events",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("offering_id", sa.Integer(), nullable=False),
+            sa.Column("section_id", sa.Integer(), nullable=True),
+            sa.Column("section_source_id", sa.String(length=32), nullable=True),
+            sa.Column("from_state", sa.String(length=16), nullable=True),
+            sa.Column("to_state", sa.String(length=16), nullable=True),
+            sa.Column("reason", sa.String(length=32), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.CheckConstraint(
+                "from_state IS NULL OR from_state IN ('looking', 'scheduling')",
+                name="valid_scheduler_popularity_from_state",
+            ),
+            sa.CheckConstraint(
+                "to_state IS NULL OR to_state IN ('looking', 'scheduling')",
+                name="valid_scheduler_popularity_to_state",
+            ),
+            sa.CheckConstraint(
+                "(from_state IS NOT NULL OR to_state IS NOT NULL) "
+                "AND (from_state IS NULL OR to_state IS NULL OR from_state <> to_state)",
+                name="valid_scheduler_popularity_transition",
+            ),
+            sa.CheckConstraint(
+                "reason IN ('cart_added', 'cart_removed', 'course_toggled', "
+                "'bundle_toggled', 'layer_toggled')",
+                name="valid_scheduler_popularity_reason",
+            ),
+            sa.ForeignKeyConstraint(
+                ["offering_id"],
+                ["course_offerings.id"],
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["section_id"],
+                ["course_sections.id"],
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    inspector = sa.inspect(op.get_bind())
+    event_indexes = _index_names(inspector, "scheduler_popularity_events")
+    if "idx_scheduler_popularity_offering_created" not in event_indexes:
+        op.create_index(
+            "idx_scheduler_popularity_offering_created",
+            "scheduler_popularity_events",
+            ["offering_id", "created_at"],
+        )
+    if "idx_scheduler_popularity_section_created" not in event_indexes:
+        op.create_index(
+            "idx_scheduler_popularity_section_created",
+            "scheduler_popularity_events",
+            ["section_id", "created_at"],
+        )
+    if "idx_scheduler_popularity_source_created" not in event_indexes:
+        op.create_index(
+            "idx_scheduler_popularity_source_created",
+            "scheduler_popularity_events",
+            ["offering_id", "section_source_id", "created_at"],
+        )
+
+    inspector = sa.inspect(op.get_bind())
+    cart_indexes = _index_names(inspector, "user_offering_carts")
+    if (
+        "user_offering_carts" in inspector.get_table_names()
+        and "idx_user_offering_carts_popularity" not in cart_indexes
+    ):
+        op.create_index(
+            "idx_user_offering_carts_popularity",
+            "user_offering_carts",
+            ["offering_id", "enabled", "user_id"],
+        )
+
+    selection_indexes = _index_names(inspector, "user_section_selections")
+    if (
+        "user_section_selections" in inspector.get_table_names()
+        and "idx_user_section_selections_popularity" not in selection_indexes
+    ):
+        op.create_index(
+            "idx_user_section_selections_popularity",
+            "user_section_selections",
+            ["offering_id", "enabled", "section_id", "user_id"],
+        )
+
+    # Older destructive timetable imports could leave an existing cart with no
+    # section rows. The API historically interpreted those missing rows as
+    # enabled, so materialize that same state before popularity starts counting.
+    inspector = sa.inspect(op.get_bind())
+    required_tables = {
+        "course_sections",
+        "user_offering_carts",
+        "user_section_selections",
+    }
+    if required_tables.issubset(set(inspector.get_table_names())):
+        op.execute(sa.text("""
+            INSERT INTO user_section_selections (
+                user_id,
+                offering_id,
+                section_id,
+                enabled,
+                source,
+                created_at,
+                updated_at
+            )
+            SELECT
+                carts.user_id,
+                sections.offering_id,
+                sections.id,
+                COALESCE((
+                    SELECT inherited.enabled
+                    FROM user_section_selections AS inherited
+                    JOIN course_sections AS inherited_section
+                      ON inherited_section.id = inherited.section_id
+                     AND inherited_section.offering_id = inherited.offering_id
+                    WHERE inherited.user_id = carts.user_id
+                      AND inherited.offering_id = sections.offering_id
+                      AND inherited_section.bundle = sections.bundle
+                      AND inherited_section.layer = sections.layer
+                    ORDER BY inherited_section.source_section_id
+                    LIMIT 1
+                ), TRUE),
+                'cart',
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            FROM user_offering_carts AS carts
+            JOIN course_sections AS sections
+              ON sections.offering_id = carts.offering_id
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM user_section_selections AS existing
+                WHERE existing.user_id = carts.user_id
+                  AND existing.offering_id = carts.offering_id
+                  AND existing.section_id = sections.id
+            )
+        """))
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    selection_indexes = _index_names(inspector, "user_section_selections")
+    if "idx_user_section_selections_popularity" in selection_indexes:
+        op.drop_index(
+            "idx_user_section_selections_popularity",
+            table_name="user_section_selections",
+        )
+
+    cart_indexes = _index_names(inspector, "user_offering_carts")
+    if "idx_user_offering_carts_popularity" in cart_indexes:
+        op.drop_index(
+            "idx_user_offering_carts_popularity",
+            table_name="user_offering_carts",
+        )
+
+    if "scheduler_popularity_events" in inspector.get_table_names():
+        op.drop_table("scheduler_popularity_events")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -72,6 +72,15 @@ def test_auto_initialized_migrations_are_idempotent():
             "20260607_course_domain_redesign.py",
             ["domain_tables.issubset"],
         ),
+        (
+            "20260807_scheduler_popularity.py",
+            [
+                '"scheduler_popularity_events" not in inspector.get_table_names()',
+                '"idx_user_offering_carts_popularity" not in cart_indexes',
+                '"idx_user_section_selections_popularity" not in selection_indexes',
+                'INSERT INTO user_section_selections',
+            ],
+        ),
     ]
 
     for filename, guard_texts in guarded_migrations:

--- a/tests/test_email_integrity.py
+++ b/tests/test_email_integrity.py
@@ -1,0 +1,304 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask_jwt_extended import create_access_token
+
+from app import create_app
+from app.extensions import cache, db
+from app.models.user import User
+from app.models.user_role import UserRole
+from app.routes.auth import is_hkust_email
+from app.services.email_service import EmailService
+from app.services.institutional_email import is_institutional_email, normalize_email
+
+
+class TestConfig:
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {}
+    JWT_SECRET_KEY = "email-integrity-test-secret"
+    CACHE_TYPE = "SimpleCache"
+    AUTO_INIT_ON_STARTUP = False
+
+
+class StubEmailService:
+    def __init__(self):
+        self.sent = []
+        self.next_code = "654321"
+
+    def generate_verification_code(self):
+        return self.next_code
+
+    def send_verification_email(self, **kwargs):
+        self.sent.append(kwargs)
+        return {"success": True}
+
+
+@pytest.fixture
+def app(monkeypatch):
+    app = create_app(TestConfig)
+    email_service = StubEmailService()
+    monkeypatch.setattr(
+        EmailService,
+        "from_app_config",
+        staticmethod(lambda: email_service),
+    )
+    monkeypatch.setattr(
+        "app.routes.auth.content_moderation.moderate_text",
+        lambda **_kwargs: {"is_safe": True, "reason": None, "risk_level": "low"},
+    )
+
+    with app.app_context():
+        db.create_all()
+        db.session.add(UserRole(name=UserRole.USER))
+        db.session.commit()
+        cache.clear()
+
+    app.email_service = email_service
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def create_user(
+    app,
+    username,
+    email,
+    *,
+    verified=False,
+    code="123456",
+    created_at=None,
+):
+    with app.app_context():
+        role = UserRole.query.filter_by(name=UserRole.USER).one()
+        user = User(
+            username=username,
+            email=email,
+            email_verified=verified,
+            role_id=role.id,
+            created_at=created_at or datetime.now(timezone.utc),
+        )
+        user.set_password("password")
+        if not verified and code:
+            user.set_email_verification_code(code)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def authorization_header(app, user_id):
+    with app.app_context():
+        token = create_access_token(identity=str(user_id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_institutional_email_validation_is_normalized_and_backward_compatible():
+    email = "  Student.Name@CONNECT.HKUST-GZ.EDU.CN "
+    assert normalize_email(email) == "student.name@connect.hkust-gz.edu.cn"
+    assert is_institutional_email(email)
+    assert is_hkust_email(email)
+    assert not is_institutional_email("student@connect.hkust-gz.edu.cn.example.com")
+
+
+def test_register_normalizes_email_and_rejects_case_insensitive_duplicate(app, client):
+    create_user(app, "legacy", "Legacy.Student@HKUST-GZ.EDU.CN")
+
+    duplicate = client.post("/auth/register", json={
+        "username": "duplicate",
+        "password": "password",
+        "email": "legacy.student@hkust-gz.edu.cn",
+    })
+    assert duplicate.status_code == 400
+    assert duplicate.get_json()["msg"] == "Email already registered"
+
+    created = client.post("/auth/register", json={
+        "username": "newstudent",
+        "password": "password",
+        "email": " New.Student@CONNECT.HKUST-GZ.EDU.CN ",
+    })
+    assert created.status_code == 201
+
+    with app.app_context():
+        user = User.query.filter_by(username="newstudent").one()
+        assert user.email == "new.student@connect.hkust-gz.edu.cn"
+
+
+def test_update_email_resets_verification_and_clears_old_code(app, client):
+    user_id = create_user(app, "verified", "old@hkust-gz.edu.cn", verified=True)
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        user.email_verification_code = "111111"
+        user.email_verification_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+        db.session.commit()
+
+    response = client.put(
+        f"/users/{user_id}",
+        json={"email": " New.Address@CONNECT.HKUST-GZ.EDU.CN "},
+        headers=authorization_header(app, user_id),
+    )
+    assert response.status_code == 200
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.email == "new.address@connect.hkust-gz.edu.cn"
+        assert user.email_verified is False
+        assert user.email_verification_code is None
+        assert user.email_verification_expires_at is None
+
+
+def test_case_only_update_preserves_verified_principal(app, client):
+    user_id = create_user(
+        app,
+        "mixedcase",
+        "Student@CONNECT.HKUST-GZ.EDU.CN",
+        verified=True,
+    )
+
+    response = client.put(
+        f"/users/{user_id}",
+        json={"email": "student@connect.hkust-gz.edu.cn"},
+        headers=authorization_header(app, user_id),
+    )
+    assert response.status_code == 200
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.email == "student@connect.hkust-gz.edu.cn"
+        assert user.email_verified is True
+
+
+def test_update_email_rejects_domain_and_case_insensitive_duplicate(app, client):
+    user_id = create_user(app, "target", "target@hkust-gz.edu.cn", verified=True)
+    create_user(app, "owner", "Taken@CONNECT.HKUST-GZ.EDU.CN", verified=True)
+    headers = authorization_header(app, user_id)
+
+    external = client.put(
+        f"/users/{user_id}",
+        json={"email": "target@example.com"},
+        headers=headers,
+    )
+    duplicate = client.put(
+        f"/users/{user_id}",
+        json={"email": "taken@connect.hkust-gz.edu.cn"},
+        headers=headers,
+    )
+
+    assert external.status_code == 400
+    assert duplicate.status_code == 400
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.email == "target@hkust-gz.edu.cn"
+        assert user.email_verified is True
+
+
+def test_add_email_normalizes_and_rejects_case_insensitive_duplicate(app, client):
+    user_id = create_user(app, "noemail", None, code=None)
+    create_user(app, "owner", "Owner@HKUST-GZ.EDU.CN")
+    headers = authorization_header(app, user_id)
+
+    duplicate = client.post(
+        f"/users/{user_id}/add-email",
+        json={"email": "owner@hkust-gz.edu.cn"},
+        headers=headers,
+    )
+    assert duplicate.status_code == 400
+
+    added = client.post(
+        f"/users/{user_id}/add-email",
+        json={"email": " Student@CONNECT.HKUST-GZ.EDU.CN "},
+        headers=headers,
+    )
+    assert added.status_code == 200
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        assert user.email == "student@connect.hkust-gz.edu.cn"
+        assert user.email_verified is False
+        assert user.email_verification_code == "654321"
+
+
+def test_verify_email_rejects_noninstitutional_and_noncanonical_accounts(app, client):
+    external_id = create_user(app, "external", "external@example.com")
+    external = client.post("/auth/verify-email", json={
+        "user_id": external_id,
+        "verification_code": "123456",
+    })
+    assert external.status_code == 400
+
+    oldest = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    first_id = create_user(
+        app,
+        "first",
+        "shared@hkust-gz.edu.cn",
+        created_at=oldest,
+    )
+    second_id = create_user(
+        app,
+        "second",
+        "SHARED@HKUST-GZ.EDU.CN",
+        created_at=oldest + timedelta(seconds=1),
+    )
+
+    second = client.post("/auth/verify-email", json={
+        "user_id": second_id,
+        "verification_code": "123456",
+    })
+    first = client.post("/auth/verify-email", json={
+        "user_id": first_id,
+        "verification_code": "123456",
+    })
+
+    assert second.status_code == 409
+    assert first.status_code == 200
+    with app.app_context():
+        assert db.session.get(User, first_id).email_verified is True
+        assert db.session.get(User, second_id).email_verified is False
+
+
+def test_verify_email_throttles_failed_codes_and_success_clears_attempts(app, client):
+    successful_id = create_user(app, "eventualsuccess", "success@hkust-gz.edu.cn")
+
+    failed = client.post("/auth/verify-email", json={
+        "user_id": successful_id,
+        "verification_code": "000000",
+    })
+    assert failed.status_code == 400
+    with app.app_context():
+        assert cache.get(f"email-verification:failures:{successful_id}") == 1
+
+    success = client.post("/auth/verify-email", json={
+        "user_id": successful_id,
+        "verification_code": "123456",
+    })
+    assert success.status_code == 200
+    with app.app_context():
+        assert cache.get(f"email-verification:failures:{successful_id}") is None
+
+    throttled_id = create_user(app, "throttled", "throttled@hkust-gz.edu.cn")
+    for _ in range(5):
+        response = client.post("/auth/verify-email", json={
+            "user_id": throttled_id,
+            "verification_code": "000000",
+        })
+        assert response.status_code == 400
+
+    response = client.post("/auth/verify-email", json={
+        "user_id": throttled_id,
+        "verification_code": "123456",
+    })
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "900"
+
+
+def test_resend_verification_has_per_user_cooldown(app, client):
+    user_id = create_user(app, "resend", "resend@hkust-gz.edu.cn")
+
+    first = client.post("/auth/resend-verification", json={"user_id": user_id})
+    second = client.post("/auth/resend-verification", json={"user_id": user_id})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.headers["Retry-After"] == "60"
+    assert len(app.email_service.sent) == 1

--- a/tests/test_email_integrity.py
+++ b/tests/test_email_integrity.py
@@ -126,6 +126,50 @@ def test_register_normalizes_email_and_rejects_case_insensitive_duplicate(app, c
         assert user.email == "new.student@connect.hkust-gz.edu.cn"
 
 
+def test_legacy_users_post_uses_hardened_registration_and_default_role(app, client):
+    with app.app_context():
+        admin_role = UserRole(name=UserRole.ADMIN, description="Administrator")
+        db.session.add(admin_role)
+        db.session.commit()
+        admin_role_id = admin_role.id
+
+    created = client.post("/users", json={
+        "username": "legacyroute",
+        "password": "password",
+        "email": " Legacy.Route@CONNECT.HKUST-GZ.EDU.CN ",
+        "role_id": admin_role_id,
+    })
+    assert created.status_code == 201
+
+    duplicate = client.post("/users", json={
+        "username": "legacyduplicate",
+        "password": "password",
+        "email": "legacy.route@connect.hkust-gz.edu.cn",
+    })
+    assert duplicate.status_code == 400
+    assert duplicate.get_json()["msg"] == "Email already registered"
+
+    external = client.post("/users", json={
+        "username": "legacyexternal",
+        "password": "password",
+        "email": "legacy@example.com",
+    })
+    assert external.status_code == 400
+
+    missing_email = client.post("/users", json={
+        "username": "legacymissing",
+        "password": "password",
+    })
+    assert missing_email.status_code == 400
+
+    with app.app_context():
+        user = User.query.filter_by(username="legacyroute").one()
+        assert user.email == "legacy.route@connect.hkust-gz.edu.cn"
+        assert user.email_verified is False
+        assert user.email_verification_code
+        assert user.role.name == UserRole.USER
+
+
 def test_update_email_resets_verification_and_clears_old_code(app, client):
     user_id = create_user(app, "verified", "old@hkust-gz.edu.cn", verified=True)
     with app.app_context():

--- a/tests/test_import_scheduler_offerings.py
+++ b/tests/test_import_scheduler_offerings.py
@@ -440,6 +440,129 @@ def test_apply_offerings_preserves_user_section_choices(app, tmp_path):
         assert selection.enabled is False
 
 
+def test_apply_offerings_backfills_new_section_choices_from_bundle_layer(app, tmp_path):
+    first_snapshot = load_offerings_file(write_payload(tmp_path, payload()))
+
+    with app.app_context():
+        apply_offerings(first_snapshot)
+        course = Course.query.filter_by(code="TEST1001").one()
+        offering = CourseOffering.query.filter_by(
+            course_id=course.id,
+            semester_id="2540",
+        ).one()
+        original = CourseSection.query.filter_by(
+            offering_id=offering.id,
+            source_section_id="TEST1001-L01",
+        ).one()
+        role = UserRole.query.filter_by(name="user").first() or UserRole(name="user")
+        db.session.add(role)
+        db.session.flush()
+        user = User(
+            username="scheduler_new_section_user",
+            email="scheduler_new_section@hkust-gz.edu.cn",
+            email_verified=True,
+            role_id=role.id,
+        )
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(UserOfferingCart(
+            user_id=user.id,
+            offering_id=offering.id,
+            enabled=False,
+        ))
+        db.session.add(UserSectionSelection(
+            user_id=user.id,
+            offering_id=offering.id,
+            section_id=original.id,
+            enabled=False,
+            source="cart",
+        ))
+        db.session.commit()
+
+        updated_payload = payload()
+        updated_payload["courses"][0]["sections"].extend([
+            {
+                "semester_id": "2540",
+                "section_id": "TEST1001-L02",
+                "course_code": "TEST1001",
+                "section_type": "L",
+                "name": "L02",
+                "bundle": 1,
+                "layer": 0,
+                "quota": 50,
+                "is_main": True,
+                "lectures": [],
+            },
+            {
+                "semester_id": "2540",
+                "section_id": "TEST1001-T01",
+                "course_code": "TEST1001",
+                "section_type": "T",
+                "name": "T01",
+                "bundle": 1,
+                "layer": 1,
+                "quota": 25,
+                "is_main": False,
+                "lectures": [],
+            },
+        ])
+        apply_offerings(load_offerings_file(write_payload(tmp_path, updated_payload)))
+
+        selections = {
+            selection.section.source_section_id: selection.enabled
+            for selection in UserSectionSelection.query.filter_by(
+                user_id=user.id,
+                offering_id=offering.id,
+            ).all()
+        }
+
+        assert selections == {
+            "TEST1001-L01": False,
+            "TEST1001-L02": False,
+            "TEST1001-T01": True,
+        }
+
+
+def test_apply_offerings_backfills_missing_existing_section_choices(app, tmp_path):
+    snapshot = load_offerings_file(write_payload(tmp_path, payload()))
+
+    with app.app_context():
+        apply_offerings(snapshot)
+        course = Course.query.filter_by(code="TEST1001").one()
+        offering = CourseOffering.query.filter_by(
+            course_id=course.id,
+            semester_id="2540",
+        ).one()
+        role = UserRole.query.filter_by(name="user").first() or UserRole(name="user")
+        db.session.add(role)
+        db.session.flush()
+        user = User(
+            username="scheduler_missing_selection_user",
+            email="scheduler_missing_selection@hkust-gz.edu.cn",
+            email_verified=True,
+            role_id=role.id,
+        )
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(UserOfferingCart(
+            user_id=user.id,
+            offering_id=offering.id,
+            enabled=False,
+        ))
+        db.session.commit()
+
+        apply_offerings(snapshot)
+
+        selections = UserSectionSelection.query.filter_by(
+            user_id=user.id,
+            offering_id=offering.id,
+        ).all()
+        assert len(selections) == 1
+        assert selections[0].enabled is True
+
+
 def test_deploy_update_dry_run_does_not_write_database(app, tmp_path):
     path = write_payload(tmp_path, payload())
     digest = file_sha256(path)

--- a/tests/test_import_scheduler_offerings.py
+++ b/tests/test_import_scheduler_offerings.py
@@ -9,7 +9,14 @@ from app import create_app
 from app.config import Config
 from app.extensions import db
 from app.models.course import Course
-from app.models.course_domain import CourseCatalogVersion, CourseMeeting, CourseOffering, CourseSection
+from app.models.course_domain import (
+    CourseCatalogVersion,
+    CourseMeeting,
+    CourseOffering,
+    CourseSection,
+    UserOfferingCart,
+    UserSectionSelection,
+)
 from app.models.scheduler_cart import SchedulerUserCourseCart
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_section import SchedulerSection
@@ -366,6 +373,71 @@ def test_apply_offerings_preserves_existing_course_rules_when_snapshot_rules_are
     assert course.pre_requirement == "(UFUG 1501 or UFUG 1503) AND (UFUG 1102 or UFUG 1105)"
     assert course.co_requirement is None
     assert course.exclusion == "UFUG 1502"
+
+
+def test_apply_offerings_preserves_user_section_choices(app, tmp_path):
+    first_snapshot = load_offerings_file(write_payload(tmp_path, payload()))
+
+    with app.app_context():
+        apply_offerings(first_snapshot)
+        course = Course.query.filter_by(code="TEST1001").one()
+        offering = CourseOffering.query.filter_by(
+            course_id=course.id,
+            semester_id="2540",
+        ).one()
+        section = CourseSection.query.filter_by(
+            offering_id=offering.id,
+            source_section_id="TEST1001-L01",
+        ).one()
+        original_section_id = section.id
+
+        role = UserRole.query.filter_by(name="user").first() or UserRole(name="user")
+        db.session.add(role)
+        db.session.flush()
+        user = User(
+            username="scheduler_choice_user",
+            email="scheduler_choice@hkust-gz.edu.cn",
+            email_verified=True,
+            role_id=role.id,
+        )
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(UserOfferingCart(
+            user_id=user.id,
+            offering_id=offering.id,
+            enabled=True,
+        ))
+        db.session.add(UserSectionSelection(
+            user_id=user.id,
+            offering_id=offering.id,
+            section_id=section.id,
+            enabled=False,
+            source="cart",
+        ))
+        db.session.commit()
+
+        updated_payload = payload()
+        updated_payload["courses"][0]["sections"][0]["quota"] = 60
+        updated_payload["courses"][0]["sections"][0]["lectures"][0]["room"] = "Room 202"
+        second_snapshot = load_offerings_file(write_payload(tmp_path, updated_payload))
+        apply_offerings(second_snapshot)
+        db.session.expire_all()
+
+        refreshed_section = CourseSection.query.filter_by(
+            offering_id=offering.id,
+            source_section_id="TEST1001-L01",
+        ).one()
+        selection = UserSectionSelection.query.filter_by(
+            user_id=user.id,
+            offering_id=offering.id,
+            section_id=refreshed_section.id,
+        ).one()
+
+        assert refreshed_section.id == original_section_id
+        assert refreshed_section.quota == 60
+        assert refreshed_section.meetings.one().room == "Room 202"
+        assert selection.enabled is False
 
 
 def test_deploy_update_dry_run_does_not_write_database(app, tmp_path):

--- a/tests/test_scheduler_data_import.py
+++ b/tests/test_scheduler_data_import.py
@@ -8,6 +8,7 @@ from app import create_app
 from app.config import Config
 from app.extensions import db
 from app.models.course import Course
+from app.models.course_domain import CourseMeeting, CourseOffering, CourseSection
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
 from app.models.scheduler_section import SchedulerSection
@@ -94,6 +95,10 @@ def test_import_snapshot_is_repeatable(app):
         assert Course.query.filter_by(code='AIAA1001').count() == 1
         assert SchedulerSection.query.count() == 1
         assert SchedulerLecture.query.count() == 1
+        offering = CourseOffering.query.filter_by(semester_id='2530').one()
+        section = CourseSection.query.filter_by(offering_id=offering.id).one()
+        assert section.source_section_id == 'L01'
+        assert CourseMeeting.query.filter_by(section_id=section.id).count() == 1
 
 
 def test_import_snapshot_rejects_orphan_lecture_without_mutating_destination(app):

--- a/tests/test_scheduler_popularity.py
+++ b/tests/test_scheduler_popularity.py
@@ -1,0 +1,415 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask_jwt_extended import create_access_token
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+from app.models.course import Course
+from app.models.course_domain import (
+    CourseOffering,
+    CourseSection,
+    UserOfferingCart,
+    UserSectionSelection,
+)
+from app.models.scheduler_popularity import SchedulerPopularityEvent
+from app.models.user import User
+from app.models.user_role import UserRole
+
+
+@compiles(JSONB, "sqlite")
+def compile_jsonb_sqlite(_type, _compiler, **_kw):
+    return "JSON"
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    CACHE_TYPE = "SimpleCache"
+    ENABLE_BACKGROUND_TASKS = False
+    JWT_SECRET_KEY = "test-secret"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def create_user(
+    username,
+    email,
+    *,
+    verified=True,
+    deleted=False,
+    created_at=None,
+):
+    role = UserRole.query.filter_by(name=UserRole.USER).first()
+    if role is None:
+        role = UserRole(name=UserRole.USER, description="Regular user")
+        db.session.add(role)
+        db.session.flush()
+    user = User(
+        username=username,
+        email=email,
+        email_verified=verified,
+        is_deleted=deleted,
+        role_id=role.id,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    user.set_password("password123")
+    db.session.add(user)
+    db.session.flush()
+    return user
+
+
+def headers_for(user):
+    token = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_offering(code="POP1001", semester="2530", *, status="offered"):
+    course = Course(
+        code=code,
+        normalized_code=code.replace(" ", "").upper(),
+        name=f"Popularity {code}",
+        credits=3,
+        subject="TEST",
+    )
+    db.session.add(course)
+    db.session.flush()
+    offering = CourseOffering(
+        course_id=course.id,
+        semester_id=semester,
+        offering_code=code,
+        title_snapshot=course.name,
+        credits_snapshot=3,
+        source="test",
+        status=status,
+    )
+    db.session.add(offering)
+    db.session.flush()
+    sections = [
+        CourseSection(
+            offering_id=offering.id,
+            source_section_id=f"{code}-L01",
+            name="L01",
+            section_type="L",
+            bundle=1,
+            layer=0,
+            quota=30,
+            is_main=True,
+        ),
+        CourseSection(
+            offering_id=offering.id,
+            source_section_id=f"{code}-T01",
+            name="T01",
+            section_type="T",
+            bundle=1,
+            layer=1,
+            quota=15,
+            is_main=False,
+        ),
+    ]
+    db.session.add_all(sections)
+    db.session.flush()
+    return course, offering, sections
+
+
+def add_cart(user, offering, sections, *, enabled=False, selected=(True, True)):
+    db.session.add(UserOfferingCart(
+        user_id=user.id,
+        offering_id=offering.id,
+        enabled=enabled,
+    ))
+    for section, selection_enabled in zip(sections, selected):
+        db.session.add(UserSectionSelection(
+            user_id=user.id,
+            offering_id=offering.id,
+            section_id=section.id,
+            enabled=selection_enabled,
+            source="cart",
+        ))
+
+
+def test_popularity_requires_authenticated_verified_canonical_institutional_viewer(client, app):
+    assert client.get("/scheduler/popularity/2530?course_codes=POP1001").status_code == 401
+
+    with app.app_context():
+        unverified = create_user("unverified", "unverified@hkust-gz.edu.cn", verified=False)
+        external = create_user("external", "external@example.com")
+        oldest = create_user(
+            "oldest",
+            "duplicate@hkust-gz.edu.cn",
+            created_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        duplicate = create_user("duplicate", " DUPLICATE@HKUST-GZ.EDU.CN ")
+        db.session.commit()
+        unverified_headers = headers_for(unverified)
+        external_headers = headers_for(external)
+        oldest_headers = headers_for(oldest)
+        duplicate_headers = headers_for(duplicate)
+
+    assert client.get("/scheduler/popularity/2530", headers=unverified_headers).status_code == 403
+    assert client.get("/scheduler/popularity/2530", headers=external_headers).status_code == 403
+    assert client.get("/scheduler/popularity/2530", headers=duplicate_headers).status_code == 403
+    assert client.get("/scheduler/popularity/2530", headers=oldest_headers).status_code == 200
+
+
+def test_popularity_is_cart_scoped_exact_anonymous_and_excludes_ineligible_duplicates(client, app):
+    with app.app_context():
+        _, offering, sections = create_offering()
+        _, hidden_offering, hidden_sections = create_offering("POP2001")
+        viewer = create_user("viewer", "viewer@hkust-gz.edu.cn")
+        looking = create_user("looking", "looking@connect.hkust-gz.edu.cn")
+        scheduling = create_user("scheduling", "scheduling@hkust-gz.edu.cn")
+        unverified = create_user("unverified_count", "uv@hkust-gz.edu.cn", verified=False)
+        external = create_user("external_count", "outside@example.com")
+        deleted = create_user("deleted_count", "deleted@hkust-gz.edu.cn", deleted=True)
+        canonical = create_user(
+            "canonical_count",
+            "same@hkust-gz.edu.cn",
+            created_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+        duplicate = create_user("duplicate_count", " SAME@HKUST-GZ.EDU.CN ")
+        create_user(
+            "canonical_without_cart",
+            "no_cart@hkust-gz.edu.cn",
+            created_at=datetime.now(timezone.utc) - timedelta(days=3),
+        )
+        duplicate_with_cart = create_user(
+            "duplicate_with_cart",
+            " NO_CART@HKUST-GZ.EDU.CN ",
+        )
+
+        add_cart(viewer, offering, sections, selected=(False, False))
+        add_cart(looking, offering, sections, enabled=False, selected=(True, False))
+        add_cart(scheduling, offering, sections, enabled=True, selected=(True, True))
+        add_cart(unverified, offering, sections)
+        add_cart(external, offering, sections)
+        add_cart(deleted, offering, sections)
+        add_cart(canonical, offering, sections, enabled=False, selected=(True, True))
+        add_cart(duplicate, offering, sections, enabled=True, selected=(True, True))
+        add_cart(duplicate_with_cart, offering, sections, enabled=True, selected=(True, True))
+        add_cart(looking, hidden_offering, hidden_sections)
+        db.session.commit()
+        viewer_headers = headers_for(viewer)
+
+    response = client.get(
+        "/scheduler/popularity/2530?course_codes=pop%201001,POP2001,POP1001",
+        headers=viewer_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "Authorization"
+    data = response.get_json()
+    assert set(data) == {"semester_id", "generated_at", "courses"}
+    assert data["semester_id"] == "2530"
+    assert len(data["courses"]) == 1
+    course = data["courses"][0]
+    assert set(course) == {"course_code", "looking_count", "scheduling_count", "sections"}
+    assert course["course_code"] == "POP1001"
+    # viewer + looking + canonical; the newer duplicate and ineligible accounts do not count.
+    assert course["looking_count"] == 3
+    assert course["scheduling_count"] == 1
+    assert course["sections"] == [
+        {"section_id": "POP1001-L01", "looking_count": 2, "scheduling_count": 1},
+        {"section_id": "POP1001-T01", "looking_count": 1, "scheduling_count": 1},
+    ]
+    serialized = str(data).lower()
+    for private_key in ("user_id", "username", "email", "event", "offering_id"):
+        assert private_key not in serialized
+
+
+def test_popularity_rejects_cross_offering_selection_and_initializes_zero_sections(client, app):
+    with app.app_context():
+        _, offering, sections = create_offering()
+        _, other_offering, other_sections = create_offering("POP3001")
+        viewer = create_user("viewer_cross", "viewer_cross@hkust-gz.edu.cn")
+        contributor = create_user("contributor_cross", "contributor_cross@hkust-gz.edu.cn")
+        add_cart(viewer, offering, sections, selected=(False, False))
+        db.session.add(UserOfferingCart(
+            user_id=contributor.id,
+            offering_id=offering.id,
+            enabled=False,
+        ))
+        # The section FK is valid, but its offering deliberately disagrees with the selection.
+        db.session.add(UserSectionSelection(
+            user_id=contributor.id,
+            offering_id=offering.id,
+            section_id=other_sections[0].id,
+            enabled=True,
+            source="cart",
+        ))
+        db.session.commit()
+        viewer_headers = headers_for(viewer)
+
+    course = client.get(
+        "/scheduler/popularity/2530?course_codes=POP1001",
+        headers=viewer_headers,
+    ).get_json()["courses"][0]
+    assert course["looking_count"] == 2
+    assert course["sections"] == [
+        {"section_id": "POP1001-L01", "looking_count": 0, "scheduling_count": 0},
+        {"section_id": "POP1001-T01", "looking_count": 0, "scheduling_count": 0},
+    ]
+
+
+def test_popularity_empty_filter_limit_and_archived_cart_scope(client, app):
+    with app.app_context():
+        _, offering, sections = create_offering(status="archived")
+        viewer = create_user("viewer_limits", "viewer_limits@hkust-gz.edu.cn")
+        add_cart(viewer, offering, sections)
+        db.session.commit()
+        viewer_headers = headers_for(viewer)
+
+    empty = client.get("/scheduler/popularity/2530", headers=viewer_headers)
+    assert empty.status_code == 200
+    assert empty.get_json()["courses"] == []
+
+    archived = client.get(
+        "/scheduler/popularity/2530?course_codes=POP1001",
+        headers=viewer_headers,
+    )
+    assert archived.status_code == 200
+    assert archived.get_json()["courses"] == []
+
+    too_many = ",".join(f"TEST{i:04d}" for i in range(31))
+    limited = client.get(
+        f"/scheduler/popularity/2530?course_codes={too_many}",
+        headers=viewer_headers,
+    )
+    assert limited.status_code == 400
+
+
+def test_cart_mutations_log_only_actual_anonymous_transitions(client, app):
+    with app.app_context():
+        create_offering()
+        user = create_user("event_user", "event_user@hkust-gz.edu.cn")
+        db.session.commit()
+        user_headers = headers_for(user)
+
+    added = client.post(
+        "/scheduler/cart/2530/add",
+        json={"course_code": "POP1001"},
+        headers=user_headers,
+    )
+    assert added.status_code == 200
+    with app.app_context():
+        assert SchedulerPopularityEvent.query.filter_by(reason="cart_added").count() == 3
+        assert "user_id" not in SchedulerPopularityEvent.__table__.columns
+
+    no_op = client.put(
+        "/scheduler/cart/2530/course/POP1001/toggle",
+        json={"enabled": False},
+        headers=user_headers,
+    )
+    assert no_op.status_code == 200
+    with app.app_context():
+        assert SchedulerPopularityEvent.query.count() == 3
+
+    enabled = client.put(
+        "/scheduler/cart/2530/course/POP1001/toggle",
+        json={"enabled": True},
+        headers=user_headers,
+    )
+    assert enabled.status_code == 200
+    with app.app_context():
+        toggles = SchedulerPopularityEvent.query.filter_by(reason="course_toggled").all()
+        assert len(toggles) == 3
+        assert {(event.from_state, event.to_state) for event in toggles} == {
+            ("looking", "scheduling")
+        }
+
+    disabled_bundle = client.put(
+        "/scheduler/cart/2530/bundle/POP1001/1/1/toggle",
+        json={"enabled": False},
+        headers=user_headers,
+    )
+    assert disabled_bundle.status_code == 200
+    with app.app_context():
+        bundle_events = SchedulerPopularityEvent.query.filter_by(reason="bundle_toggled").all()
+        assert len(bundle_events) == 1
+        assert (bundle_events[0].from_state, bundle_events[0].to_state) == ("scheduling", None)
+
+    removed = client.delete(
+        "/scheduler/cart/2530/remove/POP1001",
+        headers=user_headers,
+    )
+    assert removed.status_code == 200
+    with app.app_context():
+        removal_events = SchedulerPopularityEvent.query.filter_by(reason="cart_removed").all()
+        assert len(removal_events) == 2
+        assert sum(event.section_id is None for event in removal_events) == 1
+
+
+@pytest.mark.parametrize("route", [
+    "/scheduler/cart/2530/course/POP1001/toggle",
+    "/scheduler/cart/2530/bundle/POP1001/1/0/toggle",
+    "/scheduler/cart/2530/layer/POP1001/0/toggle",
+])
+def test_cart_toggles_require_boolean_enabled(client, app, route):
+    with app.app_context():
+        _, offering, sections = create_offering()
+        user = create_user(f"bool_{route.split('/')[-2]}", f"bool_{route.split('/')[-2]}@hkust-gz.edu.cn")
+        add_cart(user, offering, sections)
+        db.session.commit()
+        user_headers = headers_for(user)
+
+    response = client.put(route, json={"enabled": "false"}, headers=user_headers)
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "enabled must be a boolean"}
+    with app.app_context():
+        assert SchedulerPopularityEvent.query.count() == 0
+
+
+def test_ineligible_and_non_offered_mutations_do_not_log(client, app):
+    with app.app_context():
+        create_offering("ARCH1001", status="archived")
+        create_offering("POP1001")
+        user = create_user("unverified_event", "unverified_event@hkust-gz.edu.cn", verified=False)
+        create_user(
+            "canonical_event",
+            "duplicate_event@hkust-gz.edu.cn",
+            created_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        duplicate = create_user("duplicate_event", " DUPLICATE_EVENT@HKUST-GZ.EDU.CN ")
+        db.session.commit()
+        user_headers = headers_for(user)
+        duplicate_headers = headers_for(duplicate)
+
+    archived = client.post(
+        "/scheduler/cart/2530/add",
+        json={"course_code": "ARCH1001"},
+        headers=user_headers,
+    )
+    assert archived.status_code == 422
+    added = client.post(
+        "/scheduler/cart/2530/add",
+        json={"course_code": "POP1001"},
+        headers=user_headers,
+    )
+    assert added.status_code == 200
+    duplicate_added = client.post(
+        "/scheduler/cart/2530/add",
+        json={"course_code": "POP1001"},
+        headers=duplicate_headers,
+    )
+    assert duplicate_added.status_code == 200
+    with app.app_context():
+        assert SchedulerPopularityEvent.query.count() == 0

--- a/tests/test_scheduler_schema_support.py
+++ b/tests/test_scheduler_schema_support.py
@@ -69,3 +69,41 @@ def test_database_url_schema_query_maps_to_postgres_search_path():
 
     assert uri == "postgresql://user:pass@localhost/course_scheduler"
     assert engine_options["connect_args"]["options"] == "-csearch_path=public"
+
+
+def test_auto_init_course_domain_support_includes_popularity_table_and_indexes():
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(flask_app)
+
+    with flask_app.app_context():
+        with db.engine.begin() as conn:
+            conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY)"))
+            conn.execute(text("CREATE TABLE posts (id INTEGER PRIMARY KEY)"))
+            conn.execute(text(
+                """
+                CREATE TABLE courses (
+                    id INTEGER PRIMARY KEY,
+                    code VARCHAR(20) NOT NULL UNIQUE,
+                    name VARCHAR(255) NOT NULL,
+                    credits INTEGER NOT NULL,
+                    is_deleted BOOLEAN NOT NULL DEFAULT false
+                )
+                """
+            ))
+
+        app_package._auto_init_course_domain_support()
+        app_package._auto_init_course_domain_support()
+
+        inspector = inspect(db.engine)
+        assert "scheduler_popularity_events" in inspector.get_table_names()
+        cart_indexes = {index["name"] for index in inspector.get_indexes("user_offering_carts")}
+        selection_indexes = {
+            index["name"] for index in inspector.get_indexes("user_section_selections")
+        }
+        assert "idx_user_offering_carts_popularity" in cart_indexes
+        assert "idx_user_section_selections_popularity" in selection_indexes


### PR DESCRIPTION
## Summary

- Preserve stable course-section identities during scheduler imports so saved carts and section choices survive data refreshes.
- Reconcile legacy scheduler snapshots into the course-domain tables used by the main-site API and hide archived offerings.
- Gate production backend deployment on the complete pytest suite.
- Harden institutional-email ownership, verification throttling, and the legacy `POST /users` alias so duplicate principals and role injection cannot bypass the popularity trust boundary.
- Add verified-account scheduler popularity snapshots, anonymous transition logging, aggregation indexes, and an idempotent migration/backfill.

## Popularity contract

- **Looking** = the course is in a verified user's cart but disabled.
- **Actively planning** = the course is enabled in that user's scheduler.
- Section counts include only enabled section choices and are repeated by the frontend on that section's lecture blocks.
- Only active, verified, canonical HKUST-GZ accounts contribute and view.
- Viewers can request at most 30 courses already present in their own cart.
- Responses contain course/section identifiers and counts only—no names, emails, user IDs, event IDs, or contributor timestamps.
- Responses are `private, no-store`; raw transition events contain no actor identifier and have no public endpoint.

## Migration and rollout

`20260807_sched_popularity` creates the anonymous event table and aggregation indexes, then backfills missing legacy section-selection rows using same bundle/layer state or the historical default of enabled. Upgrade is idempotent; downgrade removes feature schema while retaining conservative data repairs.

## Verification

- Complete backend suite: **339 passed**
- Focused auth/email/popularity remediation suite: **20 passed**
- Migration upgrade twice + legacy backfill + downgrade: passed
- PostgreSQL DDL/backfill compilation review: passed
- Independent integration-fix review: approved
- Independent feature review found the legacy account-creation bypass; remediation `30e3292` was re-tested and approved

## Known tradeoff

Counts are intentionally exact to match the requested “selected people count.” Even without identities, small real-time counts can permit change-timing inference or scraping by a verified user who churns courses through their cart. The endpoint limits scope and account eligibility, but it does not add count bands/suppression or server-side rate limiting in this PR.
