### PR TITLE
Retry operations API readiness checks

### DIFF
--- a/.github/workflows/backend-operations.yml
+++ b/.github/workflows/backend-operations.yml
@@ -257,7 +257,17 @@ jobs:
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart dev-unikorn-api.service
               /usr/bin/systemctl is-active --quiet dev-unikorn-api.service
-              curl -fsS --max-time 20 http://127.0.0.1:8000/scheduler/semesters >/dev/null
+              api_ready=false
+              for attempt in {1..12}; do
+                if curl -fsS --connect-timeout 2 --max-time 5 \
+                  http://127.0.0.1:8000/scheduler/semesters >/dev/null; then
+                  api_ready=true
+                  break
+                fi
+                echo "Dev API is not ready yet (attempt ${attempt}/12)."
+                sleep 3
+              done
+              test "$api_ready" = "true"
             fi
 
   operate-production:
@@ -334,5 +344,15 @@ jobs:
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart prod-unikorn-api.service
               /usr/bin/systemctl is-active --quiet prod-unikorn-api.service
-              curl -fsS --max-time 20 http://127.0.0.1:8001/scheduler/semesters >/dev/null
+              api_ready=false
+              for attempt in {1..12}; do
+                if curl -fsS --connect-timeout 2 --max-time 5 \
+                  http://127.0.0.1:8001/scheduler/semesters >/dev/null; then
+                  api_ready=true
+                  break
+                fi
+                echo "Production API is not ready yet (attempt ${attempt}/12)."
+                sleep 3
+              done
+              test "$api_ready" = "true"
             fi

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -385,6 +385,8 @@ def test_operation_workflow_is_a_hardened_dispatch_api():
     assert "sudo /usr/bin/systemctl is-active" not in workflow
     assert '\"\"|APPLY_DEV|APPLY_PRODUCTION' in workflow
     assert "http://127.0.0.1:8001/scheduler/semesters" in workflow
+    assert workflow.count("for attempt in {1..12}") == 2
+    assert workflow.count('test "$api_ready" = "true"') == 2
     assert "appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2" in workflow
     assert "appleboy/ssh-action@master" not in workflow
     assert "${{ inputs." not in workflow.split("script: |", 1)[1]


### PR DESCRIPTION
## Summary

- retry the local scheduler API readiness check after dev or production data operations restart Gunicorn
- retain the immediate systemd active-state gate
- require a bounded 12-attempt/3-second readiness window in regression coverage

## Root cause and production state

The exact production duplicate plan applied successfully after a verified backup:

- 367 duplicate pairs reconciled
- 367 losers deleted
- 67 user-course records updated
- 13 tags merged and 849 tags renamed

The immutable runner report is `applied`, the service is active, and a separate post-apply dry run reports zero pairs/records/tags/blockers. The workflow itself failed only because its one-shot curl raced the freshly restarted Gunicorn listener.

## Verification

- 13 focused backend-operations tests passed
- workflow YAML parsed
- every embedded operations shell block passed `bash -n`
- `git diff --check` passed
