### PR TITLE
Fix post-restart service health gate

### DIFF
--- a/.github/workflows/backend-operations.yml
+++ b/.github/workflows/backend-operations.yml
@@ -256,7 +256,7 @@ jobs:
             "$@" | tee "/data/dev_unikorn/operation-reports/${OPS_REQUEST_ID}-${OPS_WORKFLOW_RUN_ID}-${OPS_WORKFLOW_RUN_ATTEMPT}.log"
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart dev-unikorn-api.service
-              sudo /usr/bin/systemctl is-active --quiet dev-unikorn-api.service
+              /usr/bin/systemctl is-active --quiet dev-unikorn-api.service
               curl -fsS --max-time 20 http://127.0.0.1:8000/scheduler/semesters >/dev/null
             fi
 
@@ -333,6 +333,6 @@ jobs:
             "$@" | tee "/data/prod_unikorn/operation-reports/${OPS_REQUEST_ID}-${OPS_WORKFLOW_RUN_ID}-${OPS_WORKFLOW_RUN_ATTEMPT}.log"
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart prod-unikorn-api.service
-              sudo /usr/bin/systemctl is-active --quiet prod-unikorn-api.service
+              /usr/bin/systemctl is-active --quiet prod-unikorn-api.service
               curl -fsS --max-time 20 http://127.0.0.1:8001/scheduler/semesters >/dev/null
             fi

--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -150,7 +150,7 @@ jobs:
 
           echo "Restarting production service..."
           sudo /usr/bin/systemctl restart "${service_name}"
-          if ! sudo /usr/bin/systemctl is-active --quiet "${service_name}"; then
+          if ! /usr/bin/systemctl is-active --quiet "${service_name}"; then
             echo "Production service failed to start." >&2
             sudo /usr/bin/systemctl status --no-pager --full "${service_name}" || true
             sudo /usr/bin/journalctl -u "${service_name}" -n 100 --no-pager || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
             python -m app.scripts.init_db
 
             sudo /usr/bin/systemctl restart "$service_name"
-            sudo /usr/bin/systemctl is-active --quiet "$service_name"
+            /usr/bin/systemctl is-active --quiet "$service_name"
 
             api_response="$(mktemp)"
             trap 'rm -f "$api_response"' EXIT

--- a/app/scripts/run_backend_operation.py
+++ b/app/scripts/run_backend_operation.py
@@ -474,13 +474,8 @@ def _verify_release() -> dict[str, Any]:
         if offering_ids
         else 0
     )
-    legacy_sections = SchedulerSection.query.filter_by(semester="2610").count()
-    legacy_meetings = (
-        db.session.query(func.count(SchedulerLecture.id))
-        .join(SchedulerSection, SchedulerLecture.section_id == SchedulerSection.id)
-        .filter(SchedulerSection.semester == "2610")
-        .scalar()
-    )
+    legacy_sections = SchedulerSection.query.filter_by(semester_id="2610").count()
+    legacy_meetings = SchedulerLecture.query.filter_by(semester_id="2610").count()
     tba_rows = (
         CourseSection.query.filter(
             CourseSection.offering_id.in_(offering_ids),

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -342,6 +342,7 @@ def test_operation_workflow_is_a_hardened_dispatch_api():
     assert "test \"$(git rev-parse HEAD)\" = \"$OPS_RELEASE_SHA\"" in workflow
     assert "flock -n 9" in workflow
     assert "group: backend-mutations-production" in workflow
+    assert "sudo /usr/bin/systemctl is-active" not in workflow
     assert '\"\"|APPLY_DEV|APPLY_PRODUCTION' in workflow
     assert "http://127.0.0.1:8001/scheduler/semesters" in workflow
     assert "appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2" in workflow

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -1,13 +1,44 @@
 import argparse
 import json
+import os
 from pathlib import Path
 
 import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
 
+from app import create_app
+from app.config import Config
+from app.extensions import db
 from app.scripts import run_backend_operation as operations
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+@compiles(JSONB, "sqlite")
+def compile_jsonb_sqlite(_type, _compiler, **_kw):
+    return "JSON"
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    CACHE_TYPE = "SimpleCache"
+    ENABLE_BACKGROUND_TASKS = False
+    JWT_SECRET_KEY = "test-secret"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "test-key"))
+    monkeypatch.setenv("DASHSCOPE_API_KEY", os.getenv("DASHSCOPE_API_KEY", "test-key"))
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
 
 
 def _args(*extra):
@@ -319,6 +350,15 @@ def test_database_upgrade_uses_fixed_argv_without_shell(monkeypatch):
         "heads",
     ]
     assert "shell" not in calls[0][1]
+
+
+def test_verify_release_queries_current_legacy_scheduler_schema(app):
+    with app.app_context():
+        result = operations._verify_release()
+
+    assert result["status"] == "blocked"
+    assert result["checks"]["legacy_sections"] == 0
+    assert result["checks"]["legacy_meetings"] == 0
 
 
 def test_operation_workflow_is_a_hardened_dispatch_api():

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -99,6 +99,7 @@ def test_deploy_workflows_fail_on_migration_errors_and_use_committed_revisions()
         deploy_workflow = path.read_text(encoding="utf-8")
         assert "set -Eeuo pipefail" in deploy_workflow
         assert "flock -n 9" in deploy_workflow
+        assert "sudo /usr/bin/systemctl is-active" not in deploy_workflow
         assert "flask db upgrade heads" in deploy_workflow
         assert "flask db migrate" not in deploy_workflow
 


### PR DESCRIPTION
## Summary

- keep `systemctl restart` privileged
- run the read-only `systemctl is-active` health gate without sudo in dev, production, and backend operations workflows
- query the legacy scheduler verification tables by their real `semester_id` columns
- add regressions preventing the unsupported sudo form from returning

## Root cause

The dev release reached the exact commit, created and verified its database backup, applied migrations and curriculum initialization, restarted the service successfully, and returned a healthy local API. CI then failed because `sudo systemctl is-active` is not in the deployment account's passwordless sudo allowlist. The unprivileged status command is supported and returns the required state.

The first real `verify-release` dispatch also exposed stale ORM attribute names in its legacy scheduler checks. The query now uses `SchedulerSection.semester_id` and `SchedulerLecture.semester_id`, with an empty-database integration regression that executes the complete verification query set.

## Verification

- 21 focused workflow/operations tests passed
- all workflow YAML parsed
- all embedded shell blocks passed `bash -n`
- dev service is active, migrations are at both heads, curriculum is 8 programs / 32 groups, and the local scheduler API returns HTTP 200
