### PR TITLE
fix course identity reconciliation and refresh 2610 data

### DIFF
--- a/app/data/pending/README.md
+++ b/app/data/pending/README.md
@@ -7,17 +7,20 @@ not loaded by application startup and must not be added to
 
 The manual importer defaults to dry-run. Every run must provide the reviewed
 file SHA-256 and exact control totals; adding `--apply` is the separate,
-intentional deployment step. The commands below contain the controls for the
-snapshots captured on 2026-08-09. Do not update the hashes or counts without
+intentional deployment step. Do not update the hashes or counts without
 reviewing a newly generated package.
 
 ## 2026-27 Fall scheduler (2610)
 
 The current snapshot was generated from all 29 subjects advertised by the
 official HKUST-GZ Class Schedule & Quota page. It contains 383 offered courses,
-801 sections, and 824 canonical weekly meetings. The source HTML hashes and
-retrieval timestamp are embedded in the JSON. Date-specific schedule rows and
-three A/B-lab grouping approximations are retained as explicit provenance.
+801 schedulable sections, and 820 canonical weekly meetings. Two additional
+official TBA rows (`UFUG1301/6951` and `UFUG1302/6952`) cannot be represented
+faithfully by the current layer/bundle model, so they are excluded from the
+scheduler while every source field and the reviewed reason are retained in
+provenance. The source HTML hashes and 2026-08-10 retrieval timestamp are
+embedded in the JSON. Date-specific schedule rows and three A/B-lab grouping
+approximations are also retained as explicit provenance.
 
 To reproduce the package from freshly fetched official pages (this only writes
 pending JSON and never connects to a database):
@@ -32,12 +35,39 @@ Review and dry-run the captured package:
 ```bash
 python -m app.scripts.import_pending_academic_data scheduler \
   --file app/data/pending/scheduler_offerings/26-27fall.json \
-  --expected-sha256 64cf81e1cabe6bef350b6be1c29206329fe22bfe7e6d820eedd812c419d347cc \
+  --expected-sha256 4ec2cb305a31348944cba064dba9435825f19d5c1b99f9e2e8177e233eddfbff \
   --expected-courses 383 \
   --expected-offered-courses 383 \
   --expected-sections 801 \
-  --expected-lectures 824
+  --expected-lectures 820
 ```
+
+If that dry-run reports ambiguous whitespace variants of the same course code,
+do not apply the scheduler package. First take a verified database backup and
+run the fail-closed reconciliation in its default dry-run mode:
+
+```bash
+python -m app.scripts.reconcile_course_duplicates
+```
+
+Review the reported database identity, blockers, plan SHA-256, and pair/record/
+tag counts. Applying the repair physically deletes only the reviewed duplicate
+rows, so it requires all controls from that exact plan:
+
+```bash
+python -m app.scripts.reconcile_course_duplicates \
+  --apply \
+  --expected-database DATABASE_NAME \
+  --expected-plan-sha256 PLAN_SHA256 \
+  --expected-pairs PAIR_COUNT \
+  --expected-records RECORD_COUNT \
+  --expected-tags TAG_COUNT
+```
+
+Rerun both reconciliation and scheduler dry-runs after the repair. The former
+must report zero pairs and the latter must retain the reviewed `383/383/801/820`
+control totals with no omitted imported offerings, sections, or meetings. The
+two reviewed provenance-only TBA rows must remain absent from imported sections.
 
 ## 2026 cohort curriculum requirements
 

