### PR TITLE
Promote operations readiness retry

### DIFF
--- a/.github/workflows/backend-operations.yml
+++ b/.github/workflows/backend-operations.yml
@@ -257,7 +257,17 @@ jobs:
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart dev-unikorn-api.service
               /usr/bin/systemctl is-active --quiet dev-unikorn-api.service
-              curl -fsS --max-time 20 http://127.0.0.1:8000/scheduler/semesters >/dev/null
+              api_ready=false
+              for attempt in {1..12}; do
+                if curl -fsS --connect-timeout 2 --max-time 5 \
+                  http://127.0.0.1:8000/scheduler/semesters >/dev/null; then
+                  api_ready=true
+                  break
+                fi
+                echo "Dev API is not ready yet (attempt ${attempt}/12)."
+                sleep 3
+              done
+              test "$api_ready" = "true"
             fi
 
   operate-production:
@@ -334,5 +344,15 @@ jobs:
             if [ "$OPS_MODE" = "apply" ]; then
               sudo /usr/bin/systemctl restart prod-unikorn-api.service
               /usr/bin/systemctl is-active --quiet prod-unikorn-api.service
-              curl -fsS --max-time 20 http://127.0.0.1:8001/scheduler/semesters >/dev/null
+              api_ready=false
+              for attempt in {1..12}; do
+                if curl -fsS --connect-timeout 2 --max-time 5 \
+                  http://127.0.0.1:8001/scheduler/semesters >/dev/null; then
+                  api_ready=true
+                  break
+                fi
+                echo "Production API is not ready yet (attempt ${attempt}/12)."
+                sleep 3
+              done
+              test "$api_ready" = "true"
             fi

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -385,6 +385,8 @@ def test_operation_workflow_is_a_hardened_dispatch_api():
     assert "sudo /usr/bin/systemctl is-active" not in workflow
     assert '\"\"|APPLY_DEV|APPLY_PRODUCTION' in workflow
     assert "http://127.0.0.1:8001/scheduler/semesters" in workflow
+    assert workflow.count("for attempt in {1..12}") == 2
+    assert workflow.count('test "$api_ready" = "true"') == 2
     assert "appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2" in workflow
     assert "appleboy/ssh-action@master" not in workflow
     assert "${{ inputs." not in workflow.split("script: |", 1)[1]


### PR DESCRIPTION
## Production workflow fix promotion

Promote the bounded post-operation API readiness retry already verified on dev.

The production duplicate reconciliation itself is complete and verified:

- immutable apply report status: `applied`
- verified backup SHA-256: `d5b93358763838bdc82159d0a02558eb07b171b2b6e1d2e86d44e2ff6eacec03`
- 367 pairs reconciled, 67 records updated, 13 tags merged, 849 tags renamed
- post-apply dry run: zero pairs, zero records, zero tags, zero blockers

The workflow-only change retries the local API for up to 12 attempts after a successful restart, matching the deployment workflow's readiness behavior.

Dev deployment of the fix passed clean-runner tests, exact-SHA deployment, service health, and public API checks at `66f8b26dd24a4ef5c97a7e4c3485ef7d3971c546`.