--- a/app/data/pending/scheduler_offerings/26-27fall.json
+++ b/app/data/pending/scheduler_offerings/26-27fall.json
@@ -5,7 +5,7 @@
   "provenance": {
     "source_name": "HKUST-GZ Class Schedule & Quota",
     "term_url": "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/2610/",
-    "retrieved_at": "2026-08-09T15:18:42Z",
+    "retrieved_at": "2026-08-10T19:37:12Z",
     "term_index_sha256": "82dc21664b9ca06502022e7dfada4fa81814deb8aabd96ec5c58d73654c3d86e",
     "approximations": [
       {
@@ -183,10 +183,99 @@
         "explanation": "The source uses duplicate numeric bundle suffixes for A/B alternatives. The current (layer,bundle) schema cannot preserve both lecture-to-section pairing and alternative choice, so this type uses an independent layer with unique bundles; cross-pair choices may be generated. Original names and section IDs are retained."
       },
       {
+        "kind": "unscheduled_source_section_omitted",
+        "course_code": "UFUG1301",
+        "semester_id": "2610",
+        "section_id": "6951",
+        "source_label": "TBA (6951)",
+        "retained_at": "provenance.unscheduled_sections",
+        "review_basis": "The source note explicitly identifies this as an opt-in lab fallback whose meeting will be coordinated later.",
+        "explanation": "The official row has no component type or meeting time. Mapping it to a scheduler section would invent a type, layer, and bundle that could incorrectly make the row a required choice. It is omitted from schedulable sections; all source fields remain in provenance.unscheduled_sections."
+      },
+      {
+        "kind": "unscheduled_source_section_omitted",
+        "course_code": "UFUG1302",
+        "semester_id": "2610",
+        "section_id": "6952",
+        "source_label": "TBA (6952)",
+        "retained_at": "provenance.unscheduled_sections",
+        "review_basis": "The source supplies no component type or meeting and only marks the row as requiring instructor consent.",
+        "explanation": "The official row has no component type or meeting time. Mapping it to a scheduler section would invent a type, layer, and bundle that could incorrectly make the row a required choice. It is omitted from schedulable sections; all source fields remain in provenance.unscheduled_sections."
+      },
+      {
         "kind": "date_ranges_collapsed_to_weekly_meetings",
         "affected_canonical_meetings": 143,
         "retained_date_range_values": 415,
         "explanation": "The current meeting schema stores weekday and time but no effective date range. Date-specific WCQ rows are therefore collapsed to canonical weekly slots. Every original date/time cell is retained in source_date_times for audit and a future date-aware schema migration."
+      }
+    ],
+    "unscheduled_sections": [
+      {
+        "course_code": "UFUG1301",
+        "semester_id": "2610",
+        "source_name": "TBA",
+        "source_label": "TBA (6951)",
+        "section_id": "6951",
+        "date_time": "TBA",
+        "room": "TBA",
+        "instructor": "TBA",
+        "quota": 5,
+        "enrol": 0,
+        "avail": 5,
+        "wait": 0,
+        "remarks": [
+          "> If the lab sessions listed in the course schedule are not suitable for your availability, or if you were unable to enroll in a session, you can contact the instructor to request access to the \"TBA\" section. The lab class schedule will be coordinated later based on the availability of students who select \"TBA.\" Please pay attention to further notifications.",
+          "Instructor Consent Required"
+        ],
+        "review_basis": "The source note explicitly identifies this as an opt-in lab fallback whose meeting will be coordinated later.",
+        "source_row_classes": [
+          "newsect",
+          "sectodd"
+        ],
+        "source_cell_values": [
+          "TBA (6951)",
+          "TBA",
+          "TBA",
+          "TBA",
+          "5",
+          "0",
+          "5",
+          "0",
+          "> If the lab sessions listed in the course schedule are not suitable for your availability, or if you were unable to enroll in a session, you can contact the instructor to request access to the \"TBA\" section. The lab class schedule will be coordinated later based on the availability of students who select \"TBA.\" Please pay attention to further notifications.Instructor Consent Required"
+        ]
+      },
+      {
+        "course_code": "UFUG1302",
+        "semester_id": "2610",
+        "source_name": "TBA",
+        "source_label": "TBA (6952)",
+        "section_id": "6952",
+        "date_time": "TBA",
+        "room": "TBA",
+        "instructor": "TBA",
+        "quota": 5,
+        "enrol": 0,
+        "avail": 5,
+        "wait": 0,
+        "remarks": [
+          "Instructor Consent Required"
+        ],
+        "review_basis": "The source supplies no component type or meeting and only marks the row as requiring instructor consent.",
+        "source_row_classes": [
+          "newsect",
+          "secteven"
+        ],
+        "source_cell_values": [
+          "TBA (6952)",
+          "TBA",
+          "TBA",
+          "TBA",
+          "5",
+          "0",
+          "5",
+          "0",
+          "Instructor Consent Required"
+        ]
       }
     ],
     "subjects": [
@@ -350,13 +439,13 @@
         "code": "UCUG",
         "classification": "ug",
         "url": "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/index.php?term=2610&subject=UCUG",
-        "sha256": "e15f81aee380c634679ca5cb851ae6e332369fad2bf7614dde6597932c380606"
+        "sha256": "4c504e994d171adc03f7a8dc948da994de36524ec306e068709be176fb64358f"
       },
       {
         "code": "UFUG",
         "classification": "ug",
         "url": "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/index.php?term=2610&subject=UFUG",
-        "sha256": "41cfe3ef28d2f9b73e381264b8082feb36fc2fbe69f0398461357baca8e7c803"
+        "sha256": "5b737f3b7dffb22d18a62ffcca82194401098c3b40b074d396548bed88c8a019"
       },
       {
         "code": "UGOD",
@@ -10528,7 +10617,7 @@
       "exclusion": null,
       "pg_course": true,
       "klms_course": false,
-      "vector": null,
+      "vector": "[0-0-0:0]",
       "matching": "",
       "course_info": {
         "DESCRIPTION": "This course provides a foundational introduction to microeconomics, game theory, and algorithmic mechanism design, with a specific focus on their application to modern multi-agent systems for AIoT. Students will explore how economic principles and strategic interactions govern the behavior of agents in a variety of networked environments, including adversarial defense, information systems, communication networks, social networks, and cyber-physical systems like energy and transportation grids. The curriculum bridges theoretical concepts with practical applications. Core topics include market mechanisms, consumer preferences, and the objectives of cost and welfare maximization. A significant portion of the course is dedicated to multi-agent game theory, covering strategic games, pure and mixed strategy Nash equilibrium, correlated equilibrium, and the dynamics of repeated games. We will also explore extensive-form games, solution concepts like backward induction and subgame perfect equilibrium, and games of incomplete information, such as Bayesian games. The course then advances to contemporary multi-agent paradigms, examining bandit and reinforcement learning algorithms for sequential decision-making under uncertainty, the principles of federated learning algorithms for privacy-preserving distributed optimization, and their connections to multi-agent mechanism design—including auctions, pricing, contracts, facility location, and information manipulation. The course concludes by tying these elements together within the context of distributed systems that underpin these multi-agent interactions.",
@@ -10575,7 +10664,7 @@
       "exclusion": null,
       "pg_course": true,
       "klms_course": false,
-      "vector": null,
+      "vector": "[3-0-0:3]",
       "matching": "",
       "course_info": {
         "DESCRIPTION": "This course introduces fundamental and advanced machine learning techniques for ubiquitous computing systems, with a focus on sensor-driven human-centric applications. It covers representation learning from multimodal sensor data, self-supervised learning, generative AI, and challenges such as domain shift, personalization, and on-device deployment. Through case studies in wearable AI, mobile computing, and smart cities, students will learn how to design, analyze, and deploy scalable learning systems in real-world ubiquitous settings.",
@@ -19500,18 +19589,18 @@
           "name": "T01",
           "bundle": 1,
           "semester_id": "2610",
-          "section_id": "6267",
-          "quota": 25,
+          "section_id": "6269",
+          "quota": 20,
           "enrol": 0,
-          "avail": 25,
+          "avail": 20,
           "wait": 0,
           "lectures": [
             {
               "day": 2,
               "start_time": "0900",
               "end_time": "1020",
-              "room": "Rm 202, W4",
-              "instructor": "LI, Bing",
+              "room": "Rm 201, W2",
+              "instructor": "HONG, Xuancu",
               "source_date_times": [
                 "TuTh 09:00AM - 10:20AM"
               ]
@@ -19520,8 +19609,8 @@
               "day": 4,
               "start_time": "0900",
               "end_time": "1020",
-              "room": "Rm 202, W4",
-              "instructor": "LI, Bing",
+              "room": "Rm 201, W2",
+              "instructor": "HONG, Xuancu",
               "source_date_times": [
                 "TuTh 09:00AM - 10:20AM"
               ]
@@ -19536,82 +19625,10 @@
           "name": "T02",
           "bundle": 2,
           "semester_id": "2610",
-          "section_id": "6268",
-          "quota": 25,
-          "enrol": 0,
-          "avail": 25,
-          "wait": 0,
-          "lectures": [
-            {
-              "day": 2,
-              "start_time": "1200",
-              "end_time": "1320",
-              "room": "Rm 221, W1",
-              "instructor": "LI, Bing",
-              "source_date_times": [
-                "TuTh 12:00PM - 01:20PM"
-              ]
-            },
-            {
-              "day": 4,
-              "start_time": "1200",
-              "end_time": "1320",
-              "room": "Rm 221, W1",
-              "instructor": "LI, Bing",
-              "source_date_times": [
-                "TuTh 12:00PM - 01:20PM"
-              ]
-            }
-          ],
-          "is_main": true,
-          "layer": 0
-        },
-        {
-          "course_code": "UCUG1050",
-          "section_type": "T",
-          "name": "T03",
-          "bundle": 3,
-          "semester_id": "2610",
-          "section_id": "6269",
-          "quota": 25,
-          "enrol": 0,
-          "avail": 25,
-          "wait": 0,
-          "lectures": [
-            {
-              "day": 2,
-              "start_time": "0900",
-              "end_time": "1020",
-              "room": "Rm 201, W2",
-              "instructor": "HONG, Xuancu",
-              "source_date_times": [
-                "TuTh 09:00AM - 10:20AM"
-              ]
-            },
-            {
-              "day": 4,
-              "start_time": "0900",
-              "end_time": "1020",
-              "room": "Rm 201, W2",
-              "instructor": "HONG, Xuancu",
-              "source_date_times": [
-                "TuTh 09:00AM - 10:20AM"
-              ]
-            }
-          ],
-          "is_main": true,
-          "layer": 0
-        },
-        {
-          "course_code": "UCUG1050",
-          "section_type": "T",
-          "name": "T04",
-          "bundle": 4,
-          "semester_id": "2610",
           "section_id": "6270",
-          "quota": 25,
+          "quota": 20,
           "enrol": 0,
-          "avail": 25,
+          "avail": 20,
           "wait": 0,
           "lectures": [
             {
@@ -20198,6 +20215,36 @@
               ]
             }
           ],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1051",
+          "section_type": "T",
+          "name": "T16",
+          "bundle": 16,
+          "semester_id": "2610",
+          "section_id": "6949",
+          "quota": 1,
+          "enrol": 0,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [],
+          "is_main": true,
+          "layer": 0
+        },
+        {
+          "course_code": "UCUG1051",
+          "section_type": "T",
+          "name": "T17",
+          "bundle": 17,
+          "semester_id": "2610",
+          "section_id": "6950",
+          "quota": 1,
+          "enrol": 0,
+          "avail": 1,
+          "wait": 0,
+          "lectures": [],
           "is_main": true,
           "layer": 0
         }
@@ -29379,7 +29426,7 @@
       "exclusion": null,
       "pg_course": true,
       "klms_course": false,
-      "vector": null,
+      "vector": "[3-0-0:3]",
       "matching": "",
       "course_info": {
         "DESCRIPTION": "This course examines how AI-enabled decision systems are governed in urban domains such as transport, housing, labor, and public services, and how governance choices shape access, accountability, and the distribution of risks and resources. Students gain working literacy in core AI concepts and common algorithmic system types used in digital society, and learn to apply risk-based governance and accountability instruments across the system lifecycle (Govern–Map–Measure–Manage), including algorithmic impact assessments, transparency registers, audit and continuous monitoring requirements, and data-sharing and privacy frameworks, to ensure legality, reliability, and public value in real policy contexts. This course also provides an initial, case-based lens for students to engage more deeply with sociological explanations in the subsequent course UGOD 5050 Cities and Society in spring term.",

--- a/app/routes/course.py
+++ b/app/routes/course.py
@@ -17,7 +17,11 @@ from sqlalchemy import func, desc, asc
 from functools import wraps
 import bleach
 import re
-from app.services.course_domain import current_catalog_version, display_course_code
+from app.services.course_domain import (
+    current_catalog_version,
+    display_course_code,
+    normalize_course_code,
+)
 
 bp = Blueprint('course', __name__, url_prefix='/courses')
 COURSE_REVIEW_TAG = "course-review"
@@ -116,6 +120,29 @@ def _find_course_by_identifier(identifier):
     if not candidates:
         return None
     return max(candidates, key=lambda course: _rank_course_identifier_candidate(course, compact))
+
+
+def _active_course_identity_exists(normalized_code, *, exclude_course_id=None):
+    direct_query = Course.query.filter(
+        Course.normalized_code == normalized_code,
+        Course.is_deleted == False,
+    )
+    if exclude_course_id is not None:
+        direct_query = direct_query.filter(Course.id != exclude_course_id)
+    direct_match = direct_query.first()
+    if direct_match:
+        return True
+
+    code_query = (
+        Course.query.with_entities(Course.code)
+        .filter(Course.is_deleted == False)
+    )
+    if exclude_course_id is not None:
+        code_query = code_query.filter(Course.id != exclude_course_id)
+    return any(
+        normalize_course_code(code) == normalized_code
+        for (code,) in code_query.all()
+    )
 
 
 def _scheduler_semester_id(year, semester_code):
@@ -416,16 +443,20 @@ def create_course():
         
         # Sanitize inputs
         code = bleach.clean(data['code']).strip().upper()
+        normalized_code = normalize_course_code(code)
+        if not normalized_code:
+            return jsonify({"error": "code is required"}), 400
         name = bleach.clean(data['name']).strip()
         description = bleach.clean(data.get('description', ''))
         
-        # Check if course code already exists
-        if Course.query.filter_by(code=code, is_deleted=False).first():
+        # Reject both canonical codes and whitespace-only legacy aliases.
+        if _active_course_identity_exists(normalized_code):
             return jsonify({"error": "Course with this code already exists"}), 400
         
         # Create new course
         course = Course(
             code=code,
+            normalized_code=normalized_code,
             name=name,
             description=description,
             instructor_id=data['instructor_id'],
@@ -523,15 +554,16 @@ def update_course(course_id):
         # Update fields if provided
         if 'code' in data:
             code = bleach.clean(data['code']).strip().upper()
-            # Check if new code already exists
-            existing_course = Course.query.filter(
-                Course.code == code,
-                Course.id != course_id,
-                Course.is_deleted == False
-            ).first()
-            if existing_course:
+            normalized_code = normalize_course_code(code)
+            if not normalized_code:
+                return jsonify({"error": "code is required"}), 400
+            if _active_course_identity_exists(
+                normalized_code,
+                exclude_course_id=course_id,
+            ):
                 return jsonify({"error": "Course with this code already exists"}), 400
             course.code = code
+            course.normalized_code = normalized_code
             
         if 'name' in data:
             course.name = bleach.clean(data['name']).strip()

--- a/app/scripts/adjust_aiaa_25_26_spring.py
+++ b/app/scripts/adjust_aiaa_25_26_spring.py
@@ -175,7 +175,8 @@ def _resolve_course_for_target(
         return course
 
     course = Course(
-        code=spec.preferred_code,
+        code=spec.logical_code,
+        normalized_code=spec.logical_code,
         name=spec.name,
         credits=spec.credits,
         is_active=True,
@@ -285,7 +286,7 @@ def apply_aiaa_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
         if not had_any_course:
             created_courses += 1
 
-        desired_tag_name = f"{course.code}-{TAG_SUFFIX}"
+        desired_tag_name = f"{logical}-{TAG_SUFFIX}"
         target_tag = Tag.query.filter_by(name=desired_tag_name).first()
         if not target_tag:
             target_tag = Tag(

--- a/app/scripts/adjust_ucug_25_26_spring.py
+++ b/app/scripts/adjust_ucug_25_26_spring.py
@@ -21,6 +21,7 @@ from sqlalchemy import delete
 from app.extensions import db
 from app.models.course import Course
 from app.models.tag import Tag, TagType, post_tags
+from app.services.course_domain import find_course_by_code, normalize_course_code
 from app.utils.semester import parse_semester_tag
 
 TARGET_SPRING_YEAR = "2025"
@@ -104,8 +105,9 @@ def apply_ucug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
     if to_remove:
         log(f"Removed {len(to_remove)} semester tag(s); unlinked {unlinked} post_tag row(s).")
 
-    for code, name, credits in NEW_COURSES:
-        course = Course.query.filter_by(code=code, is_deleted=False).first()
+    for source_code, name, credits in NEW_COURSES:
+        code = normalize_course_code(source_code)
+        course = find_course_by_code(code)
         if course:
             course.name = name
             course.credits = credits
@@ -113,6 +115,7 @@ def apply_ucug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
         else:
             course = Course(
                 code=code,
+                normalized_code=code,
                 name=name,
                 credits=credits,
                 is_active=True,
@@ -121,7 +124,7 @@ def apply_ucug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
             db.session.add(course)
             db.session.flush()
 
-        tag_name = f"{course.code}-{TAG_SUFFIX}"
+        tag_name = f"{code}-{TAG_SUFFIX}"
         if Tag.query.filter_by(name=tag_name).first():
             log(f"[skip] tag exists: {tag_name}")
             continue

--- a/app/scripts/adjust_ufug_25_26_spring.py
+++ b/app/scripts/adjust_ufug_25_26_spring.py
@@ -24,6 +24,7 @@ from sqlalchemy import delete
 from app.extensions import db
 from app.models.course import Course
 from app.models.tag import Tag, TagType, post_tags
+from app.services.course_domain import find_course_by_code, normalize_course_code
 from app.utils.semester import parse_semester_tag
 
 TARGET_SPRING_YEAR = "2025"
@@ -102,8 +103,9 @@ def apply_ufug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
     if to_remove:
         log(f"Removed {len(to_remove)} semester tag(s); unlinked {unlinked} post_tag row(s).")
 
-    for code, name, credits in NEW_COURSES:
-        course = Course.query.filter_by(code=code, is_deleted=False).first()
+    for source_code, name, credits in NEW_COURSES:
+        code = normalize_course_code(source_code)
+        course = find_course_by_code(code)
         if course:
             course.name = name
             course.credits = credits
@@ -111,6 +113,7 @@ def apply_ufug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
         else:
             course = Course(
                 code=code,
+                normalized_code=code,
                 name=name,
                 credits=credits,
                 is_active=True,
@@ -119,7 +122,7 @@ def apply_ufug_25_26_spring_adjustments(*, dry_run: bool = False, verbose: bool 
             db.session.add(course)
             db.session.flush()
 
-        tag_name = f"{course.code}-{TAG_SUFFIX}"
+        tag_name = f"{code}-{TAG_SUFFIX}"
         if Tag.query.filter_by(name=tag_name).first():
             log(f"[skip] tag exists: {tag_name}")
             continue

--- a/app/scripts/fetch_hkustgz_wcq.py
+++ b/app/scripts/fetch_hkustgz_wcq.py
@@ -33,9 +33,9 @@ from datetime import datetime, timezone
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Iterable, Sequence
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urljoin, urlparse
-from urllib.request import Request, urlopen
+
+import requests
 
 
 DEFAULT_TERM = "2610"
@@ -44,7 +44,8 @@ DEFAULT_EXPECTED_SUBJECTS = 29
 DEFAULT_EXPECTED_COURSES = 383
 DEFAULT_EXPECTED_OFFERED_COURSES = 383
 DEFAULT_EXPECTED_SECTIONS = 801
-DEFAULT_EXPECTED_LECTURES = 824
+DEFAULT_EXPECTED_LECTURES = 820
+DEFAULT_EXPECTED_UNSCHEDULED_SECTIONS = 2
 DEFAULT_BASE_URL = "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/"
 DEFAULT_OUTPUT = (
     Path(__file__).resolve().parents[1]
@@ -67,6 +68,9 @@ COURSE_HEADING_RE = re.compile(
 SECTION_RE = re.compile(r"^(?P<type>[A-Z]+)(?P<number>\d+)[A-Z]*$")
 SECTION_CELL_RE = re.compile(
     r"^(?P<name>[A-Z]+\d+[A-Z]*)\s*\((?P<section_id>[^()]+)\)$"
+)
+UNSCHEDULED_SECTION_CELL_RE = re.compile(
+    r"^(?P<name>TBA)\s*\((?P<section_id>[^()]+)\)$"
 )
 MEETING_RE = re.compile(
     r"(?P<days>(?:(?:Mo|Tu|We|Th|Fr|Sa|Su))+)[ \t]+"
@@ -94,6 +98,34 @@ SECTION_TYPE_DISPLAY = {
     "T": "Tutorial",
     "LA": "Lab",
     "R": "Research",
+}
+REVIEWED_UNSCHEDULED_SECTIONS: dict[
+    tuple[str, str, str], dict[str, object]
+] = {
+    ("2610", "UFUG1301", "6951"): {
+        "matching": "[Matching between Lecture & Lab required]",
+        "remarks": (
+            "> If the lab sessions listed in the course schedule are not "
+            "suitable for your availability, or if you were unable to enroll "
+            "in a session, you can contact the instructor to request access "
+            'to the "TBA" section. The lab class schedule will be coordinated '
+            "later based on the availability of students who select "
+            '"TBA." Please pay attention to further notifications.',
+            "Instructor Consent Required",
+        ),
+        "review_basis": (
+            "The source note explicitly identifies this as an opt-in lab "
+            "fallback whose meeting will be coordinated later."
+        ),
+    },
+    ("2610", "UFUG1302", "6952"): {
+        "matching": "[Matching between Lecture & Tutorial required]",
+        "remarks": ("Instructor Consent Required",),
+        "review_basis": (
+            "The source supplies no component type or meeting and only marks "
+            "the row as requiring instructor consent."
+        ),
+    },
 }
 VOID_TAGS = {
     "area",
@@ -173,6 +205,13 @@ class SubjectReference:
 class ParsedPage:
     subject: str
     courses: list[dict[str, object]]
+    unscheduled_sections: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class ParsedSections:
+    schedulable: list[dict[str, object]]
+    unscheduled: list[dict[str, object]]
 
 
 def _parse_tree(html: str) -> HtmlNode:
@@ -405,6 +444,103 @@ def _integer_cell(
     raise WCQPreparationError(f"{context}: expected an integer")
 
 
+def _popup_details(cell: HtmlNode) -> list[str]:
+    return [
+        detail
+        for detail in (
+            _text(node)
+            for node in _find_all(cell, "div", class_name="popupdetail")
+        )
+        if detail
+    ]
+
+
+def _reviewed_unscheduled_section(
+    row: HtmlNode,
+    cells: list[HtmlNode],
+    *,
+    course_code: str,
+    semester_id: str,
+    matching: str,
+    section_label: str,
+    section_id: str,
+) -> dict[str, object]:
+    identity = (semester_id, course_code, section_id)
+    policy = REVIEWED_UNSCHEDULED_SECTIONS.get(identity)
+    if policy is None:
+        raise WCQPreparationError(
+            f"{course_code}: unreviewed unscheduled section {section_label!r}; "
+            "review its semantics before excluding it from the scheduler"
+        )
+    if len(cells) != 9:
+        raise WCQPreparationError(
+            f"{course_code}/{section_label}: reviewed unscheduled section changed "
+            f"from 9 source cells to {len(cells)}"
+        )
+
+    date_time = _text(cells[1], preserve_breaks=True)
+    room = _room(cells[2])
+    instructor = _instructor(cells[3])
+    quota = _integer_cell(
+        cells[4], f"{course_code}/{section_label} quota", minimum=0
+    )
+    enrol = _integer_cell(
+        cells[5], f"{course_code}/{section_label} enrol", minimum=0
+    )
+    avail = _integer_cell(cells[6], f"{course_code}/{section_label} avail")
+    wait = _integer_cell(
+        cells[7], f"{course_code}/{section_label} wait", minimum=-1
+    )
+    remarks = _popup_details(cells[8])
+    reviewed_values: dict[str, object] = {
+        "matching": matching,
+        "date_time": date_time,
+        "room": room,
+        "instructor": instructor,
+        "quota": quota,
+        "remarks": tuple(remarks),
+    }
+    expected_values: dict[str, object] = {
+        "matching": policy["matching"],
+        "date_time": "TBA",
+        "room": "TBA",
+        "instructor": "TBA",
+        "quota": 5,
+        "remarks": policy["remarks"],
+    }
+    changed = [
+        name
+        for name, expected in expected_values.items()
+        if reviewed_values[name] != expected
+    ]
+    if changed:
+        raise WCQPreparationError(
+            f"{course_code}/{section_label}: reviewed unscheduled section changed "
+            f"({', '.join(changed)}); review it before scheduler omission"
+        )
+
+    return {
+        "course_code": course_code,
+        "semester_id": semester_id,
+        "source_name": "TBA",
+        "source_label": section_label,
+        "section_id": section_id,
+        "date_time": date_time,
+        "room": room,
+        "instructor": instructor,
+        "quota": quota,
+        "enrol": enrol,
+        "avail": avail,
+        "wait": wait,
+        "remarks": remarks,
+        "review_basis": policy["review_basis"],
+        "source_row_classes": sorted(_classes(row)),
+        "source_cell_values": [
+            _text(cell, preserve_breaks=True) for cell in cells
+        ],
+    }
+
+
 def _joined_distinct(existing: str, incoming: str) -> str:
     values: list[str] = []
     for raw_value in (existing, incoming):
@@ -477,7 +613,7 @@ def _parse_sections(
     course_code: str,
     semester_id: str,
     matching: str,
-) -> list[dict[str, object]]:
+) -> ParsedSections:
     tables = _find_all(course_node, "table", class_name="sections")
     if len(tables) != 1:
         raise WCQPreparationError(
@@ -485,8 +621,10 @@ def _parse_sections(
         )
 
     sections: list[dict[str, object]] = []
+    unscheduled_sections: list[dict[str, object]] = []
     current: dict[str, object] | None = None
     skipping_cancelled_section = False
+    skipped_unscheduled_section: str | None = None
     for row in _find_all(tables[0], "tr"):
         cells = _direct_children(row, "td")
         if not cells:
@@ -502,8 +640,26 @@ def _parse_sections(
             if CANCELLED_RE.search(row_status):
                 current = None
                 skipping_cancelled_section = True
+                skipped_unscheduled_section = None
                 continue
             skipping_cancelled_section = False
+            skipped_unscheduled_section = None
+            unscheduled_match = UNSCHEDULED_SECTION_CELL_RE.fullmatch(section_label)
+            if unscheduled_match:
+                unscheduled_sections.append(
+                    _reviewed_unscheduled_section(
+                        row,
+                        cells,
+                        course_code=course_code,
+                        semester_id=semester_id,
+                        matching=matching,
+                        section_label=section_label,
+                        section_id=unscheduled_match.group("section_id").strip(),
+                    )
+                )
+                current = None
+                skipped_unscheduled_section = section_label
+                continue
             section_match = SECTION_CELL_RE.fullmatch(section_label)
             if not section_match:
                 raise WCQPreparationError(
@@ -541,6 +697,11 @@ def _parse_sections(
         else:
             if skipping_cancelled_section:
                 continue
+            if skipped_unscheduled_section is not None:
+                raise WCQPreparationError(
+                    f"{course_code}/{skipped_unscheduled_section}: reviewed "
+                    "unscheduled section unexpectedly has a continuation row"
+                )
             if current is None:
                 raise WCQPreparationError(
                     f"{course_code}: continuation row precedes its section"
@@ -563,9 +724,9 @@ def _parse_sections(
         )
 
     if not sections:
-        # A course with only explicitly cancelled rows remains useful catalog
-        # data but is intentionally not an offered course in this snapshot.
-        return []
+        # A course with only explicitly cancelled or reviewed-unscheduled rows
+        # remains useful catalog data but is intentionally not offered here.
+        return ParsedSections([], unscheduled_sections)
 
     type_order: list[str] = []
     for section in sections:
@@ -649,7 +810,7 @@ def _parse_sections(
             str(item["name"]),
         )
     )
-    return sections
+    return ParsedSections(sections, unscheduled_sections)
 
 
 def parse_subject_page(
@@ -683,6 +844,7 @@ def parse_subject_page(
         raise WCQPreparationError(f"{expected_subject}: page contains no courses")
 
     courses: list[dict[str, object]] = []
+    unscheduled_sections: list[dict[str, object]] = []
     for course_node in course_nodes:
         headings = _find_all(course_node, "h2")
         if len(headings) != 1:
@@ -712,14 +874,16 @@ def parse_subject_page(
             normalized_info[label] = value
         leading_number = re.match(r"\d+", catalog_number)
         numeric_catalog = int(leading_number.group(0)) if leading_number else 0
+        parsed_sections = _parse_sections(
+            course_node,
+            course_code=course_code,
+            semester_id=semester_id,
+            matching=matching,
+        )
+        unscheduled_sections.extend(parsed_sections.unscheduled)
         course: dict[str, object] = {
             "course_code": course_code,
-            "sections": _parse_sections(
-                course_node,
-                course_code=course_code,
-                semester_id=semester_id,
-                matching=matching,
-            ),
+            "sections": parsed_sections.schedulable,
             "subject": subject,
             "catalog_number": catalog_number,
             "course_title": match.group("title"),
@@ -730,34 +894,55 @@ def parse_subject_page(
             "exclusion": info.get("EXCLUSION"),
             "pg_course": numeric_catalog >= 5000,
             "klms_course": False,
-            "vector": None,
+            "vector": info.get("VECTOR"),
             "matching": matching,
             "course_info": normalized_info,
         }
         courses.append(course)
 
     courses.sort(key=lambda item: str(item["course_code"]))
-    return ParsedPage(subject=actual_subject, courses=courses)
+    unscheduled_sections.sort(
+        key=lambda item: (
+            str(item["course_code"]),
+            str(item["section_id"]),
+        )
+    )
+    return ParsedPage(
+        subject=actual_subject,
+        courses=courses,
+        unscheduled_sections=unscheduled_sections,
+    )
 
 
 def _fetch_text(url: str, *, timeout: float) -> str:
-    request = Request(
-        url,
-        headers={
-            "User-Agent": USER_AGENT,
-            "Accept": "text/html,application/xhtml+xml",
-        },
-    )
     try:
-        with urlopen(request, timeout=timeout) as response:
-            content_type = response.headers.get_content_type()
-            if content_type not in {"text/html", "application/xhtml+xml"}:
-                raise WCQPreparationError(
-                    f"{url}: expected HTML, received {content_type}"
-                )
-            charset = response.headers.get_content_charset() or "utf-8"
-            return response.read().decode(charset, errors="strict")
-    except (HTTPError, URLError, TimeoutError, UnicodeError) as exc:
+        response = requests.get(
+            url,
+            timeout=timeout,
+            headers={
+                "User-Agent": USER_AGENT,
+                "Accept": "text/html,application/xhtml+xml",
+            },
+        )
+        response.raise_for_status()
+        content_type_header = response.headers.get("Content-Type", "")
+        content_type = content_type_header.split(";", 1)[0].strip().lower()
+        if content_type not in {"text/html", "application/xhtml+xml"}:
+            raise WCQPreparationError(
+                f"{url}: expected HTML, received {content_type or 'unknown'}"
+            )
+        charset_match = re.search(
+            r'''(?:^|;)\s*charset\s*=\s*(?:"([^"]+)"|'([^']+)'|([^;\s]+))''',
+            content_type_header,
+            re.IGNORECASE,
+        )
+        charset = (
+            next(value for value in charset_match.groups() if value)
+            if charset_match
+            else "utf-8"
+        )
+        return response.content.decode(charset, errors="strict")
+    except (requests.RequestException, LookupError, UnicodeError) as exc:
         raise WCQPreparationError(f"failed to fetch {url}: {exc}") from exc
 
 
@@ -799,8 +984,12 @@ def _iso_timestamp(value: str | None) -> str:
 def snapshot_counts(snapshot: dict[str, object]) -> dict[str, int]:
     courses = snapshot["courses"]
     assert isinstance(courses, list)
+    provenance = snapshot["provenance"]
+    assert isinstance(provenance, dict)
+    unscheduled_sections = provenance["unscheduled_sections"]
+    assert isinstance(unscheduled_sections, list)
     return {
-        "subjects": len(snapshot["provenance"]["subjects"]),  # type: ignore[index]
+        "subjects": len(provenance["subjects"]),  # type: ignore[arg-type]
         "courses": len(courses),
         "offered_courses": sum(
             bool(course["sections"]) for course in courses  # type: ignore[index]
@@ -811,6 +1000,7 @@ def snapshot_counts(snapshot: dict[str, object]) -> dict[str, int]:
             for course in courses
             for section in course["sections"]  # type: ignore[index]
         ),
+        "unscheduled_sections": len(unscheduled_sections),
     }
 
 
@@ -822,6 +1012,7 @@ def validate_snapshot(
     expected_offered_courses: int | None = None,
     expected_sections: int | None = None,
     expected_lectures: int | None = None,
+    expected_unscheduled_sections: int | None = None,
 ) -> dict[str, int]:
     """Validate identities and optional independently reviewed control totals."""
 
@@ -853,6 +1044,36 @@ def validate_snapshot(
                 )
             seen_sections.add(key)
 
+    provenance = snapshot.get("provenance")
+    if not isinstance(provenance, dict):
+        raise WCQPreparationError("snapshot provenance must be an object")
+    unscheduled_sections = provenance.get("unscheduled_sections")
+    if not isinstance(unscheduled_sections, list):
+        raise WCQPreparationError(
+            "snapshot provenance.unscheduled_sections must be a list"
+        )
+    seen_unscheduled: set[tuple[str, str]] = set()
+    for source_section in unscheduled_sections:
+        if not isinstance(source_section, dict):
+            raise WCQPreparationError("unscheduled source section must be an object")
+        key = (
+            str(source_section.get("semester_id", "")),
+            str(source_section.get("section_id", "")),
+        )
+        if not all(key):
+            raise WCQPreparationError(
+                "unscheduled source section identity is incomplete"
+            )
+        if key in seen_sections:
+            raise WCQPreparationError(
+                f"unscheduled source section {key[0]}/{key[1]} is also schedulable"
+            )
+        if key in seen_unscheduled:
+            raise WCQPreparationError(
+                f"duplicate unscheduled source section {key[0]}/{key[1]}"
+            )
+        seen_unscheduled.add(key)
+
     counts = snapshot_counts(snapshot)
     expectations = {
         "subjects": expected_subjects,
@@ -860,6 +1081,7 @@ def validate_snapshot(
         "offered_courses": expected_offered_courses,
         "sections": expected_sections,
         "lectures": expected_lectures,
+        "unscheduled_sections": expected_unscheduled_sections,
     }
     mismatches = [
         f"{name}={counts[name]} (expected {expected})"
@@ -895,6 +1117,7 @@ def build_snapshot(
         )
 
     courses: list[dict[str, object]] = []
+    unscheduled_sections: list[dict[str, object]] = []
     for reference in references:
         page = parse_subject_page(
             subject_html[reference.code],
@@ -902,7 +1125,14 @@ def build_snapshot(
             semester_id=term,
         )
         courses.extend(page.courses)
+        unscheduled_sections.extend(page.unscheduled_sections)
     courses.sort(key=lambda item: str(item["course_code"]))
+    unscheduled_sections.sort(
+        key=lambda item: (
+            str(item["course_code"]),
+            str(item["section_id"]),
+        )
+    )
 
     approximations: list[dict[str, object]] = []
     for course in courses:
@@ -938,6 +1168,26 @@ def build_snapshot(
                     ),
                 }
             )
+
+    for source_section in unscheduled_sections:
+        approximations.append(
+            {
+                "kind": "unscheduled_source_section_omitted",
+                "course_code": str(source_section["course_code"]),
+                "semester_id": str(source_section["semester_id"]),
+                "section_id": str(source_section["section_id"]),
+                "source_label": str(source_section["source_label"]),
+                "retained_at": "provenance.unscheduled_sections",
+                "review_basis": str(source_section["review_basis"]),
+                "explanation": (
+                    "The official row has no component type or meeting time. "
+                    "Mapping it to a scheduler section would invent a type, "
+                    "layer, and bundle that could incorrectly make the row a "
+                    "required choice. It is omitted from schedulable sections; "
+                    "all source fields remain in provenance.unscheduled_sections."
+                ),
+            }
+        )
 
     date_range_meetings = []
     for course in courses:
@@ -978,6 +1228,7 @@ def build_snapshot(
             "retrieved_at": retrieved_at,
             "term_index_sha256": hashlib.sha256(index_html.encode("utf-8")).hexdigest(),
             "approximations": approximations,
+            "unscheduled_sections": unscheduled_sections,
             "subjects": [
                 {
                     "code": reference.code,
@@ -1080,6 +1331,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--expected-lectures", type=int, default=DEFAULT_EXPECTED_LECTURES
     )
     parser.add_argument(
+        "--expected-unscheduled-sections",
+        type=int,
+        default=DEFAULT_EXPECTED_UNSCHEDULED_SECTIONS,
+        help=(
+            "reviewed source rows intentionally retained only as provenance "
+            f"(default: {DEFAULT_EXPECTED_UNSCHEDULED_SECTIONS})"
+        ),
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="replace an existing pending JSON file after explicit review",
@@ -1102,6 +1362,7 @@ def run(args: argparse.Namespace) -> tuple[Path, dict[str, int]]:
         "expected_offered_courses",
         "expected_sections",
         "expected_lectures",
+        "expected_unscheduled_sections",
     ):
         value = getattr(args, name)
         if value is not None and value < 0:
@@ -1152,6 +1413,7 @@ def run(args: argparse.Namespace) -> tuple[Path, dict[str, int]]:
         expected_offered_courses=args.expected_offered_courses,
         expected_sections=args.expected_sections,
         expected_lectures=args.expected_lectures,
+        expected_unscheduled_sections=args.expected_unscheduled_sections,
     )
     _atomic_write_json(args.output, snapshot, force=args.force)
     return args.output, counts
@@ -1168,7 +1430,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"prepared {output}: subjects={counts['subjects']} "
         f"courses={counts['courses']} offered_courses={counts['offered_courses']} "
         f"sections={counts['sections']} "
-        f"lectures={counts['lectures']}"
+        f"lectures={counts['lectures']} "
+        f"unscheduled_sections={counts['unscheduled_sections']}"
     )
     print("No database import or deployment was performed.")
     return 0

--- a/app/scripts/import_courses.py
+++ b/app/scripts/import_courses.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import sessionmaker
 from app.models.course import Course
 from app.models.tag import TagType
 from app import create_app, db
+from app.services.course_domain import normalize_course_code
+
+
+class CourseImportValidationError(RuntimeError):
+    pass
 
 def get_term_season(term_code):
     """Convert term code to season name."""
@@ -18,6 +23,94 @@ def get_term_season(term_code):
     season_code = term_code[2:]
     return f"{year}{season_map.get(season_code, '')}"
 
+
+def _prepare_course_rows(courses_data):
+    prepared_rows = []
+    skipped_count = 0
+    source_codes_by_normalized = {}
+
+    for course_data in courses_data:
+        try:
+            if not isinstance(course_data, dict) or not all(
+                key in course_data for key in ['course_code', 'name', 'unit']
+            ):
+                print(f"Skipping course due to missing required fields: {course_data}")
+                skipped_count += 1
+                continue
+
+            code = course_data['course_code'].strip()
+            name = course_data['name'].strip()
+            credits = int(course_data['unit'])
+            normalized_code = normalize_course_code(code)
+            if not normalized_code or not name:
+                print(f"Skipping course due to empty required fields: {course_data}")
+                skipped_count += 1
+                continue
+        except Exception as error:
+            print(f"Error processing course {course_data}: {str(error)}")
+            skipped_count += 1
+            continue
+
+        previous_code = source_codes_by_normalized.get(normalized_code)
+        if previous_code is not None:
+            raise CourseImportValidationError(
+                'input contains duplicate normalized course identity '
+                f'{normalized_code}: {previous_code!r}, {code!r}'
+            )
+        source_codes_by_normalized[normalized_code] = code
+        prepared_rows.append((course_data, code, normalized_code, name, credits))
+
+    return prepared_rows, skipped_count
+
+
+def _existing_courses_by_normalized_code(session, normalized_codes):
+    normalized_codes = set(normalized_codes)
+    identity_rows = session.query(
+        Course.id,
+        Course.code,
+        Course.normalized_code,
+    ).all()
+    candidate_ids_by_code = {}
+    for course_id, code, normalized_code in identity_rows:
+        stored_code = normalize_course_code(normalized_code)
+        derived_code = normalize_course_code(code)
+        if not ({stored_code, derived_code} & normalized_codes):
+            continue
+        if stored_code and stored_code != derived_code:
+            raise CourseImportValidationError(
+                'course normalization is inconsistent for existing row '
+                f'id={course_id}: code={code!r}, normalized_code={normalized_code!r}'
+            )
+        candidate_code = stored_code or derived_code
+        candidate_ids_by_code.setdefault(candidate_code, []).append(course_id)
+
+    ambiguous = {
+        normalized_code: matching_ids
+        for normalized_code, matching_ids in candidate_ids_by_code.items()
+        if len(matching_ids) > 1
+    }
+    if ambiguous:
+        details = '; '.join(
+            f'{normalized_code}=rows[{",".join(str(course_id) for course_id in matching_ids)}]'
+            for normalized_code, matching_ids in sorted(ambiguous.items())
+        )
+        raise CourseImportValidationError(
+            'ambiguous existing course rows for normalized import codes: ' + details
+        )
+
+    candidate_ids = [
+        matching_ids[0]
+        for matching_ids in candidate_ids_by_code.values()
+    ]
+    candidates_by_id = {
+        course.id: course
+        for course in session.query(Course).filter(Course.id.in_(candidate_ids)).all()
+    } if candidate_ids else {}
+    return {
+        normalized_code: candidates_by_id[matching_ids[0]]
+        for normalized_code, matching_ids in candidate_ids_by_code.items()
+    }
+
 def import_courses_from_file(file_path, session):
     """Import courses from a JSON file."""
     print(f"Processing file: {file_path}")
@@ -28,6 +121,15 @@ def import_courses_from_file(file_path, session):
     
     with open(file_path, 'r', encoding='utf-8') as f:
         courses_data = json.load(f)
+
+    if not isinstance(courses_data, list):
+        raise CourseImportValidationError('course import payload must be a list')
+
+    prepared_rows, skipped_count = _prepare_course_rows(courses_data)
+    courses_by_normalized_code = _existing_courses_by_normalized_code(
+        session,
+        [row[2] for row in prepared_rows],
+    )
     
     # Get or create COURSE tag type
     course_tag_type = session.query(TagType).filter_by(name='COURSE').first()
@@ -37,44 +139,28 @@ def import_courses_from_file(file_path, session):
         session.commit()
     
     imported_count = 0
-    skipped_count = 0
     
-    for course_data in courses_data:
+    for course_data, code, normalized_code, name, credits in prepared_rows:
         try:
-            # Skip if required fields are missing
-            if not all(k in course_data for k in ['course_code', 'name', 'unit']):
-                print(f"Skipping course due to missing required fields: {course_data}")
-                skipped_count += 1
-                continue
-            
-            # Clean and prepare course data
-            code = course_data['course_code'].strip()
-            name = course_data['name'].strip()
-            credits = int(course_data['unit'])
-            
-            # Skip if any required field is empty
-            if not code or not name:
-                print(f"Skipping course due to empty required fields: {course_data}")
-                skipped_count += 1
-                continue
-            
-            # Check if course already exists
-            existing_course = session.query(Course).filter_by(code=code).first()
+            existing_course = courses_by_normalized_code.get(normalized_code)
             if existing_course:
                 # Update existing course
                 existing_course.name = name
                 existing_course.credits = credits
+                existing_course.normalized_code = normalized_code
                 course = existing_course
             else:
                 # Create new course
                 course = Course(
-                    code=code,
+                    code=normalized_code,
+                    normalized_code=normalized_code,
                     name=name,
                     credits=credits,
                     is_active=True
                 )
                 session.add(course)
                 session.flush()  # Get the course ID
+                courses_by_normalized_code[normalized_code] = course
             
             # Create semester tag using the Course model's method
             try:

--- a/app/scripts/migrate_scheduler_data.py
+++ b/app/scripts/migrate_scheduler_data.py
@@ -22,6 +22,7 @@ from app.models.course import Course
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_map import SchedulerMapComponent, SchedulerMapLine
 from app.models.scheduler_section import SchedulerSection
+from app.services.course_domain import normalize_course_code
 from app.services.course_domain_migration import migrate_offerings
 
 
@@ -84,9 +85,23 @@ def validate_snapshot(snapshot):
     course_codes = {row[0] for row in snapshot.courses}
     section_keys = {(row[0], row[1]) for row in snapshot.sections}
     component_ids = {row[0] for row in snapshot.components}
+    source_codes_by_normalized = {}
 
     if not snapshot.sections:
         raise SnapshotValidationError('snapshot contains no sections')
+
+    for row in snapshot.courses:
+        source_code = row[0]
+        normalized_code = normalize_course_code(source_code)
+        if not normalized_code:
+            raise SnapshotValidationError('snapshot contains an empty course code')
+        previous_code = source_codes_by_normalized.get(normalized_code)
+        if previous_code is not None:
+            raise SnapshotValidationError(
+                'snapshot contains duplicate normalized course identity '
+                f'{normalized_code}: {previous_code!r}, {source_code!r}'
+            )
+        source_codes_by_normalized[normalized_code] = source_code
 
     for row in snapshot.sections:
         if row[2] not in course_codes:
@@ -125,20 +140,89 @@ def _normalized_subject(subject):
     return subject.strip().upper() if isinstance(subject, str) else subject
 
 
+def _existing_courses_by_normalized_code(course_codes):
+    normalized_codes = {
+        normalize_course_code(course_code)
+        for course_code in course_codes
+        if normalize_course_code(course_code)
+    }
+    if not normalized_codes:
+        return {}
+
+    identity_rows = db.session.query(
+        Course.id,
+        Course.code,
+        Course.normalized_code,
+    ).all()
+    candidate_ids_by_code = {}
+    for course_id, code, normalized_code in identity_rows:
+        stored_code = normalize_course_code(normalized_code)
+        derived_code = normalize_course_code(code)
+        if not ({stored_code, derived_code} & normalized_codes):
+            continue
+        if stored_code and stored_code != derived_code:
+            raise SnapshotValidationError(
+                'course normalization is inconsistent for existing row '
+                f'id={course_id}: code={code!r}, normalized_code={normalized_code!r}'
+            )
+        candidate_code = stored_code or derived_code
+        candidate_ids_by_code.setdefault(candidate_code, []).append(course_id)
+
+    ambiguous = {
+        normalized_code: matching_ids
+        for normalized_code, matching_ids in candidate_ids_by_code.items()
+        if len(matching_ids) > 1
+    }
+    if ambiguous:
+        details = '; '.join(
+            f'{normalized_code}=rows[{",".join(str(course_id) for course_id in matching_ids)}]'
+            for normalized_code, matching_ids in sorted(ambiguous.items())
+        )
+        raise SnapshotValidationError(
+            'ambiguous existing course rows for normalized scheduler codes: ' + details
+        )
+
+    candidate_ids = [
+        matching_ids[0]
+        for matching_ids in candidate_ids_by_code.values()
+    ]
+    candidates_by_id = {
+        course.id: course
+        for course in Course.query.filter(Course.id.in_(candidate_ids)).all()
+    } if candidate_ids else {}
+    return {
+        normalized_code: candidates_by_id[matching_ids[0]]
+        for normalized_code, matching_ids in candidate_ids_by_code.items()
+    }
+
+
 def import_snapshot(source_conn):
     snapshot = load_snapshot(source_conn)
     validate_snapshot(snapshot)
 
     try:
+        courses_by_normalized_code = _existing_courses_by_normalized_code(
+            [row[0] for row in snapshot.courses]
+        )
         SchedulerMapLine.query.delete()
         SchedulerMapComponent.query.delete()
         SchedulerLecture.query.delete()
         SchedulerSection.query.delete()
 
+        courses_by_source_code = {}
         for row in snapshot.courses:
-            course = Course.query.filter_by(code=row[0]).first()
+            normalized_code = normalize_course_code(row[0])
+            course = courses_by_normalized_code.get(normalized_code)
             if course is None:
-                course = Course(code=row[0], name=row[1], credits=row[7])
+                course = Course(
+                    code=normalized_code,
+                    normalized_code=normalized_code,
+                    name=row[1],
+                    credits=row[7],
+                )
+                courses_by_normalized_code[normalized_code] = course
+            else:
+                course.normalized_code = normalized_code
             course.name = row[1]
             course.course_title_abbr = row[2]
             course.description = row[3] or ''
@@ -152,14 +236,14 @@ def import_snapshot(source_conn):
             course.klms_course = row[11]
             course.vector = row[12]
             db.session.add(course)
+            courses_by_source_code[row[0]] = course
         db.session.flush()
 
-        courses = {course.code: course for course in Course.query.all()}
         for row in snapshot.sections:
             db.session.add(SchedulerSection(
                 semester_id=row[0],
                 section_id=row[1],
-                course_id=courses[row[2]].id,
+                course_id=courses_by_source_code[row[2]].id,
                 name=row[3],
                 bundle=row[4],
                 layer=row[5],

--- a/app/scripts/reconcile_course_duplicates.py
+++ b/app/scripts/reconcile_course_duplicates.py
@@ -1,0 +1,1153 @@
+"""Safely reconcile the narrow legacy Course duplicate shape.
+
+This repair intentionally supports only one observed shape: exactly two active
+Course rows whose codes differ only by whitespace, with the compact code row
+selected as the survivor.  Any reference to a loser outside
+``user_course_records`` blocks the repair.
+
+Dry-run is the default.  Apply requires the database name, the exact dry-run
+plan SHA-256, and independently reviewed pair/record/tag counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import defaultdict
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import column, delete, func, inspect, select, table, text, update
+from sqlalchemy.engine import make_url
+
+from app.extensions import db
+from app.models.academic_map import UserCourseRecord
+from app.models.course import Course
+from app.models.scheduler_cart import SchedulerUserBundleCart, SchedulerUserCourseCart
+from app.models.tag import Tag, TagType, post_tags
+from app.scripts.import_scheduler_offerings import create_import_app
+from app.services.course_domain import normalize_course_code
+
+
+PLAN_VERSION = 2
+ALLOWED_LOSER_FOREIGN_KEY = ("user_course_records", ("course_id",))
+APPLY_LOCK_TIMEOUT = "5s"
+EXPECTED_COURSE_FOREIGN_KEYS = frozenset({
+    ("course_catalog_versions", ("course_id",)),
+    ("course_offerings", ("course_id",)),
+    ("course_requirement_edges", ("from_course_id",)),
+    ("course_requirement_edges", ("to_course_id",)),
+    ("scheduler_sections", ("course_id",)),
+    ("user_course_attempts", ("course_id",)),
+    ("user_course_records", ("course_id",)),
+    ("user_course_states", ("course_id",)),
+})
+COURSE_METADATA_FIELDS = (
+    "name",
+    "description",
+    "instructor_id",
+    "credits",
+    "capacity",
+    "subject",
+    "catalog_number",
+    "course_title_abbr",
+    "pre_requirement",
+    "co_requirement",
+    "exclusion",
+    "pg_course",
+    "klms_course",
+    "vector",
+)
+
+
+class ReconciliationError(RuntimeError):
+    """Raised when mutation fails after controls have been accepted."""
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_value,
+    )
+
+
+def plan_sha256(plan: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(plan).encode("utf-8")).hexdigest()
+
+
+def _row_sha256(model: Any) -> str:
+    """Fingerprint every persisted column without exposing full row contents."""
+    row = {
+        column.name: _json_value(getattr(model, column.name))
+        for column in model.__table__.columns
+    }
+    return hashlib.sha256(_canonical_json(row).encode("utf-8")).hexdigest()
+
+
+def _database_identity() -> dict[str, str]:
+    url = make_url(db.engine.url)
+    inspector = inspect(db.session.connection())
+    return {
+        "dialect": db.engine.dialect.name,
+        "name": str(url.database or ""),
+        "schema": str(inspector.default_schema_name or ""),
+    }
+
+
+def _course_snapshot(course: Course) -> dict[str, Any]:
+    return {
+        "id": course.id,
+        "code": course.code,
+        "normalized_code": course.normalized_code,
+        "display_code": course.display_code,
+        "name": course.name,
+        "credits": course.credits,
+        "subject": course.subject,
+        "catalog_number": course.catalog_number,
+        "is_active": bool(course.is_active),
+        "is_deleted": bool(course.is_deleted),
+        "created_at": _json_value(course.created_at),
+        "updated_at": _json_value(course.updated_at),
+        "row_sha256": _row_sha256(course),
+    }
+
+
+def _sort_objects(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(items, key=_canonical_json)
+
+
+def _duplicate_pairs() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    groups: dict[str, list[Course]] = defaultdict(list)
+    blockers: list[dict[str, Any]] = []
+
+    for course in Course.query.order_by(Course.id).all():
+        derived = normalize_course_code(course.code)
+        stored = normalize_course_code(course.normalized_code)
+        if stored and stored != derived:
+            blockers.append({
+                "type": "inconsistent_normalized_code",
+                "course_id": course.id,
+                "code": course.code,
+                "normalized_code": course.normalized_code,
+                "derived_code": derived,
+            })
+        if derived:
+            groups[derived].append(course)
+
+    pairs: list[dict[str, Any]] = []
+    for normalized_code, courses in sorted(groups.items()):
+        if len(courses) <= 1:
+            continue
+
+        compact = [course for course in courses if course.code == normalized_code]
+        is_supported = (
+            len(courses) == 2
+            and len(compact) == 1
+            and all(bool(course.is_active) and not bool(course.is_deleted) for course in courses)
+        )
+        if not is_supported:
+            blockers.append({
+                "type": "unsupported_duplicate_shape",
+                "normalized_code": normalized_code,
+                "rows": [_course_snapshot(course) for course in courses],
+                "expected": "exactly two active rows with exactly one compact code",
+            })
+            continue
+
+        survivor = compact[0]
+        loser = next(course for course in courses if course.id != survivor.id)
+        if (
+            loser.code == survivor.code
+            or "".join(loser.code.split()) != survivor.code
+        ):
+            blockers.append({
+                "type": "unsupported_duplicate_shape",
+                "normalized_code": normalized_code,
+                "rows": [_course_snapshot(course) for course in courses],
+                "expected": "codes must differ only by whitespace",
+            })
+            continue
+
+        differing_fields = [
+            field_name
+            for field_name in COURSE_METADATA_FIELDS
+            if getattr(survivor, field_name) != getattr(loser, field_name)
+        ]
+        pairs.append({
+            "normalized_code": normalized_code,
+            "survivor": _course_snapshot(survivor),
+            "loser": _course_snapshot(loser),
+            "metadata_policy": "compact_survivor_wins",
+            "differing_metadata_fields": differing_fields,
+        })
+
+    return pairs, _sort_objects(blockers)
+
+
+def _pair_indexes(
+    pairs: list[dict[str, Any]],
+) -> tuple[dict[int, dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    by_loser_id = {pair["loser"]["id"]: pair for pair in pairs}
+    by_loser_code = {pair["loser"]["code"]: pair for pair in pairs}
+    by_normalized = {pair["normalized_code"]: pair for pair in pairs}
+    return by_loser_id, by_loser_code, by_normalized
+
+
+def _user_course_record_actions(
+    pairs: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    by_loser_id, by_loser_code, _ = _pair_indexes(pairs)
+    actions: list[dict[str, Any]] = []
+    blockers: list[dict[str, Any]] = []
+
+    for record in UserCourseRecord.query.order_by(UserCourseRecord.id).all():
+        id_pair = by_loser_id.get(record.course_id)
+        code_pair = by_loser_code.get(record.course_code)
+        if id_pair is None and code_pair is None:
+            continue
+        if id_pair is not None and code_pair is not None and id_pair is not code_pair:
+            blockers.append({
+                "type": "user_course_record_cross_pair_identity",
+                "record_id": record.id,
+                "course_id": record.course_id,
+                "course_code": record.course_code,
+            })
+            continue
+
+        pair = id_pair or code_pair
+        survivor_id = pair["survivor"]["id"]
+        loser_id = pair["loser"]["id"]
+        if record.course_id not in {None, survivor_id, loser_id}:
+            blockers.append({
+                "type": "user_course_record_conflicting_course_id",
+                "record_id": record.id,
+                "course_id": record.course_id,
+                "course_code": record.course_code,
+                "expected_course_ids": [survivor_id, loser_id],
+            })
+            continue
+        if normalize_course_code(record.course_code) != pair["normalized_code"]:
+            blockers.append({
+                "type": "user_course_record_conflicting_course_code",
+                "record_id": record.id,
+                "course_id": record.course_id,
+                "course_code": record.course_code,
+                "expected_normalized_code": pair["normalized_code"],
+            })
+            continue
+
+        actions.append({
+            "record_id": record.id,
+            "record_row_sha256": _row_sha256(record),
+            "old_course_id": record.course_id,
+            "old_course_code": record.course_code,
+            "new_course_id": survivor_id,
+            "new_course_code": pair["survivor"]["code"],
+        })
+
+    return actions, _sort_objects(blockers)
+
+
+def _normalized_code_uniqueness_audit() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    inspector = inspect(db.session.connection())
+    schema = str(inspector.default_schema_name or "")
+    candidates: list[dict[str, Any]] = []
+
+    for constraint in inspector.get_unique_constraints(
+        Course.__tablename__,
+        schema=schema or None,
+    ):
+        columns = list(constraint.get("column_names") or ())
+        if columns == ["normalized_code"]:
+            candidates.append({
+                "kind": "constraint",
+                "name": constraint.get("name"),
+                "columns": columns,
+            })
+
+    for index in inspector.get_indexes(Course.__tablename__, schema=schema or None):
+        columns = list(index.get("column_names") or ())
+        dialect_options = index.get("dialect_options") or {}
+        is_partial = (
+            dialect_options.get("postgresql_where") is not None
+            or dialect_options.get("sqlite_where") is not None
+        )
+        if index.get("unique") and columns == ["normalized_code"] and not is_partial:
+            candidates.append({
+                "kind": "index",
+                "name": index.get("name"),
+                "columns": columns,
+            })
+
+    if db.engine.dialect.name == "postgresql":
+        # PostgreSQL can expose an invalid/not-ready index through reflection;
+        # such an index does not provide the invariant this destructive repair needs.
+        enforced = bool(db.session.execute(text("""
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_index AS index_meta
+                JOIN pg_class AS table_meta
+                  ON table_meta.oid = index_meta.indrelid
+                JOIN pg_namespace AS namespace_meta
+                  ON namespace_meta.oid = table_meta.relnamespace
+                WHERE namespace_meta.nspname = :schema
+                  AND table_meta.relname = :table_name
+                  AND index_meta.indisunique
+                  AND index_meta.indisvalid
+                  AND index_meta.indisready
+                  AND index_meta.indpred IS NULL
+                  AND index_meta.indexprs IS NULL
+                  AND index_meta.indnkeyatts = 1
+                  AND index_meta.indkey[0] = (
+                      SELECT attribute_meta.attnum
+                      FROM pg_attribute AS attribute_meta
+                      WHERE attribute_meta.attrelid = table_meta.oid
+                        AND attribute_meta.attname = 'normalized_code'
+                        AND NOT attribute_meta.attisdropped
+                  )
+            )
+        """), {
+            "schema": schema,
+            "table_name": Course.__tablename__,
+        }).scalar_one())
+    else:
+        enforced = bool(candidates)
+
+    audit = {
+        "schema": schema,
+        "table": Course.__tablename__,
+        "column": "normalized_code",
+        "enforced": enforced,
+        "candidates": sorted(candidates, key=_canonical_json),
+    }
+    blockers = [] if enforced else [{
+        "type": "missing_normalized_code_uniqueness",
+        "schema": schema,
+        "table": Course.__tablename__,
+        "column": "normalized_code",
+    }]
+    return audit, blockers
+
+
+def _count_loser_references(
+    schema: str,
+    table_name: str,
+    column_name: str,
+    loser_ids: list[int],
+) -> int:
+    if not loser_ids:
+        return 0
+    referenced_table = table(
+        table_name,
+        column(column_name),
+        schema=schema or None,
+    )
+    return int(db.session.execute(
+        select(func.count())
+        .select_from(referenced_table)
+        .where(referenced_table.c[column_name].in_(loser_ids))
+    ).scalar_one())
+
+
+def _postgresql_course_foreign_keys(schema: str) -> list[dict[str, Any]]:
+    """Read every FK to the target Course table, including other schemas."""
+    rows = db.session.execute(text("""
+        SELECT
+            source_namespace.nspname AS schema,
+            source_table.relname AS table_name,
+            constraint_meta.conname AS constraint_name,
+            array_agg(
+                source_attribute.attname::text
+                ORDER BY key_position.position
+            ) AS columns,
+            target_namespace.nspname AS referred_schema,
+            target_table.relname AS referred_table,
+            array_agg(
+                target_attribute.attname::text
+                ORDER BY key_position.position
+            ) AS referred_columns,
+            CASE constraint_meta.confdeltype
+                WHEN 'a' THEN 'NO ACTION'
+                WHEN 'r' THEN 'RESTRICT'
+                WHEN 'c' THEN 'CASCADE'
+                WHEN 'n' THEN 'SET NULL'
+                WHEN 'd' THEN 'SET DEFAULT'
+            END AS ondelete,
+            constraint_meta.convalidated AS validated
+        FROM pg_constraint AS constraint_meta
+        JOIN pg_class AS source_table
+          ON source_table.oid = constraint_meta.conrelid
+        JOIN pg_namespace AS source_namespace
+          ON source_namespace.oid = source_table.relnamespace
+        JOIN pg_class AS target_table
+          ON target_table.oid = constraint_meta.confrelid
+        JOIN pg_namespace AS target_namespace
+          ON target_namespace.oid = target_table.relnamespace
+        JOIN LATERAL generate_subscripts(
+            constraint_meta.conkey,
+            1
+        ) AS key_position(position) ON TRUE
+        JOIN pg_attribute AS source_attribute
+          ON source_attribute.attrelid = source_table.oid
+         AND source_attribute.attnum = constraint_meta.conkey[key_position.position]
+        JOIN pg_attribute AS target_attribute
+          ON target_attribute.attrelid = target_table.oid
+         AND target_attribute.attnum = constraint_meta.confkey[key_position.position]
+        WHERE constraint_meta.contype = 'f'
+          AND target_namespace.nspname = :schema
+          AND target_table.relname = :table_name
+        GROUP BY
+            source_namespace.nspname,
+            source_table.relname,
+            constraint_meta.conname,
+            target_namespace.nspname,
+            target_table.relname,
+            constraint_meta.confdeltype,
+            constraint_meta.convalidated
+        ORDER BY
+            source_namespace.nspname,
+            source_table.relname,
+            constraint_meta.conname
+    """), {
+        "schema": schema,
+        "table_name": Course.__tablename__,
+    }).mappings().all()
+    return [
+        {
+            "schema": str(row["schema"]),
+            "table": str(row["table_name"]),
+            "constraint": row["constraint_name"],
+            "columns": list(row["columns"] or ()),
+            "referred_schema": str(row["referred_schema"]),
+            "referred_table": str(row["referred_table"]),
+            "referred_columns": list(row["referred_columns"] or ()),
+            "ondelete": row["ondelete"],
+            "validated": bool(row["validated"]),
+        }
+        for row in rows
+    ]
+
+
+def _reflected_course_foreign_keys(
+    inspector: Any,
+    schema: str,
+    table_names: set[str],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for table_name in sorted(table_names):
+        for foreign_key in inspector.get_foreign_keys(
+            table_name,
+            schema=schema or None,
+        ):
+            referred_schema = str(foreign_key.get("referred_schema") or schema)
+            if (
+                foreign_key.get("referred_table") != Course.__tablename__
+                or referred_schema != schema
+            ):
+                continue
+            rows.append({
+                "schema": schema,
+                "table": table_name,
+                "constraint": foreign_key.get("name"),
+                "columns": list(foreign_key.get("constrained_columns") or ()),
+                "referred_schema": referred_schema,
+                "referred_table": foreign_key.get("referred_table"),
+                "referred_columns": list(foreign_key.get("referred_columns") or ()),
+                "ondelete": (foreign_key.get("options") or {}).get("ondelete"),
+                "validated": True,
+            })
+    return rows
+
+
+def _inventory_course_foreign_keys(
+    loser_ids: list[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    inspector = inspect(db.session.connection())
+    schema = str(inspector.default_schema_name or "")
+    table_names = set(inspector.get_table_names(schema=schema or None))
+    inventory: list[dict[str, Any]] = []
+    blockers: list[dict[str, Any]] = []
+    seen: dict[tuple[str, tuple[str, ...]], int] = defaultdict(int)
+
+    foreign_keys = (
+        _postgresql_course_foreign_keys(schema)
+        if db.engine.dialect.name == "postgresql"
+        else _reflected_course_foreign_keys(inspector, schema, table_names)
+    )
+    for foreign_key in foreign_keys:
+        source_schema = str(foreign_key["schema"])
+        table_name = str(foreign_key["table"])
+        columns = tuple(foreign_key["columns"])
+        referred_columns = tuple(foreign_key["referred_columns"])
+        key = (table_name, columns)
+        is_default_schema = source_schema == schema
+        if is_default_schema:
+            seen[key] += 1
+        entry = {
+            "schema": source_schema,
+            "table": table_name,
+            "constraint": foreign_key["constraint"],
+            "columns": list(columns),
+            "referred_schema": foreign_key["referred_schema"],
+            "referred_table": foreign_key["referred_table"],
+            "referred_columns": list(referred_columns),
+            "ondelete": foreign_key["ondelete"],
+            "validated": foreign_key["validated"],
+            "loser_reference_count": None,
+        }
+
+        is_supported_shape = len(columns) == 1 and referred_columns == ("id",)
+        is_expected = is_default_schema and key in EXPECTED_COURSE_FOREIGN_KEYS
+        if (
+            not is_supported_shape
+            or not is_expected
+            or not foreign_key["validated"]
+        ):
+            blockers.append({
+                "type": "unsupported_course_foreign_key",
+                "schema": source_schema,
+                "table": table_name,
+                "constraint": foreign_key["constraint"],
+                "columns": list(columns),
+                "referred_columns": list(referred_columns),
+                "validated": foreign_key["validated"],
+            })
+            inventory.append(entry)
+            continue
+
+        count = _count_loser_references(
+            source_schema,
+            table_name,
+            columns[0],
+            loser_ids,
+        )
+        entry["loser_reference_count"] = count
+        inventory.append(entry)
+
+        if count and key != ALLOWED_LOSER_FOREIGN_KEY:
+            blockers.append({
+                "type": "blocked_loser_foreign_key_references",
+                "schema": source_schema,
+                "table": table_name,
+                "constraint": foreign_key["constraint"],
+                "columns": list(columns),
+                "loser_reference_count": count,
+            })
+
+    for table_name, columns in sorted(EXPECTED_COURSE_FOREIGN_KEYS):
+        occurrence_count = seen.get((table_name, columns), 0)
+        if occurrence_count == 1:
+            continue
+
+        reference_count = None
+        if table_name in table_names:
+            available_columns = {
+                item["name"]
+                for item in inspector.get_columns(table_name, schema=schema or None)
+            }
+            if len(columns) == 1 and columns[0] in available_columns:
+                reference_count = _count_loser_references(
+                    schema,
+                    table_name,
+                    columns[0],
+                    loser_ids,
+                )
+        blockers.append({
+            "type": (
+                "missing_expected_course_foreign_key"
+                if occurrence_count == 0
+                else "duplicate_expected_course_foreign_key"
+            ),
+            "schema": schema,
+            "table": table_name,
+            "columns": list(columns),
+            "constraint_count": occurrence_count,
+            "loser_reference_count": reference_count,
+        })
+
+    return _sort_objects(inventory), _sort_objects(blockers)
+
+
+def _legacy_cart_audit(
+    pairs: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    _, _, by_normalized = _pair_indexes(pairs)
+    course_rows = []
+    bundle_rows = []
+
+    for row in SchedulerUserCourseCart.query.order_by(
+        SchedulerUserCourseCart.user_id,
+        SchedulerUserCourseCart.semester_id,
+        SchedulerUserCourseCart.course_code,
+    ).all():
+        pair = by_normalized.get(normalize_course_code(row.course_code))
+        if pair is None or row.course_code == pair["survivor"]["code"]:
+            continue
+        course_rows.append({
+            "user_id": row.user_id,
+            "semester_id": row.semester_id,
+            "course_code": row.course_code,
+        })
+
+    for row in SchedulerUserBundleCart.query.order_by(
+        SchedulerUserBundleCart.user_id,
+        SchedulerUserBundleCart.semester_id,
+        SchedulerUserBundleCart.course_code,
+        SchedulerUserBundleCart.id,
+        SchedulerUserBundleCart.layer,
+    ).all():
+        pair = by_normalized.get(normalize_course_code(row.course_code))
+        if pair is None or row.course_code == pair["survivor"]["code"]:
+            continue
+        bundle_rows.append({
+            "user_id": row.user_id,
+            "semester_id": row.semester_id,
+            "course_code": row.course_code,
+            "bundle_id": row.id,
+            "layer": row.layer,
+        })
+
+    blockers = []
+    if course_rows or bundle_rows:
+        blockers.append({
+            "type": "legacy_cart_alias_references",
+            "course_cart_count": len(course_rows),
+            "bundle_cart_count": len(bundle_rows),
+        })
+    return {
+        "course_rows": course_rows,
+        "bundle_rows": bundle_rows,
+        "course_row_count": len(course_rows),
+        "bundle_row_count": len(bundle_rows),
+    }, blockers
+
+
+def _course_tag_type_plan() -> dict[str, Any]:
+    candidates = (
+        TagType.query
+        .filter(func.lower(TagType.name) == TagType.COURSE.lower())
+        .order_by(TagType.id)
+        .all()
+    )
+    selected = next((item for item in candidates if item.name == TagType.COURSE), None)
+    selected = selected or (candidates[0] if candidates else None)
+    return {
+        "action": "reuse" if selected else "create",
+        "selected_id": selected.id if selected else None,
+        "selected_name": selected.name if selected else TagType.COURSE,
+        "candidate_ids": [item.id for item in candidates],
+    }
+
+
+def _tag_actions(pairs: list[dict[str, Any]]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    _, by_loser_code, _ = _pair_indexes(pairs)
+    tags = Tag.query.order_by(Tag.id).all()
+    tags_by_name = {tag.name: tag for tag in tags}
+    type_name_by_id = {
+        tag_type.id: tag_type.name
+        for tag_type in TagType.query.order_by(TagType.id).all()
+    }
+    post_ids_by_tag: dict[int, set[int]] = defaultdict(set)
+    for post_id, tag_id in db.session.execute(
+        select(post_tags.c.post_id, post_tags.c.tag_id)
+    ).all():
+        post_ids_by_tag[tag_id].add(post_id)
+
+    actions = []
+    blockers: list[dict[str, Any]] = []
+    for source in tags:
+        pair = by_loser_code.get(source.name)
+        if pair is None and "-" in source.name:
+            pair = by_loser_code.get(source.name.split("-", 1)[0])
+        if pair is None:
+            continue
+
+        loser_code = pair["loser"]["code"]
+        if source.name != loser_code and not source.name.startswith(f"{loser_code}-"):
+            continue
+        target_name = pair["survivor"]["code"] + source.name[len(loser_code):]
+        target = tags_by_name.get(target_name)
+        if target is not None and target.id == source.id:
+            blockers.append({
+                "type": "tag_maps_to_itself",
+                "tag_id": source.id,
+                "tag_name": source.name,
+            })
+            continue
+
+        source_posts = post_ids_by_tag.get(source.id, set())
+        target_posts = post_ids_by_tag.get(target.id, set()) if target is not None else set()
+        actions.append({
+            "normalized_code": pair["normalized_code"],
+            "source_tag_id": source.id,
+            "source_tag_row_sha256": _row_sha256(source),
+            "source_name": source.name,
+            "source_type": type_name_by_id.get(source.tag_type_id),
+            "target_tag_id": target.id if target is not None else None,
+            "target_tag_row_sha256": _row_sha256(target) if target is not None else None,
+            "target_name": target_name,
+            "target_type": type_name_by_id.get(target.tag_type_id) if target is not None else None,
+            "action": "merge" if target is not None else "rename",
+            "source_post_ids": sorted(source_posts),
+            "target_post_ids": sorted(target_posts),
+            "post_ids_to_link": sorted(source_posts - target_posts),
+            "overlapping_post_link_count": len(source_posts & target_posts),
+        })
+
+    return {
+        "course_tag_type": _course_tag_type_plan(),
+        "actions": sorted(actions, key=lambda item: (item["source_name"], item["source_tag_id"])),
+        "tag_count": len(actions),
+        "rename_count": sum(item["action"] == "rename" for item in actions),
+        "merge_count": sum(item["action"] == "merge" for item in actions),
+        "source_post_link_count": sum(len(item["source_post_ids"]) for item in actions),
+        "post_links_to_copy_count": sum(len(item["post_ids_to_link"]) for item in actions),
+        "overlapping_post_link_count": sum(item["overlapping_post_link_count"] for item in actions),
+    }, blockers
+
+
+def build_reconciliation_plan() -> dict[str, Any]:
+    pairs, blockers = _duplicate_pairs()
+    loser_ids = [pair["loser"]["id"] for pair in pairs]
+
+    normalized_code_uniqueness, uniqueness_blockers = _normalized_code_uniqueness_audit()
+    record_actions, record_blockers = _user_course_record_actions(pairs)
+    foreign_keys, foreign_key_blockers = _inventory_course_foreign_keys(loser_ids)
+    legacy_carts, legacy_cart_blockers = _legacy_cart_audit(pairs)
+    tags, tag_blockers = _tag_actions(pairs)
+
+    blockers.extend(uniqueness_blockers)
+    blockers.extend(record_blockers)
+    blockers.extend(foreign_key_blockers)
+    blockers.extend(legacy_cart_blockers)
+    blockers.extend(tag_blockers)
+
+    return {
+        "version": PLAN_VERSION,
+        "database": _database_identity(),
+        "pair_count": len(pairs),
+        "loser_count": len(loser_ids),
+        "user_course_record_count": len(record_actions),
+        "loser_fk_user_course_record_count": sum(
+            action["old_course_id"] in loser_ids for action in record_actions
+        ),
+        "tag_count": tags["tag_count"],
+        "pairs": pairs,
+        "user_course_records": record_actions,
+        "normalized_code_uniqueness": normalized_code_uniqueness,
+        "foreign_keys": foreign_keys,
+        "legacy_carts": legacy_carts,
+        "tags": tags,
+        "blockers": _sort_objects(blockers),
+    }
+
+
+def _control_errors(
+    plan: dict[str, Any],
+    sha256: str,
+    *,
+    expected_database: str | None,
+    expected_plan_sha256: str | None,
+    expected_pairs: int | None,
+    expected_records: int | None,
+    expected_tags: int | None,
+) -> list[str]:
+    required = {
+        "expected_database": expected_database,
+        "expected_plan_sha256": expected_plan_sha256,
+        "expected_pairs": expected_pairs,
+        "expected_records": expected_records,
+        "expected_tags": expected_tags,
+    }
+    errors = [f"{name} is required for apply" for name, value in required.items() if value is None]
+    if errors:
+        return errors
+
+    if expected_database != plan["database"]["name"]:
+        errors.append(
+            f"database mismatch: actual={plan['database']['name']!r} expected={expected_database!r}"
+        )
+    if expected_plan_sha256 != sha256:
+        errors.append(f"plan SHA-256 mismatch: actual={sha256} expected={expected_plan_sha256}")
+    for label, expected, actual in (
+        ("pairs", expected_pairs, plan["pair_count"]),
+        ("records", expected_records, plan["user_course_record_count"]),
+        ("tags", expected_tags, plan["tag_count"]),
+    ):
+        if expected != actual:
+            errors.append(f"{label} count mismatch: actual={actual} expected={expected}")
+    return errors
+
+
+def _lock_apply_tables(plan: dict[str, Any]) -> None:
+    if db.engine.dialect.name != "postgresql":
+        return
+    inspector = inspect(db.session.connection())
+    schema = str(inspector.default_schema_name or "")
+    existing = set(inspector.get_table_names(schema=schema or None))
+    table_names = {
+        Course.__tablename__,
+        UserCourseRecord.__tablename__,
+        Tag.__tablename__,
+        TagType.__tablename__,
+        post_tags.name,
+        SchedulerUserCourseCart.__tablename__,
+        SchedulerUserBundleCart.__tablename__,
+    }
+    table_names.update(item["table"] for item in plan["foreign_keys"])
+    table_names &= existing
+    preparer = db.engine.dialect.identifier_preparer
+    schema_prefix = f"{preparer.quote_schema(schema)}." if schema else ""
+    rendered = ", ".join(
+        f"{schema_prefix}{preparer.quote_identifier(name)}"
+        for name in sorted(table_names)
+    )
+    if rendered:
+        db.session.execute(
+            text("SELECT set_config('lock_timeout', :lock_timeout, true)"),
+            {"lock_timeout": APPLY_LOCK_TIMEOUT},
+        )
+        db.session.execute(text(f"LOCK TABLE {rendered} IN SHARE ROW EXCLUSIVE MODE"))
+
+
+def _ensure_course_tag_type(plan: dict[str, Any]) -> int:
+    selected_id = plan["tags"]["course_tag_type"]["selected_id"]
+    if selected_id is not None:
+        selected = db.session.get(TagType, selected_id)
+        if selected is None or selected.name.lower() != TagType.COURSE.lower():
+            raise ReconciliationError("planned course tag type no longer exists")
+        return selected.id
+
+    existing = (
+        TagType.query
+        .filter(func.lower(TagType.name) == TagType.COURSE.lower())
+        .order_by(TagType.id)
+        .first()
+    )
+    if existing is not None:
+        return existing.id
+    created = TagType(name=TagType.COURSE)
+    db.session.add(created)
+    db.session.flush()
+    return created.id
+
+
+def _apply_user_course_records(plan: dict[str, Any]) -> int:
+    updated = 0
+    for action in plan["user_course_records"]:
+        result = db.session.execute(
+            update(UserCourseRecord)
+            .where(UserCourseRecord.id == action["record_id"])
+            .values(
+                course_id=action["new_course_id"],
+                course_code=action["new_course_code"],
+            )
+            .execution_options(synchronize_session="fetch")
+        )
+        if result.rowcount != 1:
+            raise ReconciliationError(
+                f"user course record {action['record_id']} changed after planning"
+            )
+        updated += 1
+    db.session.flush()
+    db.session.expire_all()
+    return updated
+
+
+def _apply_tags(plan: dict[str, Any]) -> dict[str, int]:
+    course_tag_type_id = _ensure_course_tag_type(plan)
+    renamed = 0
+    merged = 0
+    linked = 0
+
+    for action in plan["tags"]["actions"]:
+        source = db.session.get(Tag, action["source_tag_id"])
+        if source is None or source.name != action["source_name"]:
+            raise ReconciliationError(
+                f"source tag {action['source_tag_id']} changed after planning"
+            )
+
+        if action["action"] == "rename":
+            collision = Tag.query.filter_by(name=action["target_name"]).first()
+            if collision is not None and collision.id != source.id:
+                raise ReconciliationError(
+                    f"tag target {action['target_name']!r} appeared after planning"
+                )
+            source.name = action["target_name"]
+            source.tag_type_id = course_tag_type_id
+            renamed += 1
+            continue
+
+        target = db.session.get(Tag, action["target_tag_id"])
+        if target is None or target.name != action["target_name"]:
+            raise ReconciliationError(
+                f"target tag {action['target_tag_id']} changed after planning"
+            )
+        target.tag_type_id = course_tag_type_id
+        for post_id in action["post_ids_to_link"]:
+            db.session.execute(post_tags.insert().values(
+                post_id=post_id,
+                tag_id=target.id,
+            ))
+            linked += 1
+        db.session.execute(delete(post_tags).where(post_tags.c.tag_id == source.id))
+        db.session.execute(delete(Tag).where(Tag.id == source.id))
+        merged += 1
+
+    db.session.flush()
+    return {
+        "course_tag_type_id": course_tag_type_id,
+        "renamed": renamed,
+        "merged": merged,
+        "post_links_copied": linked,
+    }
+
+
+def _verify_no_loser_foreign_keys(plan: dict[str, Any]) -> None:
+    loser_ids = [pair["loser"]["id"] for pair in plan["pairs"]]
+    remaining = []
+    for item in plan["foreign_keys"]:
+        columns = item["columns"]
+        if len(columns) != 1 or item["referred_columns"] != ["id"]:
+            remaining.append({**item, "verification_error": "unsupported foreign key shape"})
+            continue
+        referenced_table = table(
+            item["table"],
+            column(columns[0]),
+            schema=item.get("schema") or None,
+        )
+        count = int(db.session.execute(
+            select(func.count())
+            .select_from(referenced_table)
+            .where(referenced_table.c[columns[0]].in_(loser_ids))
+        ).scalar_one()) if loser_ids else 0
+        if count:
+            remaining.append({**item, "loser_reference_count": count})
+    if remaining:
+        raise ReconciliationError(
+            "loser foreign-key references remain after the planned rewrites: "
+            + _canonical_json({"remaining": remaining})
+        )
+
+
+def _apply_courses(plan: dict[str, Any]) -> int:
+    loser_ids = [pair["loser"]["id"] for pair in plan["pairs"]]
+    _verify_no_loser_foreign_keys(plan)
+
+    if loser_ids:
+        result = db.session.execute(delete(Course).where(Course.id.in_(loser_ids)))
+        if result.rowcount != len(loser_ids):
+            raise ReconciliationError(
+                f"deleted {result.rowcount} loser courses; expected {len(loser_ids)}"
+            )
+
+    for pair in plan["pairs"]:
+        result = db.session.execute(
+            update(Course)
+            .where(Course.id == pair["survivor"]["id"])
+            .values(normalized_code=pair["normalized_code"])
+        )
+        if result.rowcount != 1:
+            raise ReconciliationError(
+                f"survivor course {pair['survivor']['id']} changed after planning"
+            )
+    db.session.flush()
+    return len(loser_ids)
+
+
+def _verify_applied_plan(plan: dict[str, Any], course_tag_type_id: int | None = None) -> None:
+    loser_ids = [pair["loser"]["id"] for pair in plan["pairs"]]
+    if loser_ids and Course.query.filter(Course.id.in_(loser_ids)).count():
+        raise ReconciliationError("one or more loser courses still exist")
+
+    for pair in plan["pairs"]:
+        survivor = db.session.get(Course, pair["survivor"]["id"])
+        if (
+            survivor is None
+            or survivor.code != pair["survivor"]["code"]
+            or survivor.normalized_code != pair["normalized_code"]
+        ):
+            raise ReconciliationError(
+                f"survivor {pair['survivor']['id']} failed normalization verification"
+            )
+
+    for action in plan["user_course_records"]:
+        record = db.session.get(UserCourseRecord, action["record_id"])
+        if (
+            record is None
+            or record.course_id != action["new_course_id"]
+            or record.course_code != action["new_course_code"]
+        ):
+            raise ReconciliationError(
+                f"user course record {action['record_id']} failed verification"
+            )
+
+    for action in plan["tags"]["actions"]:
+        if action["action"] == "rename":
+            target = db.session.get(Tag, action["source_tag_id"])
+        else:
+            target = db.session.get(Tag, action["target_tag_id"])
+            if db.session.get(Tag, action["source_tag_id"]) is not None:
+                raise ReconciliationError(
+                    f"merged source tag {action['source_tag_id']} still exists"
+                )
+        if target is None or target.name != action["target_name"]:
+            raise ReconciliationError(
+                f"tag target {action['target_name']!r} failed verification"
+            )
+        if course_tag_type_id is not None and target.tag_type_id != course_tag_type_id:
+            raise ReconciliationError(
+                f"tag target {action['target_name']!r} is not a course tag"
+            )
+        target_post_ids = set(db.session.execute(
+            select(post_tags.c.post_id).where(post_tags.c.tag_id == target.id)
+        ).scalars())
+        if not set(action["source_post_ids"]).issubset(target_post_ids):
+            raise ReconciliationError(
+                f"tag target {action['target_name']!r} lost post associations"
+            )
+
+
+def _apply_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    records_updated = _apply_user_course_records(plan)
+    tag_summary = _apply_tags(plan)
+    losers_deleted = _apply_courses(plan)
+    db.session.expire_all()
+    _verify_applied_plan(
+        plan,
+        course_tag_type_id=tag_summary["course_tag_type_id"],
+    )
+    return {
+        "pairs_reconciled": plan["pair_count"],
+        "losers_deleted": losers_deleted,
+        "user_course_records_updated": records_updated,
+        "tags_renamed": tag_summary["renamed"],
+        "tags_merged": tag_summary["merged"],
+        "post_links_copied": tag_summary["post_links_copied"],
+    }
+
+
+def run_reconciliation(
+    *,
+    apply: bool = False,
+    expected_database: str | None = None,
+    expected_plan_sha256: str | None = None,
+    expected_pairs: int | None = None,
+    expected_records: int | None = None,
+    expected_tags: int | None = None,
+) -> dict[str, Any]:
+    try:
+        plan = build_reconciliation_plan()
+        sha256 = plan_sha256(plan)
+        result = {
+            "status": "blocked" if plan["blockers"] else "dry-run",
+            "mode": "apply" if apply else "dry-run",
+            "plan_sha256": sha256,
+            "plan": plan,
+        }
+
+        if not apply:
+            db.session.rollback()
+            return result
+
+        control_errors = _control_errors(
+            plan,
+            sha256,
+            expected_database=expected_database,
+            expected_plan_sha256=expected_plan_sha256,
+            expected_pairs=expected_pairs,
+            expected_records=expected_records,
+            expected_tags=expected_tags,
+        )
+        if plan["blockers"] or control_errors:
+            result["status"] = "blocked"
+            result["control_errors"] = control_errors
+            db.session.rollback()
+            return result
+
+        _lock_apply_tables(plan)
+        # The first plan populated the ORM identity map before locks were held.
+        # Force the locked replan to reload rows that another transaction could
+        # have committed while this transaction was waiting for those locks.
+        db.session.expire_all()
+        locked_plan = build_reconciliation_plan()
+        locked_sha256 = plan_sha256(locked_plan)
+        if locked_sha256 != sha256 or locked_sha256 != expected_plan_sha256:
+            result["status"] = "blocked"
+            result["control_errors"] = [
+                "reconciliation plan changed while acquiring apply locks: "
+                f"before={sha256} locked={locked_sha256}"
+            ]
+            result["locked_plan_sha256"] = locked_sha256
+            db.session.rollback()
+            return result
+
+        applied = _apply_plan(locked_plan)
+        db.session.commit()
+        result["status"] = "applied"
+        result["applied"] = applied
+        return result
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reconcile simple whitespace-variant Course duplicates.",
+    )
+    parser.add_argument("--database-url", help="Optional database URL; otherwise DATABASE_URL is used.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the reviewed plan. Without this flag the command is a dry-run.",
+    )
+    parser.add_argument("--expected-database")
+    parser.add_argument("--expected-plan-sha256")
+    parser.add_argument("--expected-pairs", type=int)
+    parser.add_argument("--expected-records", type=int)
+    parser.add_argument("--expected-tags", type=int)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    app = create_import_app(args.database_url)
+    try:
+        with app.app_context():
+            result = run_reconciliation(
+                apply=args.apply,
+                expected_database=args.expected_database,
+                expected_plan_sha256=args.expected_plan_sha256,
+                expected_pairs=args.expected_pairs,
+                expected_records=args.expected_records,
+                expected_tags=args.expected_tags,
+            )
+    except Exception as exc:
+        print(json.dumps({
+            "status": "failed",
+            "message": str(exc),
+        }, ensure_ascii=False, sort_keys=True), file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    if result["status"] == "blocked":
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/course_catalog_sync.py
+++ b/app/services/course_catalog_sync.py
@@ -29,7 +29,8 @@ def sync_course_catalog_from_payload(payload: dict[str, Any]) -> dict[str, int]:
     courses = payload.get("courses") if isinstance(payload.get("courses"), list) else []
     courses_by_normalized_code: dict[str, list[Course]] = {}
     for course in Course.query.filter_by(is_deleted=False).all():
-        courses_by_normalized_code.setdefault(_normalize_code(course.code), []).append(course)
+        identity = _normalize_code(course.normalized_code or course.code)
+        courses_by_normalized_code.setdefault(identity, []).append(course)
 
     upserted = 0
     skipped = 0
@@ -47,7 +48,14 @@ def sync_course_catalog_from_payload(payload: dict[str, Any]) -> dict[str, int]:
             if credits is None:
                 skipped += 1
                 continue
-            course = Course(code=code, name=name, credits=credits, is_active=True, is_deleted=False)
+            course = Course(
+                code=code,
+                normalized_code=normalized_code,
+                name=name,
+                credits=credits,
+                is_active=True,
+                is_deleted=False,
+            )
             db.session.add(course)
             courses_by_normalized_code.setdefault(normalized_code, []).append(course)
         else:

--- a/tests/test_adjust_aiaa_25_26_spring.py
+++ b/tests/test_adjust_aiaa_25_26_spring.py
@@ -114,3 +114,9 @@ def test_apply_aiaa_adjustments_syncs_spring_from_fall_and_normalizes_tags(app):
         compact_spring_tag = Tag.query.filter_by(name="AIAA5033-2025spring").first()
         assert compact_spring_tag is not None
         assert linked_tag_ids == {compact_spring_tag.id}
+
+        new_course = Course.query.filter_by(code="AIAA2711").one()
+        assert new_course.normalized_code == "AIAA2711"
+        assert Course.query.filter_by(code="AIAA 2711").first() is None
+        assert Tag.query.filter_by(name="AIAA2711-2025spring").one()
+        assert Tag.query.filter_by(name="AIAA 2711-2025spring").first() is None

--- a/tests/test_adjust_general_education_25_26_spring.py
+++ b/tests/test_adjust_general_education_25_26_spring.py
@@ -1,0 +1,79 @@
+import pytest
+
+from app import create_app
+from app.extensions import db
+from app.models.course import Course
+from app.models.tag import Tag, TagType
+from app.scripts.adjust_ucug_25_26_spring import (
+    NEW_COURSES as UCUG_NEW_COURSES,
+    apply_ucug_25_26_spring_adjustments,
+)
+from app.scripts.adjust_ufug_25_26_spring import (
+    NEW_COURSES as UFUG_NEW_COURSES,
+    apply_ufug_25_26_spring_adjustments,
+)
+from app.services.course_domain import normalize_course_code
+
+
+class TestConfig:
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {}
+    JWT_SECRET_KEY = "test-secret"
+    CACHE_TYPE = "SimpleCache"
+    AUTO_INIT_ON_STARTUP = False
+
+
+@pytest.fixture
+def app():
+    app = create_app(TestConfig)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+@pytest.mark.parametrize(
+    ("apply_adjustments", "course_specs", "existing_code"),
+    (
+        (apply_ufug_25_26_spring_adjustments, UFUG_NEW_COURSES, "UFUG1403"),
+        (apply_ucug_25_26_spring_adjustments, UCUG_NEW_COURSES, "UCUG1052A"),
+    ),
+)
+def test_adjustments_reuse_compact_courses_and_create_canonical_rows_and_tags(
+    app,
+    apply_adjustments,
+    course_specs,
+    existing_code,
+):
+    with app.app_context():
+        course_type = TagType(name=TagType.COURSE)
+        existing_course = Course(
+            code=existing_code,
+            normalized_code=existing_code,
+            name="Old title",
+            credits=1,
+            is_active=True,
+            is_deleted=False,
+        )
+        db.session.add_all([course_type, existing_course])
+        db.session.commit()
+        existing_course_id = existing_course.id
+
+        apply_adjustments(dry_run=False, verbose=False)
+        apply_adjustments(dry_run=False, verbose=False)
+
+        matching_existing = [
+            course
+            for course in Course.query.all()
+            if normalize_course_code(course.code) == existing_code
+        ]
+        assert [course.id for course in matching_existing] == [existing_course_id]
+
+        for source_code, _name, _credits in course_specs:
+            canonical_code = normalize_course_code(source_code)
+            course = Course.query.filter_by(code=canonical_code).one()
+            assert course.normalized_code == canonical_code
+            assert Tag.query.filter_by(name=f"{canonical_code}-2025spring").one()
+            assert Tag.query.filter_by(name=f"{source_code}-2025spring").first() is None

--- a/tests/test_course_catalog_sync.py
+++ b/tests/test_course_catalog_sync.py
@@ -1,4 +1,5 @@
 import pytest
+from flask_jwt_extended import create_access_token
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.compiler import compiles
 
@@ -6,6 +7,8 @@ from app import create_app
 from app.config import Config
 from app.extensions import db
 from app.models.course import Course
+from app.models.user import User
+from app.models.user_role import UserRole
 
 
 @compiles(JSONB, "sqlite")
@@ -34,6 +37,34 @@ def app(monkeypatch):
         db.drop_all()
 
 
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _create_admin() -> User:
+    role = UserRole.query.filter_by(name=UserRole.ADMIN).first()
+    if role is None:
+        role = UserRole(name=UserRole.ADMIN, description="Admin role")
+        db.session.add(role)
+        db.session.flush()
+    admin = User(
+        username="course_catalog_admin",
+        email="course_catalog_admin@connect.hkust-gz.edu.cn",
+        role_id=role.id,
+        email_verified=True,
+        password_hash="test-password-hash",
+    )
+    db.session.add(admin)
+    db.session.flush()
+    return admin
+
+
+def _auth_headers(user_id: int) -> dict[str, str]:
+    token = create_access_token(identity=str(user_id))
+    return {"Authorization": f"Bearer {token}"}
+
+
 def test_sync_course_catalog_upserts_course_rows(app):
     from app.services.course_catalog_sync import sync_course_catalog_from_payload
 
@@ -56,6 +87,7 @@ def test_sync_course_catalog_upserts_course_rows(app):
     assert course.name == "Academic Orientation for AI Students"
     assert course.credits == 1
     assert course.description == "Official description."
+    assert course.normalized_code == "AIAA1010"
 
 
 def test_sync_course_catalog_updates_existing_spaced_course_code(app):
@@ -174,3 +206,213 @@ def test_sync_course_catalog_updates_course_rules(app):
     assert course.exclusion == "UFUG 1502"
     assert course.subject == "RULE"
     assert course.catalog_number == "1504"
+
+
+def test_sync_uses_stored_normalized_identity_without_rewriting_legacy_code(app):
+    from app.services.course_catalog_sync import sync_course_catalog_from_payload
+
+    payload = {
+        "courses": [
+            {
+                "course_code": "NORM9001",
+                "course_title": "Normalized Identity",
+                "credit": "3",
+            }
+        ]
+    }
+
+    with app.app_context():
+        legacy = Course(
+            code="LEGACY-9001",
+            normalized_code="NORM9001",
+            name="Old title",
+            credits=3,
+        )
+        db.session.add(legacy)
+        db.session.commit()
+        before_count = Course.query.count()
+
+        sync_course_catalog_from_payload(payload)
+
+        assert Course.query.count() == before_count
+        assert legacy.code == "LEGACY-9001"
+        assert legacy.name == "Normalized Identity"
+
+
+def test_sync_does_not_normalize_ambiguous_legacy_pairs(app):
+    from app.services.course_catalog_sync import sync_course_catalog_from_payload
+
+    payload = {
+        "courses": [
+            {
+                "course_code": "SAFE9001",
+                "course_title": "Safe Startup",
+                "credit": "3",
+            }
+        ]
+    }
+
+    with app.app_context():
+        canonical = Course(
+            code="SAFE9001",
+            normalized_code="SAFE9001",
+            name="Old canonical title",
+            credits=3,
+        )
+        legacy = Course(code="SAFE 9001", name="Old legacy title", credits=3)
+        db.session.add_all([canonical, legacy])
+        db.session.commit()
+
+        sync_course_catalog_from_payload(payload)
+
+        assert canonical.normalized_code == "SAFE9001"
+        assert legacy.normalized_code is None
+        assert canonical.name == "Safe Startup"
+        assert legacy.name == "Safe Startup"
+
+
+def test_admin_create_populates_normalized_code_and_rejects_whitespace_alias(app, client):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.commit()
+        headers = _auth_headers(admin.id)
+
+        created = client.post(
+            "/courses",
+            headers=headers,
+            json={
+                "code": "NADM 9001",
+                "name": "Admin-created Course",
+                "instructor_id": admin.id,
+                "credits": 3,
+            },
+        )
+        duplicate = client.post(
+            "/courses",
+            headers=headers,
+            json={
+                "code": "NADM9001",
+                "name": "Duplicate Course",
+                "instructor_id": admin.id,
+                "credits": 3,
+            },
+        )
+
+        course = Course.query.filter_by(code="NADM 9001").one()
+        assert created.status_code == 201
+        assert course.normalized_code == "NADM9001"
+        assert duplicate.status_code == 400
+        assert Course.query.filter(
+            Course.normalized_code == "NADM9001",
+            Course.is_deleted == False,
+        ).count() == 1
+
+
+def test_admin_create_rejects_legacy_alias_without_backfilling_it(app, client):
+    with app.app_context():
+        admin = _create_admin()
+        legacy = Course(code="LADM 9001", name="Legacy Course", credits=3)
+        db.session.add(legacy)
+        db.session.commit()
+        headers = _auth_headers(admin.id)
+
+        response = client.post(
+            "/courses",
+            headers=headers,
+            json={
+                "code": "LADM9001",
+                "name": "Duplicate Course",
+                "instructor_id": admin.id,
+                "credits": 3,
+            },
+        )
+
+        assert response.status_code == 400
+        assert legacy.normalized_code is None
+        assert Course.query.filter(
+            Course.is_deleted == False,
+        ).filter(Course.code.in_(["LADM 9001", "LADM9001"])).count() == 1
+
+
+def test_admin_update_rejects_normalized_alias_and_leaves_course_unchanged(app, client):
+    with app.app_context():
+        admin = _create_admin()
+        source = Course(
+            code="UADM9001",
+            normalized_code="UADM9001",
+            name="Source Course",
+            credits=3,
+        )
+        target = Course(
+            code="UADM9002",
+            normalized_code="UADM9002",
+            name="Target Course",
+            credits=3,
+        )
+        db.session.add_all([admin, source, target])
+        db.session.commit()
+        headers = _auth_headers(admin.id)
+
+        response = client.put(
+            f"/courses/{target.id}",
+            headers=headers,
+            json={"code": "UADM 9001"},
+        )
+
+        db.session.refresh(target)
+        assert response.status_code == 400
+        assert target.code == "UADM9002"
+        assert target.normalized_code == "UADM9002"
+
+
+def test_admin_update_sets_normalized_identity_for_unique_code(app, client):
+    with app.app_context():
+        admin = _create_admin()
+        course = Course(code="OLD9001", name="Old Course", credits=3)
+        db.session.add_all([admin, course])
+        db.session.commit()
+        headers = _auth_headers(admin.id)
+
+        response = client.put(
+            f"/courses/{course.id}",
+            headers=headers,
+            json={"code": "NEWC 9001"},
+        )
+
+        db.session.refresh(course)
+        assert response.status_code == 200
+        assert course.code == "NEWC 9001"
+        assert course.normalized_code == "NEWC9001"
+
+
+@pytest.mark.parametrize("method", ["post", "put"])
+def test_admin_course_write_rejects_whitespace_only_code(app, client, method):
+    with app.app_context():
+        admin = _create_admin()
+        course = Course(code="KEEP9001", name="Keep Course", credits=3)
+        db.session.add_all([admin, course])
+        db.session.commit()
+        headers = _auth_headers(admin.id)
+
+        if method == "post":
+            response = client.post(
+                "/courses",
+                headers=headers,
+                json={
+                    "code": "   ",
+                    "name": "Invalid Course",
+                    "instructor_id": admin.id,
+                    "credits": 3,
+                },
+            )
+        else:
+            response = client.put(
+                f"/courses/{course.id}",
+                headers=headers,
+                json={"code": "   "},
+            )
+
+        db.session.refresh(course)
+        assert response.status_code == 400
+        assert course.code == "KEEP9001"
+        assert course.normalized_code is None

--- a/tests/test_fetch_hkustgz_wcq.py
+++ b/tests/test_fetch_hkustgz_wcq.py
@@ -1,10 +1,14 @@
 import copy
+import json
+from pathlib import Path
 
 import pytest
+import requests
 
 from app.scripts.fetch_hkustgz_wcq import (
     WCQPreparationError,
     _build_parser,
+    _fetch_text,
     build_snapshot,
     parse_index,
     parse_subject_page,
@@ -123,6 +127,90 @@ ALPHANUMERIC_LABS_COURSE = """
 """
 
 
+UFUG_INDEX_HTML = """
+<!doctype html>
+<html>
+  <head><title>UFUG - HKUST Class Schedule &amp; Quota</title></head>
+  <body>
+    <a href="/wcq/cgi-bin/2610/">2026-27 Fall</a>
+    <div class="depts">
+      <a class="ug" href="/wcq/cgi-bin/2610/subject/UFUG">UFUG</a>
+    </div>
+  </body>
+</html>
+"""
+
+
+UFUG_1301_WITH_UNSCHEDULED_FALLBACK = """
+<div class="course">
+  <div class="courseinfo">
+    <div class="matching">[Matching between Lecture &amp; Lab required]</div>
+    <table><tr><th>DESCRIPTION</th><td>General chemistry.</td></tr></table>
+  </div>
+  <h2>UFUG 1301 - General Chemistry (3 units)</h2>
+  <table class="sections">
+    <tr><th>Section</th></tr>
+    <tr class="newsect secteven">
+      <td>L01 (6187)</td><td>We 01:30PM - 04:20PM</td><td>Rm 149, E1</td>
+      <td>HE, Quanfu</td><td>24</td><td>0</td><td>24</td><td>0</td><td>&nbsp;</td>
+    </tr>
+    <tr class="newsect sectodd">
+      <td>TBA (6951)</td><td>TBA</td><td>TBA</td><td>TBA</td>
+      <td>5</td><td>0</td><td>5</td><td>0</td>
+      <td>
+        <div class="popup classnotes"><div class="popupdetail">
+          &gt; If the lab sessions listed in the course schedule are not suitable
+          for your availability, or if you were unable to enroll in a session,
+          you can contact the instructor to request access to the &quot;TBA&quot;
+          section.
+          The lab class schedule will be coordinated later based on the
+          availability of students who select &quot;TBA.&quot; Please pay attention to
+          further notifications.
+        </div></div>
+        <div class="popup consent"><div class="popupdetail">
+          Instructor Consent Required
+        </div></div>&nbsp;
+      </td>
+    </tr>
+    <tr class="newsect secteven">
+      <td>LA01 (6189)</td><td>We 01:30PM - 04:20PM</td>
+      <td>Mendeleev Lab</td><td>HE, Quanfu</td>
+      <td>24</td><td>0</td><td>24</td><td>0</td><td>&nbsp;</td>
+    </tr>
+  </table>
+</div>
+"""
+
+
+UFUG_1302_WITH_UNSCHEDULED_FALLBACK = """
+<div class="course">
+  <div class="courseinfo">
+    <div class="matching">[Matching between Lecture &amp; Tutorial required]</div>
+    <table><tr><th>DESCRIPTION</th><td>Honors chemistry.</td></tr></table>
+  </div>
+  <h2>UFUG 1302 - Honors Chemistry A (3 units)</h2>
+  <table class="sections">
+    <tr><th>Section</th></tr>
+    <tr class="newsect secteven">
+      <td>L01 (6364)</td><td>TuTh 12:00PM - 01:20PM</td><td>Rm 239, E1</td>
+      <td>CAO, Bei</td><td>48</td><td>0</td><td>48</td><td>0</td><td>&nbsp;</td>
+    </tr>
+    <tr class="newsect sectodd">
+      <td>T01 (6366)</td><td>Fr 02:00PM - 02:50PM</td><td>Rm 235, E1</td>
+      <td>CAO, Bei</td><td>48</td><td>0</td><td>48</td><td>0</td><td>&nbsp;</td>
+    </tr>
+    <tr class="newsect secteven">
+      <td>TBA (6952)</td><td>TBA</td><td>TBA</td><td>TBA</td>
+      <td>5</td><td>0</td><td>5</td><td>0</td>
+      <td><div class="popup consent"><div class="popupdetail">
+        Instructor Consent Required
+      </div></div>&nbsp;</td>
+    </tr>
+  </table>
+</div>
+"""
+
+
 def test_parse_index_uses_reproducible_front_controller_urls():
     term_name, subjects = parse_index(
         INDEX_HTML,
@@ -150,6 +238,7 @@ def test_parse_subject_preserves_info_occupancy_matching_and_canonical_meetings(
     assert course["pre_requirement"] == "UFUG 2601"
     assert course["co_requirement"] == "DSAA 1001"
     assert course["exclusion"] == "AIAA 9999"
+    assert course["vector"] == "3-0-1:4"
     assert course["course_info"]["VECTOR"] == "3-0-1:4"
 
     sections = {section["name"]: section for section in course["sections"]}
@@ -187,6 +276,256 @@ def test_parse_subject_preserves_info_occupancy_matching_and_canonical_meetings(
             ],
         },
     ]
+
+
+def test_fetch_text_uses_requests_headers_status_and_declared_charset(monkeypatch):
+    calls = []
+
+    class Response:
+        headers = {"Content-Type": 'Text/HTML; charset = "iso-8859-1"'}
+        content = "café".encode("iso-8859-1")
+
+        def raise_for_status(self):
+            calls.append("raise_for_status")
+
+    def get(url, *, timeout, headers):
+        calls.append((url, timeout, headers))
+        return Response()
+
+    monkeypatch.setattr("app.scripts.fetch_hkustgz_wcq.requests.get", get)
+
+    assert _fetch_text("https://wcq.example/2610", timeout=4.5) == "café"
+    assert calls == [
+        (
+            "https://wcq.example/2610",
+            4.5,
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/132.0 Safari/537.36 "
+                    "campusForum-scheduler-data-preparation/1.0"
+                ),
+                "Accept": "text/html,application/xhtml+xml",
+            },
+        ),
+        "raise_for_status",
+    ]
+
+
+def test_fetch_text_rejects_non_html_and_wraps_transport_errors(monkeypatch):
+    class JsonResponse:
+        headers = {"Content-Type": "application/json; charset=utf-8"}
+        content = b"{}"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.scripts.fetch_hkustgz_wcq.requests.get",
+        lambda *args, **kwargs: JsonResponse(),
+    )
+    with pytest.raises(
+        WCQPreparationError,
+        match="expected HTML, received application/json",
+    ):
+        _fetch_text("https://wcq.example/not-html", timeout=1)
+
+    def timeout(*args, **kwargs):
+        raise requests.Timeout("source did not respond")
+
+    monkeypatch.setattr("app.scripts.fetch_hkustgz_wcq.requests.get", timeout)
+    with pytest.raises(
+        WCQPreparationError,
+        match="failed to fetch .*source did not respond",
+    ):
+        _fetch_text("https://wcq.example/timeout", timeout=1)
+
+
+def test_committed_snapshot_preserves_every_official_vector_value():
+    snapshot_path = (
+        Path(__file__).resolve().parents[1]
+        / "app"
+        / "data"
+        / "pending"
+        / "scheduler_offerings"
+        / "26-27fall.json"
+    )
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    vector_courses = {
+        course["course_code"]: course["vector"]
+        for course in snapshot["courses"]
+        if "VECTOR" in course["course_info"]
+    }
+
+    assert vector_courses == {
+        "IOTA6910L": "[0-0-0:0]",
+        "IOTA6910M": "[3-0-0:3]",
+        "UGOD6100L": "[3-0-0:3]",
+    }
+    assert all(
+        course["vector"] == course["course_info"].get("VECTOR")
+        for course in snapshot["courses"]
+    )
+
+
+def test_reviewed_tba_rows_are_provenance_only_and_never_scheduler_layers():
+    subject_html = _page(
+        "UFUG",
+        UFUG_1301_WITH_UNSCHEDULED_FALLBACK
+        + UFUG_1302_WITH_UNSCHEDULED_FALLBACK,
+    )
+    parsed = parse_subject_page(subject_html, expected_subject="UFUG")
+    courses = {course["course_code"]: course for course in parsed.courses}
+
+    assert [
+        section["name"] for section in courses["UFUG1301"]["sections"]
+    ] == ["L01", "LA01"]
+    assert [
+        section["name"] for section in courses["UFUG1302"]["sections"]
+    ] == ["L01", "T01"]
+    assert all(
+        section["layer"] == 0
+        for course in courses.values()
+        for section in course["sections"]
+    )
+    assert [
+        (section["course_code"], section["section_id"])
+        for section in parsed.unscheduled_sections
+    ] == [("UFUG1301", "6951"), ("UFUG1302", "6952")]
+
+    first = parsed.unscheduled_sections[0]
+    assert first == {
+        "course_code": "UFUG1301",
+        "semester_id": "2610",
+        "source_name": "TBA",
+        "source_label": "TBA (6951)",
+        "section_id": "6951",
+        "date_time": "TBA",
+        "room": "TBA",
+        "instructor": "TBA",
+        "quota": 5,
+        "enrol": 0,
+        "avail": 5,
+        "wait": 0,
+        "remarks": [
+            "> If the lab sessions listed in the course schedule are not "
+            "suitable for your availability, or if you were unable to enroll "
+            "in a session, you can contact the instructor to request access "
+            'to the "TBA" section. The lab class schedule will be coordinated '
+            "later based on the availability of students who select "
+            '"TBA." Please pay attention to further notifications.',
+            "Instructor Consent Required",
+        ],
+        "review_basis": (
+            "The source note explicitly identifies this as an opt-in lab "
+            "fallback whose meeting will be coordinated later."
+        ),
+        "source_row_classes": ["newsect", "sectodd"],
+        "source_cell_values": first["source_cell_values"],
+    }
+    assert len(first["source_cell_values"]) == 9
+    assert first["source_cell_values"][:8] == [
+        "TBA (6951)",
+        "TBA",
+        "TBA",
+        "TBA",
+        "5",
+        "0",
+        "5",
+        "0",
+    ]
+    assert "Instructor Consent Required" in first["source_cell_values"][8]
+
+    snapshot = build_snapshot(
+        index_html=UFUG_INDEX_HTML,
+        term="2610",
+        term_url="https://w5.hkust-gz.edu.cn/wcq/cgi-bin/2610/",
+        retrieved_at="2026-08-11T00:00:00Z",
+        semester_start_date="2026-09-01",
+        subject_html={"UFUG": subject_html},
+    )
+    assert snapshot["provenance"]["unscheduled_sections"] == (
+        parsed.unscheduled_sections
+    )
+    omissions = [
+        item
+        for item in snapshot["provenance"]["approximations"]
+        if item["kind"] == "unscheduled_source_section_omitted"
+    ]
+    assert [
+        (item["course_code"], item["section_id"], item["retained_at"])
+        for item in omissions
+    ] == [
+        ("UFUG1301", "6951", "provenance.unscheduled_sections"),
+        ("UFUG1302", "6952", "provenance.unscheduled_sections"),
+    ]
+    assert validate_snapshot(
+        snapshot,
+        expected_subjects=1,
+        expected_courses=2,
+        expected_offered_courses=2,
+        expected_sections=4,
+        expected_lectures=5,
+        expected_unscheduled_sections=2,
+    ) == {
+        "subjects": 1,
+        "courses": 2,
+        "offered_courses": 2,
+        "sections": 4,
+        "lectures": 5,
+        "unscheduled_sections": 2,
+    }
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "message"),
+    [
+        ("TBA (6951)", "TBA (7999)", "unreviewed unscheduled section"),
+        (
+            "<td>TBA</td><td>TBA</td><td>TBA</td>",
+            "<td>Fr 09:00AM - 09:50AM</td><td>TBA</td><td>TBA</td>",
+            "reviewed unscheduled section changed",
+        ),
+        (
+            "The lab class schedule will be coordinated later",
+            "The lab may be scheduled later",
+            "reviewed unscheduled section changed",
+        ),
+    ],
+)
+def test_reviewed_tba_row_fails_closed_if_identity_or_semantics_change(
+    old, new, message
+):
+    changed = UFUG_1301_WITH_UNSCHEDULED_FALLBACK.replace(old, new, 1)
+
+    with pytest.raises(WCQPreparationError, match=message):
+        parse_subject_page(_page("UFUG", changed), expected_subject="UFUG")
+
+
+def test_unscheduled_control_total_detects_silent_provenance_loss():
+    subject_html = _page(
+        "UFUG",
+        UFUG_1301_WITH_UNSCHEDULED_FALLBACK
+        + UFUG_1302_WITH_UNSCHEDULED_FALLBACK,
+    )
+    snapshot = build_snapshot(
+        index_html=UFUG_INDEX_HTML,
+        term="2610",
+        term_url="https://w5.hkust-gz.edu.cn/wcq/cgi-bin/2610/",
+        retrieved_at="2026-08-11T00:00:00Z",
+        semester_start_date="2026-09-01",
+        subject_html={"UFUG": subject_html},
+    )
+    snapshot["provenance"]["unscheduled_sections"].pop()
+
+    with pytest.raises(
+        WCQPreparationError,
+        match=r"unscheduled_sections=1 \(expected 2\)",
+    ):
+        validate_snapshot(snapshot, expected_unscheduled_sections=2)
+
+    assert _build_parser().parse_args([]).expected_unscheduled_sections == 2
 
 
 def test_research_only_course_uses_compatibility_main_type_fallback():
@@ -269,12 +608,14 @@ def test_build_snapshot_requires_every_advertised_subject_and_records_hashes():
         expected_offered_courses=3,
         expected_sections=7,
         expected_lectures=7,
+        expected_unscheduled_sections=0,
     ) == {
         "subjects": 2,
         "courses": 3,
         "offered_courses": 3,
         "sections": 7,
         "lectures": 7,
+        "unscheduled_sections": 0,
     }
 
     with pytest.raises(WCQPreparationError, match="missing=TEST"):

--- a/tests/test_import_courses.py
+++ b/tests/test_import_courses.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+from app.models.course import Course
+from app.models.tag import Tag
+from app.scripts.import_courses import (
+    CourseImportValidationError,
+    import_courses_from_file,
+)
+
+
+@compiles(JSONB, 'sqlite')
+def compile_jsonb_sqlite(_type, _compiler, **_kw):
+    return 'JSON'
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    CACHE_TYPE = 'SimpleCache'
+    ENABLE_BACKGROUND_TASKS = False
+    JWT_SECRET_KEY = 'test-secret'
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv('DASHSCOPE_API_KEY', 'test-key')
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _write_payload(tmp_path, rows):
+    path = tmp_path / 'courses_2610.json'
+    path.write_text(json.dumps(rows), encoding='utf-8')
+    return path
+
+
+def test_legacy_import_resolves_spaced_identity_and_normalizes_new_rows(app, tmp_path):
+    path = _write_payload(tmp_path, [
+        {'course_code': 'TEST1001', 'name': 'Updated title', 'unit': 3},
+        {'course_code': 'NEWC 2001', 'name': 'New course', 'unit': 2},
+    ])
+
+    with app.app_context():
+        legacy = Course(code='TEST 1001', name='Legacy title', credits=1)
+        db.session.add(legacy)
+        db.session.commit()
+        legacy_id = legacy.id
+        before_count = Course.query.count()
+
+        imported, skipped = import_courses_from_file(path, db.session)
+
+        assert (imported, skipped) == (2, 0)
+        assert Course.query.count() == before_count + 1
+        resolved = db.session.get(Course, legacy_id)
+        assert resolved.code == 'TEST 1001'
+        assert resolved.normalized_code == 'TEST1001'
+        assert resolved.name == 'Updated title'
+        created = Course.query.filter_by(code='NEWC2001').one()
+        assert created.normalized_code == 'NEWC2001'
+        assert Tag.query.filter_by(name='NEWC2001-26Fall').one()
+
+
+def test_legacy_import_rejects_ambiguous_existing_normalized_identity(app, tmp_path):
+    path = _write_payload(tmp_path, [
+        {'course_code': 'TEST1001', 'name': 'Imported title', 'unit': 3},
+    ])
+
+    with app.app_context():
+        db.session.add_all([
+            Course(
+                code='TEST1001',
+                normalized_code='TEST1001',
+                name='Canonical',
+                credits=3,
+            ),
+            Course(code='TEST 1001', name='Legacy duplicate', credits=3),
+        ])
+        db.session.commit()
+
+        with pytest.raises(
+            CourseImportValidationError,
+            match='ambiguous existing course rows',
+        ):
+            import_courses_from_file(path, db.session)
+
+        assert Course.query.filter_by(name='Imported title').count() == 0
+        assert Course.query.filter(
+            Course.code.in_(['TEST1001', 'TEST 1001'])
+        ).count() == 2
+
+
+def test_legacy_import_rejects_source_course_aliases_before_writing(app, tmp_path):
+    path = _write_payload(tmp_path, [
+        {'course_code': 'TEST1001', 'name': 'Canonical', 'unit': 3},
+        {'course_code': 'TEST 1001', 'name': 'Alias', 'unit': 3},
+    ])
+
+    with app.app_context():
+        before_count = Course.query.count()
+        with pytest.raises(
+            CourseImportValidationError,
+            match='duplicate normalized course identity',
+        ):
+            import_courses_from_file(path, db.session)
+
+        assert Course.query.count() == before_count
+
+
+def test_legacy_import_rejects_inconsistent_existing_identity(app, tmp_path):
+    path = _write_payload(tmp_path, [
+        {'course_code': 'TEST1001', 'name': 'Imported title', 'unit': 3},
+    ])
+
+    with app.app_context():
+        db.session.add(Course(
+            code='WRNG1001',
+            normalized_code='TEST1001',
+            name='Inconsistent',
+            credits=3,
+        ))
+        db.session.commit()
+
+        with pytest.raises(
+            CourseImportValidationError,
+            match='normalization is inconsistent',
+        ):
+            import_courses_from_file(path, db.session)
+
+        assert Course.query.filter_by(name='Imported title').count() == 0
+        assert Course.query.filter_by(code='WRNG1001').count() == 1

--- a/tests/test_import_pending_academic_data.py
+++ b/tests/test_import_pending_academic_data.py
@@ -107,7 +107,7 @@ EXPECTED_COUNTS = CurriculumExpectations(
 
 PENDING_DATA_DIR = Path(__file__).resolve().parents[1] / "app" / "data" / "pending"
 REVIEWED_SCHEDULER_SHA256 = (
-    "64cf81e1cabe6bef350b6be1c29206329fe22bfe7e6d820eedd812c419d347cc"
+    "4ec2cb305a31348944cba064dba9435825f19d5c1b99f9e2e8177e233eddfbff"
 )
 REVIEWED_CURRICULUM_SHA256 = (
     "a99cbe5c120ba5fcd707651f4609a6ca08e6d5bfa205734979ad6d9739f6b056"
@@ -126,7 +126,19 @@ def test_reviewed_pending_scheduler_package_matches_locked_controls():
 
     assert file_sha256(path) == REVIEWED_SCHEDULER_SHA256
     snapshot = load_offerings_file(path, "2610")
-    assert snapshot_counts(snapshot) == SnapshotExpectations(383, 383, 801, 824)
+    assert snapshot_counts(snapshot) == SnapshotExpectations(383, 383, 801, 820)
+
+    raw_snapshot = json.loads(path.read_text(encoding="utf-8"))
+    unscheduled = raw_snapshot["provenance"]["unscheduled_sections"]
+    assert [
+        (section["course_code"], section["section_id"])
+        for section in unscheduled
+    ] == [("UFUG1301", "6951"), ("UFUG1302", "6952")]
+    assert not {
+        section["section_id"]
+        for course in raw_snapshot["courses"]
+        for section in course["sections"]
+    } & {"6951", "6952"}
 
 
 def test_reviewed_pending_curriculum_package_matches_locked_controls():

--- a/tests/test_reconcile_course_duplicates.py
+++ b/tests/test_reconcile_course_duplicates.py
@@ -1,0 +1,637 @@
+import os
+
+import pytest
+from sqlalchemy import inspect, select, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+
+from app.extensions import db
+from app.models.academic_map import UserCourseRecord
+from app.models.course import Course
+from app.models.post import Post
+from app.models.scheduler_cart import SchedulerUserCourseCart
+from app.models.scheduler_section import SchedulerSection
+from app.models.tag import Tag, TagType, post_tags
+from app.models.user import User
+from app.models.user_role import UserRole
+from app.scripts.import_scheduler_offerings import create_import_app
+import app.scripts.reconcile_course_duplicates as reconcile_course_duplicates
+from app.scripts.reconcile_course_duplicates import (
+    EXPECTED_COURSE_FOREIGN_KEYS,
+    build_reconciliation_plan,
+    plan_sha256,
+    run_reconciliation,
+)
+
+
+@compiles(JSONB, "sqlite")
+def compile_jsonb_sqlite(_type, _compiler, **_kw):
+    return "JSON"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "test-key"))
+    monkeypatch.setenv("DASHSCOPE_API_KEY", os.getenv("DASHSCOPE_API_KEY", "test-key"))
+    app = create_import_app("sqlite:///:memory:")
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _user():
+    role = UserRole(name="reconcile-user")
+    db.session.add(role)
+    db.session.flush()
+    user = User(
+        username="reconcile-user",
+        password_hash="test-password-hash",
+        email="reconcile@connect.hkust-gz.edu.cn",
+        email_verified=True,
+        role_id=role.id,
+    )
+    db.session.add(user)
+    db.session.flush()
+    return user
+
+
+def _pair(code="TEST1001", spaced_code="TEST 1001"):
+    survivor = Course(
+        code=code,
+        normalized_code=code,
+        name="Canonical Course",
+        credits=3,
+        subject=code[:4],
+        catalog_number=code[4:],
+    )
+    loser = Course(
+        code=spaced_code,
+        normalized_code=None,
+        name="Legacy Course",
+        credits=3,
+    )
+    db.session.add_all([survivor, loser])
+    db.session.flush()
+    return survivor, loser
+
+
+def _apply_from_plan(plan):
+    return run_reconciliation(
+        apply=True,
+        expected_database=plan["database"]["name"],
+        expected_plan_sha256=plan_sha256(plan),
+        expected_pairs=plan["pair_count"],
+        expected_records=plan["user_course_record_count"],
+        expected_tags=plan["tag_count"],
+    )
+
+
+def test_dry_run_is_stable_and_does_not_mutate(app):
+    with app.app_context():
+        survivor, loser = _pair()
+        user = _user()
+        record = UserCourseRecord(
+            user_id=user.id,
+            course_id=loser.id,
+            course_code=loser.code,
+            status=UserCourseRecord.STATUS_COMPLETED,
+        )
+        db.session.add(record)
+        db.session.commit()
+
+        first = run_reconciliation()
+        second = run_reconciliation()
+
+        assert first["status"] == "dry-run"
+        assert first["plan_sha256"] == second["plan_sha256"]
+        assert first["plan"]["pair_count"] == 1
+        assert first["plan"]["user_course_record_count"] == 1
+        assert first["plan"]["blockers"] == []
+        assert db.session.get(Course, loser.id) is not None
+        assert db.session.get(UserCourseRecord, record.id).course_id == loser.id
+        assert db.session.get(Course, survivor.id).normalized_code == "TEST1001"
+
+
+def test_plan_requires_exact_course_schema_invariants(app):
+    with app.app_context():
+        _pair()
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+
+        assert plan["normalized_code_uniqueness"]["enforced"] is True
+        actual_foreign_keys = {
+            (item["table"], tuple(item["columns"]))
+            for item in plan["foreign_keys"]
+        }
+        assert actual_foreign_keys == EXPECTED_COURSE_FOREIGN_KEYS
+        assert plan["blockers"] == []
+
+
+def test_missing_normalized_code_uniqueness_blocks(monkeypatch, app):
+    with app.app_context():
+        _pair()
+        db.session.commit()
+        real_inspector = inspect(db.engine)
+
+        class InspectorWithoutNormalizedUnique:
+            def __getattr__(self, name):
+                return getattr(real_inspector, name)
+
+            def get_unique_constraints(self, table_name, schema=None):
+                return [
+                    item
+                    for item in real_inspector.get_unique_constraints(table_name, schema=schema)
+                    if item.get("column_names") != ["normalized_code"]
+                ]
+
+            def get_indexes(self, table_name, schema=None):
+                return [
+                    item
+                    for item in real_inspector.get_indexes(table_name, schema=schema)
+                    if item.get("column_names") != ["normalized_code"]
+                ]
+
+        proxy = InspectorWithoutNormalizedUnique()
+        monkeypatch.setattr(reconcile_course_duplicates, "inspect", lambda _engine: proxy)
+
+        plan = build_reconciliation_plan()
+
+        assert plan["normalized_code_uniqueness"]["enforced"] is False
+        assert any(
+            blocker["type"] == "missing_normalized_code_uniqueness"
+            for blocker in plan["blockers"]
+        )
+
+
+def test_missing_expected_course_foreign_key_blocks(monkeypatch, app):
+    with app.app_context():
+        _pair()
+        db.session.commit()
+        real_inspector = inspect(db.engine)
+
+        class InspectorWithoutSchedulerCourseForeignKey:
+            def __getattr__(self, name):
+                return getattr(real_inspector, name)
+
+            def get_foreign_keys(self, table_name, schema=None):
+                foreign_keys = real_inspector.get_foreign_keys(table_name, schema=schema)
+                if table_name != "scheduler_sections":
+                    return foreign_keys
+                return [
+                    item
+                    for item in foreign_keys
+                    if item.get("constrained_columns") != ["course_id"]
+                ]
+
+        proxy = InspectorWithoutSchedulerCourseForeignKey()
+        monkeypatch.setattr(reconcile_course_duplicates, "inspect", lambda _engine: proxy)
+
+        plan = build_reconciliation_plan()
+
+        assert any(
+            blocker["type"] == "missing_expected_course_foreign_key"
+            and blocker["table"] == "scheduler_sections"
+            and blocker["columns"] == ["course_id"]
+            for blocker in plan["blockers"]
+        )
+
+
+def test_unexpected_course_foreign_key_blocks_even_without_rows(app):
+    with app.app_context():
+        _pair()
+        db.session.execute(text("""
+            CREATE TABLE rogue_course_refs (
+                id INTEGER PRIMARY KEY,
+                course_id INTEGER,
+                FOREIGN KEY(course_id) REFERENCES courses(id) ON DELETE CASCADE
+            )
+        """))
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+
+        assert any(
+            blocker["type"] == "unsupported_course_foreign_key"
+            and blocker["table"] == "rogue_course_refs"
+            for blocker in plan["blockers"]
+        )
+        db.session.execute(text("DROP TABLE rogue_course_refs"))
+        db.session.commit()
+
+
+def test_cross_schema_course_foreign_key_blocks(monkeypatch, app):
+    with app.app_context():
+        _survivor, loser = _pair()
+        db.session.commit()
+        inspector = inspect(db.session.connection())
+        schema = str(inspector.default_schema_name or "")
+        table_names = set(inspector.get_table_names(schema=schema or None))
+        default_rows = reconcile_course_duplicates._reflected_course_foreign_keys(
+            inspector,
+            schema,
+            table_names,
+        )
+        cross_schema_row = {
+            "schema": "audit",
+            "table": "course_audit",
+            "constraint": "fk_course_audit_course",
+            "columns": ["course_id"],
+            "referred_schema": schema,
+            "referred_table": "courses",
+            "referred_columns": ["id"],
+            "ondelete": "CASCADE",
+            "validated": True,
+        }
+        monkeypatch.setattr(db.engine.dialect, "name", "postgresql")
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "_postgresql_course_foreign_keys",
+            lambda _schema: [*default_rows, cross_schema_row],
+        )
+
+        inventory, blockers = reconcile_course_duplicates._inventory_course_foreign_keys(
+            [loser.id]
+        )
+
+        assert any(
+            item["schema"] == "audit" and item["table"] == "course_audit"
+            for item in inventory
+        )
+        assert any(
+            blocker["type"] == "unsupported_course_foreign_key"
+            and blocker["schema"] == "audit"
+            and blocker["table"] == "course_audit"
+            for blocker in blockers
+        )
+
+
+def test_plan_introspection_uses_the_session_transaction(monkeypatch, app):
+    with app.app_context():
+        _pair()
+        db.session.commit()
+        session_connection = db.session.connection()
+        inspected_connectables = []
+
+        def inspect_session_connection(connectable):
+            inspected_connectables.append(connectable)
+            return inspect(connectable)
+
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "inspect",
+            inspect_session_connection,
+        )
+
+        plan = build_reconciliation_plan()
+
+        assert plan["blockers"] == []
+        assert inspected_connectables
+        assert all(
+            connectable is session_connection
+            for connectable in inspected_connectables
+        )
+
+
+def test_apply_merges_records_tags_and_post_links(app):
+    with app.app_context():
+        survivor, loser = _pair()
+        user = _user()
+        record = UserCourseRecord(
+            user_id=user.id,
+            course_id=loser.id,
+            course_code=loser.code,
+            status=UserCourseRecord.STATUS_COMPLETED,
+        )
+        course_type = TagType(name="COURSE")
+        user_type = TagType(name="user")
+        db.session.add_all([record, course_type, user_type])
+        db.session.flush()
+
+        source_plain = Tag(name=loser.code, tag_type_id=course_type.id)
+        target_plain = Tag(name=survivor.code, tag_type_id=user_type.id)
+        source_semester = Tag(name=f"{loser.code}-25-26Spring", tag_type_id=course_type.id)
+        post_source = Post(user_id=user.id, title="Source", content="Source")
+        post_target = Post(user_id=user.id, title="Target", content="Target")
+        db.session.add_all([source_plain, target_plain, source_semester, post_source, post_target])
+        db.session.flush()
+        db.session.execute(post_tags.insert(), [
+            {"post_id": post_source.id, "tag_id": source_plain.id},
+            {"post_id": post_target.id, "tag_id": target_plain.id},
+            {"post_id": post_source.id, "tag_id": source_semester.id},
+        ])
+        source_plain_id = source_plain.id
+        source_semester_id = source_semester.id
+        target_plain_id = target_plain.id
+        survivor_id = survivor.id
+        loser_id = loser.id
+        record_id = record.id
+        post_source_id = post_source.id
+        post_target_id = post_target.id
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+        assert plan["tag_count"] == 2
+        assert plan["tags"]["rename_count"] == 1
+        assert plan["tags"]["merge_count"] == 1
+        result = _apply_from_plan(plan)
+
+        assert result["status"] == "applied"
+        assert result["applied"] == {
+            "pairs_reconciled": 1,
+            "losers_deleted": 1,
+            "user_course_records_updated": 1,
+            "tags_renamed": 1,
+            "tags_merged": 1,
+            "post_links_copied": 1,
+        }
+        assert db.session.get(Course, loser_id) is None
+        canonical = db.session.get(Course, survivor_id)
+        assert canonical.normalized_code == "TEST1001"
+        updated_record = db.session.get(UserCourseRecord, record_id)
+        assert (updated_record.course_id, updated_record.course_code) == (
+            survivor_id,
+            "TEST1001",
+        )
+
+        assert db.session.get(Tag, source_plain_id) is None
+        merged_tag = db.session.get(Tag, target_plain_id)
+        assert merged_tag.name == survivor.code
+        assert merged_tag.tag_type.name.lower() == TagType.COURSE
+        assert set(db.session.execute(
+            select(post_tags.c.post_id).where(post_tags.c.tag_id == merged_tag.id)
+        ).scalars()) == {post_source_id, post_target_id}
+
+        renamed_tag = db.session.get(Tag, source_semester_id)
+        assert renamed_tag.name == f"{survivor.code}-25-26Spring"
+        assert renamed_tag.tag_type.name.lower() == TagType.COURSE
+        assert set(db.session.execute(
+            select(post_tags.c.post_id).where(post_tags.c.tag_id == renamed_tag.id)
+        ).scalars()) == {post_source_id}
+
+
+def test_apply_requires_exact_controls_and_rolls_back(app):
+    with app.app_context():
+        _survivor, loser = _pair()
+        db.session.commit()
+        plan = build_reconciliation_plan()
+
+        result = run_reconciliation(
+            apply=True,
+            expected_database=plan["database"]["name"],
+            expected_plan_sha256=plan_sha256(plan),
+            expected_pairs=1,
+            expected_records=1,
+            expected_tags=0,
+        )
+
+        assert result["status"] == "blocked"
+        assert result["control_errors"] == [
+            "records count mismatch: actual=0 expected=1"
+        ]
+        assert db.session.get(Course, loser.id) is not None
+
+
+def test_loser_reference_outside_user_records_blocks(app):
+    with app.app_context():
+        _survivor, loser = _pair()
+        db.session.add(SchedulerSection(
+            semester_id="2530",
+            section_id="TEST1001-L01",
+            course_id=loser.id,
+            name="L01",
+            bundle=1,
+            layer=0,
+            quota=30,
+            section_type="L",
+            is_main=True,
+        ))
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+        assert any(
+            blocker["type"] == "blocked_loser_foreign_key_references"
+            and blocker["table"] == "scheduler_sections"
+            for blocker in plan["blockers"]
+        )
+        assert any(
+            item["table"] == "user_course_records"
+            for item in plan["foreign_keys"]
+        )
+        result = _apply_from_plan(plan)
+        assert result["status"] == "blocked"
+        assert db.session.get(Course, loser.id) is not None
+
+
+def test_legacy_cart_alias_blocks(app):
+    with app.app_context():
+        _survivor, loser = _pair()
+        user = _user()
+        db.session.add(SchedulerUserCourseCart(
+            user_id=user.id,
+            semester_id="2530",
+            course_code=loser.code,
+            enabled=True,
+        ))
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+
+        assert plan["legacy_carts"]["course_row_count"] == 1
+        assert any(
+            blocker["type"] == "legacy_cart_alias_references"
+            for blocker in plan["blockers"]
+        )
+
+
+def test_unsupported_duplicate_shape_blocks(app):
+    with app.app_context():
+        _pair()
+        db.session.add(Course(
+            code="TEST\t1001",
+            normalized_code=None,
+            name="Third Variant",
+            credits=3,
+        ))
+        db.session.commit()
+
+        plan = build_reconciliation_plan()
+
+        assert plan["pair_count"] == 0
+        assert any(
+            blocker["type"] == "unsupported_duplicate_shape"
+            and blocker["normalized_code"] == "TEST1001"
+            for blocker in plan["blockers"]
+        )
+
+
+def test_apply_failure_rolls_back_record_rewrite(monkeypatch, app):
+    with app.app_context():
+        survivor, loser = _pair()
+        user = _user()
+        record = UserCourseRecord(
+            user_id=user.id,
+            course_id=loser.id,
+            course_code=loser.code,
+            status=UserCourseRecord.STATUS_COMPLETED,
+        )
+        db.session.add(record)
+        db.session.commit()
+        plan = build_reconciliation_plan()
+
+        def fail_after_record_rewrite(_plan):
+            raise RuntimeError("injected tag failure")
+
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "_apply_tags",
+            fail_after_record_rewrite,
+        )
+        with pytest.raises(RuntimeError, match="injected tag failure"):
+            _apply_from_plan(plan)
+
+        db.session.expire_all()
+        assert db.session.get(Course, loser.id) is not None
+        unchanged = db.session.get(UserCourseRecord, record.id)
+        assert (unchanged.course_id, unchanged.course_code) == (loser.id, loser.code)
+        assert db.session.get(Course, survivor.id).normalized_code == survivor.code
+
+
+def test_plan_fingerprints_all_course_and_tag_columns(app):
+    with app.app_context():
+        survivor, loser = _pair()
+        course_type = TagType(name=TagType.COURSE)
+        db.session.add(course_type)
+        db.session.flush()
+        source_tag = Tag(
+            name=loser.code,
+            tag_type_id=course_type.id,
+            description="original",
+        )
+        db.session.add(source_tag)
+        db.session.commit()
+
+        first = build_reconciliation_plan()
+        first_pair = first["pairs"][0]
+        first_tag = first["tags"]["actions"][0]
+
+        # Raw SQL deliberately bypasses Course.updated_at so the row fingerprint,
+        # rather than a timestamp side effect, must detect the drift.
+        db.session.execute(
+            text("UPDATE courses SET vector = :vector WHERE id = :course_id"),
+            {"vector": "[1-2-3:4]", "course_id": survivor.id},
+        )
+        db.session.commit()
+        second = build_reconciliation_plan()
+        second_pair = second["pairs"][0]
+
+        assert (
+            first_pair["survivor"]["row_sha256"]
+            != second_pair["survivor"]["row_sha256"]
+        )
+        assert plan_sha256(first) != plan_sha256(second)
+
+        db.session.execute(
+            text("UPDATE tags SET description = :description WHERE id = :tag_id"),
+            {"description": "changed", "tag_id": source_tag.id},
+        )
+        db.session.commit()
+        third = build_reconciliation_plan()
+        third_tag = third["tags"]["actions"][0]
+
+        assert (
+            first_tag["source_tag_row_sha256"]
+            != third_tag["source_tag_row_sha256"]
+        )
+        assert plan_sha256(second) != plan_sha256(third)
+
+
+def test_apply_deletes_loser_before_claiming_its_normalized_code(app):
+    with app.app_context():
+        survivor, loser = _pair()
+        survivor.normalized_code = None
+        db.session.commit()
+        loser.normalized_code = survivor.code
+        db.session.commit()
+        survivor_id = survivor.id
+        loser_id = loser.id
+
+        plan = build_reconciliation_plan()
+        assert plan["blockers"] == []
+        result = _apply_from_plan(plan)
+
+        assert result["status"] == "applied"
+        assert db.session.get(Course, loser_id) is None
+        assert db.session.get(Course, survivor_id).normalized_code == "TEST1001"
+
+
+def test_apply_expires_identity_map_after_lock_before_replan(monkeypatch, app):
+    with app.app_context():
+        _pair()
+        db.session.commit()
+        reviewed_plan = build_reconciliation_plan()
+        events = []
+        real_build_plan = reconcile_course_duplicates.build_reconciliation_plan
+        real_expire_all = db.session.expire_all
+
+        def record_build_plan():
+            events.append("build")
+            return real_build_plan()
+
+        def record_lock(_plan):
+            events.append("lock")
+
+        def record_expire_all():
+            events.append("expire")
+            real_expire_all()
+
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "build_reconciliation_plan",
+            record_build_plan,
+        )
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "_lock_apply_tables",
+            record_lock,
+        )
+        monkeypatch.setattr(db.session, "expire_all", record_expire_all)
+
+        result = _apply_from_plan(reviewed_plan)
+
+        assert result["status"] == "applied"
+        assert events[:4] == ["build", "lock", "expire", "build"]
+
+
+def test_postgresql_locks_set_a_finite_timeout_first(monkeypatch, app):
+    with app.app_context():
+        statements = []
+        real_inspector = inspect(db.engine)
+
+        class PostgreSQLInspector:
+            default_schema_name = "public"
+
+            def get_table_names(self, schema=None):
+                return real_inspector.get_table_names()
+
+        def capture_execute(statement, parameters=None):
+            statements.append((str(statement), parameters))
+
+        monkeypatch.setattr(db.engine.dialect, "name", "postgresql")
+        monkeypatch.setattr(
+            reconcile_course_duplicates,
+            "inspect",
+            lambda _engine: PostgreSQLInspector(),
+        )
+        monkeypatch.setattr(db.session, "execute", capture_execute)
+
+        reconcile_course_duplicates._lock_apply_tables({"foreign_keys": []})
+
+        assert "set_config('lock_timeout'" in statements[0][0]
+        assert statements[0][1] == {
+            "lock_timeout": reconcile_course_duplicates.APPLY_LOCK_TIMEOUT,
+        }
+        assert statements[1][0].startswith("LOCK TABLE ")

--- a/tests/test_scheduler_data_import.py
+++ b/tests/test_scheduler_data_import.py
@@ -93,6 +93,7 @@ def test_import_snapshot_is_repeatable(app):
         }
         assert second == first
         assert Course.query.filter_by(code='AIAA1001').count() == 1
+        assert Course.query.filter_by(code='AIAA1001').one().normalized_code == 'AIAA1001'
         assert SchedulerSection.query.count() == 1
         assert SchedulerLecture.query.count() == 1
         offering = CourseOffering.query.filter_by(semester_id='2530').one()
@@ -117,6 +118,108 @@ def test_import_snapshot_rejects_orphan_lecture_without_mutating_destination(app
 
         assert Course.query.filter_by(code='KEEP1001').one()
         assert Course.query.filter_by(code='AIAA1001').count() == 0
+        assert SchedulerSection.query.count() == 0
+
+
+def test_import_snapshot_resolves_spaced_existing_course_identity(app):
+    conn = source_connection()
+
+    with app.app_context():
+        legacy = Course(code='AIAA 1001', name='Legacy title', credits=1)
+        db.session.add(legacy)
+        db.session.commit()
+        legacy_id = legacy.id
+        before_count = Course.query.count()
+
+        import_snapshot(conn)
+
+        assert Course.query.count() == before_count
+        resolved = db.session.get(Course, legacy_id)
+        assert resolved.code == 'AIAA 1001'
+        assert resolved.normalized_code == 'AIAA1001'
+        assert resolved.name == 'AI Basics'
+        assert SchedulerSection.query.one().course_id == legacy_id
+
+
+def test_import_snapshot_canonicalizes_new_spaced_source_code(app):
+    conn = source_connection()
+    conn.execute(text(
+        "UPDATE course SET course_code = 'AIAA 1001' WHERE course_code = 'AIAA1001'"
+    ))
+    conn.execute(text(
+        "UPDATE section SET course_code = 'AIAA 1001' WHERE course_code = 'AIAA1001'"
+    ))
+    conn.commit()
+
+    with app.app_context():
+        import_snapshot(conn)
+
+        course = Course.query.filter_by(code='AIAA1001').one()
+        assert course.code == 'AIAA1001'
+        assert course.normalized_code == 'AIAA1001'
+        assert SchedulerSection.query.one().course_id == course.id
+
+
+def test_import_snapshot_rejects_ambiguous_existing_normalized_identity(app):
+    conn = source_connection()
+
+    with app.app_context():
+        db.session.add_all([
+            Course(
+                code='AIAA1001',
+                normalized_code='AIAA1001',
+                name='Canonical',
+                credits=3,
+            ),
+            Course(code='AIAA 1001', name='Legacy duplicate', credits=3),
+        ])
+        db.session.commit()
+
+        with pytest.raises(SnapshotValidationError, match='ambiguous existing course rows'):
+            import_snapshot(conn)
+
+        assert Course.query.filter(
+            Course.code.in_(['AIAA1001', 'AIAA 1001'])
+        ).count() == 2
+        assert SchedulerSection.query.count() == 0
+
+
+def test_import_snapshot_rejects_inconsistent_existing_normalized_identity(app):
+    conn = source_connection()
+
+    with app.app_context():
+        db.session.add(Course(
+            code='WRNG1001',
+            normalized_code='AIAA1001',
+            name='Inconsistent',
+            credits=3,
+        ))
+        db.session.commit()
+
+        with pytest.raises(SnapshotValidationError, match='normalization is inconsistent'):
+            import_snapshot(conn)
+
+        assert Course.query.filter_by(code='WRNG1001').count() == 1
+        assert SchedulerSection.query.count() == 0
+
+
+def test_import_snapshot_rejects_source_course_aliases(app):
+    conn = source_connection()
+    conn.execute(text(
+        "INSERT INTO course VALUES "
+        "('AIAA 1001','Alias','AI','Intro',NULL,NULL,NULL,3,'AIAA','1001',0,0,'A')"
+    ))
+    conn.commit()
+
+    with app.app_context():
+        before_count = Course.query.count()
+        with pytest.raises(
+            SnapshotValidationError,
+            match='duplicate normalized course identity',
+        ):
+            import_snapshot(conn)
+
+        assert Course.query.count() == before_count
         assert SchedulerSection.query.count() == 0
 
 


### PR DESCRIPTION
## What changed

- Add a fail-closed, dry-run-by-default course-identity reconciliation command with exact database, plan hash, row-count, FK-topology, and locking controls.
- Prevent whitespace aliases from recurring through admin create/update routes, catalog sync, deferred UFUG/UCUG/AIAA adjustments, and legacy course/scheduler importers.
- Refresh the official 2026–27 Fall (2610) snapshot to 383 courses, 801 schedulable sections, and 820 canonical meetings.
- Preserve the two official unscheduled TBA rows (UFUG1301/6951 and UFUG1302/6952) as audited provenance instead of inventing incorrect scheduler layers or bundles.
- Preserve all official VECTOR values and use the project requests/certifi transport for live WCQ fetching.

## Root cause

Several historical paths resolved courses by exact raw code. Spaced codes such as `UFUG 1403` could therefore coexist with canonical `UFUG1403` rows. The deferred startup adjustments could recreate those aliases after a database cleanup.

## Impact

Course identities are now normalized consistently, ambiguous legacy states fail closed, and operators have a reviewed transactional repair path. The pending 2610 package remains manual and is not wired into startup or deployment.

## Validation

- Full backend suite: 430 passed
- `git diff --check`
- Live WCQ controls: 29 subjects, 383 courses, 801 schedulable sections, 820 meetings, 2 provenance-only TBA rows
- Dev reconciliation: zero duplicate pairs after repair and concurrent API traffic
- Dev 2610 importer: clean dry-run with no omitted offerings, sections, meetings, or stale carts
