### PR TITLE
fix: make academic operations retry-safe

### DIFF
--- a/app/scripts/run_backend_operation.py
+++ b/app/scripts/run_backend_operation.py
@@ -22,16 +22,22 @@ import sys
 import tempfile
 from typing import Any, Iterator
 
-from sqlalchemy import func, text
+from sqlalchemy import func, inspect, text
 
 from app.extensions import db
 from app.models.academic_map import CurriculumProgram, CurriculumRequirementGroup
 from app.models.course import Course
-from app.models.course_domain import CourseMeeting, CourseOffering, CourseSection
+from app.models.course_domain import (
+    CourseCatalogVersion,
+    CourseMeeting,
+    CourseOffering,
+    CourseSection,
+)
 from app.models.scheduler_lecture import SchedulerLecture
 from app.models.scheduler_section import SchedulerSection
 from app.scripts.import_pending_academic_data import (
     CurriculumExpectations,
+    load_curriculum_file,
     run_pending_curriculum_update,
     run_pending_scheduler_update,
 )
@@ -39,9 +45,11 @@ from app.scripts.import_scheduler_offerings import (
     SnapshotExpectations,
     create_import_app,
     file_sha256,
+    load_offerings_file,
 )
 from app.scripts.reconcile_course_duplicates import run_reconciliation
-from app.services.course_domain import normalize_course_code
+from app.services.academic_curriculum_sync import curriculum_persisted_projection
+from app.services.course_domain import display_course_code, normalize_course_code
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -390,11 +398,563 @@ def _validate_current_data_plan(
         raise OperationBlocked("operation does not support data-plan validation")
 
     serialized_result = _json_value(current_result)
+    approved_result = approved.get("result")
+    if isinstance(approved_result, dict):
+        approved_result = {
+            key: value
+            for key, value in approved_result.items()
+            if key not in {"pre_state_sha256", "desired_state_sha256"}
+        }
     if (
         _result_status(current_result) != "dry-run"
-        or _sha256_json(serialized_result) != approved.get("result_sha256")
+        or not isinstance(approved_result, dict)
+        or _sha256_json(serialized_result) != _sha256_json(approved_result)
     ):
         raise OperationBlocked("current data plan does not match approved dry-run")
+
+
+def _validate_approved_pre_state(
+    args: argparse.Namespace,
+    package: dict[str, Any],
+) -> None:
+    approved = _read_report(args.approved_dry_run_id)
+    result = approved.get("result")
+    approved_pre_state = (
+        result.get("pre_state_sha256") if isinstance(result, dict) else None
+    )
+    if not isinstance(approved_pre_state, str) or not SHA256_RE.fullmatch(
+        approved_pre_state
+    ):
+        raise OperationBlocked("approved dry-run is missing an exact pre-state digest")
+    current_pre_state = _data_pre_state(args.operation, package)
+    if current_pre_state["pre_state_sha256"] != approved_pre_state:
+        raise OperationBlocked("current data state does not match approved dry-run")
+
+
+def _sorted_projection(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(rows, key=_canonical_json)
+
+
+def _scheduler_desired_projection(snapshot: Any, package_sha256: str) -> dict[str, Any]:
+    courses = _scheduler_desired_course_projection(snapshot)
+    offerings = []
+    catalog_versions = []
+    domain_sections = []
+    legacy_sections = []
+    domain_meetings = []
+    legacy_meetings = []
+
+    for course in snapshot.courses:
+        code = normalize_course_code(course.course_code)
+        catalog_versions.append(
+            {
+                "course_code": code,
+                "source": "scheduler_offerings",
+                "source_version": snapshot.semester_id,
+                "catalog_year": snapshot.semester_id[:2],
+                "title": course.course_title,
+                "title_abbr": course.course_title_abbr,
+                "description": course.course_desc,
+                "credits": course.credit,
+                "pre_requirement_raw": course.pre_requirement,
+                "co_requirement_raw": course.co_requirement,
+                "exclusion_raw": course.exclusion,
+                "pg_course": course.pg_course,
+                "klms_course": course.klms_course,
+                "vector": course.vector,
+                "effective_from_semester_id": snapshot.semester_id,
+            }
+        )
+        if course.sections:
+            offerings.append(
+                {
+                    "course_code": code,
+                    "offering_code": course.course_code,
+                    "title_snapshot": course.course_title,
+                    "credits_snapshot": course.credit,
+                    "source": "scheduler_offerings",
+                    "import_hash": package_sha256,
+                    "status": "offered",
+                    "course_is_active": True,
+                    "course_is_deleted": False,
+                    "catalog_version_course_code": code,
+                    "catalog_version_source": "scheduler_offerings",
+                    "catalog_version_source_version": snapshot.semester_id,
+                }
+            )
+
+        for section in course.sections:
+            common_section = {
+                "course_code": code,
+                "section_id": section.section_id,
+                "name": section.name,
+                "section_type": section.section_type,
+                "bundle": section.bundle,
+                "layer": section.layer,
+                "quota": section.quota,
+                "is_main": section.is_main,
+            }
+            domain_sections.append(
+                {
+                    **common_section,
+                    "enrol": section.enrol,
+                    "avail": section.avail,
+                    "wait": section.wait,
+                }
+            )
+            legacy_sections.append(common_section)
+            for lecture in section.lectures:
+                common_meeting = {
+                    "course_code": code,
+                    "section_id": section.section_id,
+                    "day": lecture.day,
+                    "start_time": lecture.start_time,
+                    "end_time": lecture.end_time,
+                    "room": lecture.room,
+                }
+                domain_meetings.append(
+                    {**common_meeting, "instructor": lecture.instructor}
+                )
+                legacy_meetings.append(
+                    {**common_meeting, "instructor": lecture.instructor}
+                )
+
+    return {
+        "semester_id": snapshot.semester_id,
+        "courses": courses,
+        "offerings": _sorted_projection(offerings),
+        "catalog_versions": _sorted_projection(catalog_versions),
+        "domain_sections": _sorted_projection(domain_sections),
+        "domain_meetings": _sorted_projection(domain_meetings),
+        "legacy_sections": _sorted_projection(legacy_sections),
+        "legacy_meetings": _sorted_projection(legacy_meetings),
+        "invalid_archived_offerings": [],
+    }
+
+
+def _scheduler_desired_course_projection(snapshot: Any) -> list[dict[str, Any]]:
+    rows = []
+    for course in snapshot.courses:
+        row = {
+            "course_code": normalize_course_code(course.course_code),
+            "normalized_code": normalize_course_code(course.course_code),
+            "display_code": display_course_code(course.course_code),
+            "canonical_title": course.course_title,
+            "name": course.course_title,
+            "description": course.course_desc,
+            "credits": course.credit,
+            "subject": course.subject.upper() if course.subject else None,
+            "catalog_number": course.catalog_number,
+            "course_title_abbr": course.course_title_abbr,
+            "pg_course": course.pg_course,
+            "klms_course": course.klms_course,
+            "vector": course.vector,
+            "is_active": True,
+            "is_deleted": False,
+        }
+        for attribute in ("pre_requirement", "co_requirement", "exclusion"):
+            value = getattr(course, attribute)
+            if value is not None:
+                row[attribute] = value
+        rows.append(row)
+    return _sorted_projection(rows)
+
+
+def _scheduler_current_course_projection(
+    desired: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    desired_by_code = {row["course_code"]: row for row in desired}
+    rows = []
+    for course in Course.query.all():
+        code = normalize_course_code(course.normalized_code or course.code)
+        expected = desired_by_code.get(code)
+        if expected is None:
+            continue
+        rows.append(
+            {
+                key: code if key == "course_code" else getattr(course, key)
+                for key in expected
+            }
+        )
+    return _sorted_projection(rows)
+
+
+def _scheduler_current_projection(
+    semester_id: str,
+    desired_courses: list[dict[str, Any]],
+) -> dict[str, Any]:
+    active_offerings = (
+        CourseOffering.query.join(Course, CourseOffering.course_id == Course.id)
+        .filter(
+            CourseOffering.semester_id == semester_id,
+            CourseOffering.status != "archived",
+        )
+        .all()
+    )
+    offerings = [
+        {
+            "course_code": normalize_course_code(offering.course.normalized_code or offering.course.code),
+            "offering_code": offering.offering_code,
+            "title_snapshot": offering.title_snapshot,
+            "credits_snapshot": offering.credits_snapshot,
+            "source": offering.source,
+            "import_hash": offering.import_hash,
+            "status": offering.status,
+            "course_is_active": offering.course.is_active,
+            "course_is_deleted": offering.course.is_deleted,
+            "catalog_version_course_code": (
+                normalize_course_code(
+                    offering.catalog_version.course.normalized_code
+                    or offering.catalog_version.course.code
+                )
+                if offering.catalog_version is not None
+                else None
+            ),
+            "catalog_version_source": (
+                offering.catalog_version.source
+                if offering.catalog_version is not None
+                else None
+            ),
+            "catalog_version_source_version": (
+                offering.catalog_version.source_version
+                if offering.catalog_version is not None
+                else None
+            ),
+        }
+        for offering in active_offerings
+    ]
+
+    catalog_versions = [
+        {
+            "course_code": normalize_course_code(version.course.normalized_code or version.course.code),
+            "source": version.source,
+            "source_version": version.source_version,
+            "catalog_year": version.catalog_year,
+            "title": version.title,
+            "title_abbr": version.title_abbr,
+            "description": version.description,
+            "credits": version.credits,
+            "pre_requirement_raw": version.pre_requirement_raw,
+            "co_requirement_raw": version.co_requirement_raw,
+            "exclusion_raw": version.exclusion_raw,
+            "pg_course": version.pg_course,
+            "klms_course": version.klms_course,
+            "vector": version.vector,
+            "effective_from_semester_id": version.effective_from_semester_id,
+        }
+        for version in (
+            db.session.query(CourseCatalogVersion)
+            .join(Course)
+            .filter(
+                CourseCatalogVersion.source == "scheduler_offerings",
+                CourseCatalogVersion.source_version == semester_id,
+            )
+            .all()
+        )
+    ]
+
+    domain_sections = [
+        {
+            "course_code": normalize_course_code(section.offering.course.normalized_code or section.offering.course.code),
+            "section_id": section.source_section_id,
+            "name": section.name,
+            "section_type": section.section_type,
+            "bundle": section.bundle,
+            "layer": section.layer,
+            "quota": section.quota,
+            "is_main": section.is_main,
+            "enrol": section.enrol,
+            "avail": section.avail,
+            "wait": section.wait,
+        }
+        for section in (
+            CourseSection.query.join(CourseOffering)
+            .filter(
+                CourseOffering.semester_id == semester_id,
+                CourseOffering.status != "archived",
+            )
+            .all()
+        )
+    ]
+    domain_meetings = [
+        {
+            "course_code": normalize_course_code(meeting.section.offering.course.normalized_code or meeting.section.offering.course.code),
+            "section_id": meeting.section.source_section_id,
+            "day": meeting.day,
+            "start_time": meeting.start_time,
+            "end_time": meeting.end_time,
+            "room": meeting.room,
+            "instructor": meeting.instructor_text,
+        }
+        for meeting in (
+            CourseMeeting.query.join(CourseSection).join(CourseOffering)
+            .filter(
+                CourseOffering.semester_id == semester_id,
+                CourseOffering.status != "archived",
+            )
+            .all()
+        )
+    ]
+    legacy_sections = [
+        {
+            "course_code": normalize_course_code(section.course.normalized_code or section.course.code),
+            "section_id": section.section_id,
+            "name": section.name,
+            "section_type": section.section_type,
+            "bundle": section.bundle,
+            "layer": section.layer,
+            "quota": section.quota,
+            "is_main": section.is_main,
+        }
+        for section in SchedulerSection.query.filter_by(semester_id=semester_id).all()
+    ]
+    legacy_by_section = {
+        section.section_id: normalize_course_code(section.course.normalized_code or section.course.code)
+        for section in SchedulerSection.query.filter_by(semester_id=semester_id).all()
+    }
+    legacy_meetings = [
+        {
+            "course_code": legacy_by_section.get(lecture.section_id, ""),
+            "section_id": lecture.section_id,
+            "day": lecture.day,
+            "start_time": lecture.start_time,
+            "end_time": lecture.end_time,
+            "room": lecture.room,
+            "instructor": lecture.instructor,
+        }
+        for lecture in SchedulerLecture.query.filter_by(semester_id=semester_id).all()
+    ]
+    invalid_archived_offerings = [
+        normalize_course_code(offering.course.normalized_code or offering.course.code)
+        for offering in CourseOffering.query.filter_by(
+            semester_id=semester_id, status="archived"
+        ).all()
+        if CourseSection.query.filter_by(offering_id=offering.id).count()
+    ]
+    return {
+        "semester_id": semester_id,
+        "courses": _scheduler_current_course_projection(desired_courses),
+        "offerings": _sorted_projection(offerings),
+        "catalog_versions": _sorted_projection(catalog_versions),
+        "domain_sections": _sorted_projection(domain_sections),
+        "domain_meetings": _sorted_projection(domain_meetings),
+        "legacy_sections": _sorted_projection(legacy_sections),
+        "legacy_meetings": _sorted_projection(legacy_meetings),
+        "invalid_archived_offerings": sorted(invalid_archived_offerings),
+    }
+
+
+def _curriculum_current_projection(desired: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    current = []
+    for expected in desired:
+        program = CurriculumProgram.query.filter_by(
+            code=expected["code"], cohort=expected["cohort"]
+        ).one_or_none()
+        if program is None:
+            continue
+        groups = [
+            {
+                "key": group.key,
+                "name_en": group.name_en,
+                "name_zh": group.name_zh,
+                "category": group.category,
+                "min_credits": group.min_credits,
+                "min_courses": group.min_courses,
+                "rule": group.rule or {},
+                "sort_order": group.sort_order,
+            }
+            for group in CurriculumRequirementGroup.query.filter_by(
+                program_id=program.id
+            ).all()
+        ]
+        current.append(
+            {
+                "code": program.code,
+                "cohort": program.cohort,
+                "name_en": program.name_en,
+                "name_zh": program.name_zh,
+                "total_min_credits": program.total_min_credits,
+                "common_core_min_credits": program.common_core_min_credits,
+                "major_min_credits": program.major_min_credits,
+                "home_areas": program.home_areas or [],
+                "is_active": program.is_active,
+                "requirement_groups": sorted(groups, key=lambda group: group["key"]),
+            }
+        )
+    return sorted(current, key=lambda program: (program["code"], program["cohort"]))
+
+
+def _scheduler_import_run(package_sha256: str) -> dict[str, Any] | None:
+    if not inspect(db.engine).has_table("scheduler_offering_import_runs"):
+        return None
+    row = db.session.execute(
+        text(
+            """
+            SELECT semester_id, status
+            FROM scheduler_offering_import_runs
+            WHERE import_hash = :import_hash
+            """
+        ),
+        {"import_hash": package_sha256},
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def _data_postcondition(
+    operation: str,
+    package: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        actual_sha256 = file_sha256(package["resolved_path"])
+    except OSError as exc:
+        raise OperationBlocked("committed package file is unreadable") from exc
+    if actual_sha256 != package["sha256"]:
+        raise OperationBlocked(
+            f"committed package SHA-256 mismatch: {actual_sha256} != {package['sha256']}"
+        )
+
+    expected = package.get("expected") or {}
+    if operation == "scheduler-import":
+        expectations = SnapshotExpectations(
+            courses=int(expected["courses"]),
+            offered_courses=int(expected["offered_courses"]),
+            sections=int(expected["sections"]),
+            lectures=int(expected["lectures"]),
+        )
+        snapshot = load_offerings_file(
+            package["resolved_path"], package.get("semester_id")
+        )
+        actual_counts = {
+            "courses": len(snapshot.courses),
+            "offered_courses": sum(bool(course.sections) for course in snapshot.courses),
+            "sections": sum(len(course.sections) for course in snapshot.courses),
+            "lectures": sum(
+                len(section.lectures)
+                for course in snapshot.courses
+                for section in course.sections
+            ),
+        }
+        reviewed_counts = asdict(expectations)
+        if actual_counts != reviewed_counts:
+            raise OperationBlocked(
+                "scheduler package no longer matches reviewed exact counts"
+            )
+        desired = _scheduler_desired_projection(snapshot, package["sha256"])
+        current = _scheduler_current_projection(
+            snapshot.semester_id,
+            desired["courses"],
+        )
+        ledger = _scheduler_import_run(package["sha256"])
+        mismatches = [
+            key
+            for key in desired
+            if _canonical_json(desired[key]) != _canonical_json(current[key])
+        ]
+        return {
+            "matches": not mismatches,
+            "desired_state_sha256": _sha256_json(desired),
+            "current_state_sha256": _sha256_json(current),
+            "mismatched_components": mismatches,
+            "ledger_status": (ledger or {}).get("status"),
+            "ledger_semester_id": (ledger or {}).get("semester_id"),
+        }
+
+    if operation == "curriculum-sync":
+        expectations = CurriculumExpectations(
+            program_definitions=int(expected["program_definitions"]),
+            program_cohorts=int(expected["program_cohorts"]),
+            requirement_groups=int(expected["requirement_groups"]),
+            unique_course_codes=int(expected["unique_course_codes"]),
+        )
+        snapshot = load_curriculum_file(package["resolved_path"], expectations)
+        desired = curriculum_persisted_projection(snapshot.payload)
+        current = _curriculum_current_projection(desired)
+        return {
+            "matches": _canonical_json(desired) == _canonical_json(current),
+            "desired_state_sha256": _sha256_json(desired),
+            "current_state_sha256": _sha256_json(current),
+            "expected_programs": len(desired),
+            "current_programs": len(current),
+        }
+
+    raise OperationBlocked("operation does not have data postconditions")
+
+
+def _data_pre_state(operation: str, package: dict[str, Any]) -> dict[str, str]:
+    postcondition = _data_postcondition(operation, package)
+    if operation == "scheduler-import":
+        state = {"package_owned": postcondition["current_state_sha256"]}
+    else:
+        state = {"package_owned": postcondition["current_state_sha256"]}
+    return {"pre_state_sha256": _sha256_json(state)}
+
+
+def _with_data_state(result: Any, operation: str, package: dict[str, Any]) -> dict[str, Any]:
+    serialized = _json_value(result)
+    if not isinstance(serialized, dict):
+        raise OperationBlocked("data operation returned a malformed result")
+    postcondition = _data_postcondition(operation, package)
+    return {
+        **serialized,
+        **_data_pre_state(operation, package),
+        "desired_state_sha256": postcondition["desired_state_sha256"],
+    }
+
+
+def _already_applied_result(
+    operation: str,
+    package: dict[str, Any],
+    postcondition: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "status": "already-applied",
+        "mode": "apply",
+        "message": (
+            f"{operation} package is already present; exact package-owned "
+            "postconditions were verified."
+        ),
+        "package_id": package.get("id"),
+        "package_sha256": package["sha256"],
+        "postcondition": postcondition,
+    }
+
+
+def _run_data_apply(
+    args: argparse.Namespace,
+    package: dict[str, Any],
+    operation: Any,
+) -> Any:
+    before = _data_postcondition(args.operation, package)
+    if before["matches"]:
+        return _already_applied_result(args.operation, package, before)
+
+    if args.operation == "scheduler-import" and before.get("ledger_status") in {
+        "applied",
+        "running",
+    }:
+        raise OperationBlocked(
+            "scheduler import ledger exists but exact package postconditions do not match"
+        )
+
+    _validate_current_data_plan(args, package)
+    _validate_approved_pre_state(args, package)
+    result = operation(args, package)
+    if _result_status(result) == "skipped":
+        raise OperationBlocked(
+            "data importer returned skipped without verified exact postconditions"
+        )
+    if _result_status(result) != "applied":
+        return result
+
+    after = _data_postcondition(args.operation, package)
+    if not after["matches"]:
+        raise OperationBlocked(
+            "data importer completed without satisfying exact package postconditions"
+        )
+    return {
+        **_json_value(result),
+        "postcondition": after,
+    }
 
 
 @contextmanager
@@ -576,12 +1136,18 @@ def _run(args: argparse.Namespace, package: dict[str, Any] | None) -> Any:
             return _verify_release()
         if args.operation == "scheduler-import":
             if args.mode == "apply":
-                _validate_current_data_plan(args, package)
-            return _scheduler_operation(args, package)
+                return _run_data_apply(args, package, _scheduler_operation)
+            result = _scheduler_operation(args, package)
+            if _result_status(result) == "dry-run":
+                return _with_data_state(result, args.operation, package)
+            return result
         if args.operation == "curriculum-sync":
             if args.mode == "apply":
-                _validate_current_data_plan(args, package)
-            return _curriculum_operation(args, package)
+                return _run_data_apply(args, package, _curriculum_operation)
+            result = _curriculum_operation(args, package)
+            if _result_status(result) == "dry-run":
+                return _with_data_state(result, args.operation, package)
+            return result
         if args.operation == "course-duplicates":
             return _reconciliation_operation(args)
     raise OperationBlocked("operation is not allowlisted")

--- a/app/services/academic_curriculum_sync.py
+++ b/app/services/academic_curriculum_sync.py
@@ -55,6 +55,94 @@ def _normalize_rule(value: Any) -> dict:
     return normalized
 
 
+def curriculum_persisted_projection(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the package fields owned by the curriculum synchronizer.
+
+    The projection deliberately mirrors the normalizers used by
+    ``sync_curriculum_requirements_from_payload`` and omits database identities
+    and timestamps.  Backend operations use it to verify that a reviewed
+    package's complete persisted postcondition is present before treating a
+    retry as already applied.
+    """
+    programs = payload.get("programs") if isinstance(payload.get("programs"), list) else []
+    projection: list[dict[str, Any]] = []
+
+    for item in programs:
+        if not isinstance(item, dict):
+            continue
+
+        code = _program_code(item.get("code"))
+        name_en = _clean_text(item.get("name_en"))
+        cohorts = (
+            [
+                _clean_text(cohort)
+                for cohort in item.get("cohorts", [])
+                if _clean_text(cohort)
+            ]
+            if isinstance(item.get("cohorts"), list)
+            else []
+        )
+        cohort = _clean_text(item.get("cohort"))
+        if cohort:
+            cohorts = [cohort]
+        if not code or not cohorts or not name_en:
+            continue
+
+        groups: list[dict[str, Any]] = []
+        raw_groups = (
+            item.get("requirement_groups")
+            if isinstance(item.get("requirement_groups"), list)
+            else []
+        )
+        for group_item in raw_groups:
+            if not isinstance(group_item, dict):
+                continue
+            key = _clean_text(group_item.get("key"))
+            name = _clean_text(group_item.get("name_en"))
+            category = _clean_text(group_item.get("category")) or "major"
+            if not key or not name:
+                continue
+            groups.append(
+                {
+                    "key": key,
+                    "name_en": name,
+                    "name_zh": _clean_text(group_item.get("name_zh")) or None,
+                    "category": category,
+                    "min_credits": _integer(group_item.get("min_credits")),
+                    "min_courses": _integer(group_item.get("min_courses")),
+                    "rule": _normalize_rule(group_item.get("rule")),
+                    "sort_order": _integer(group_item.get("sort_order"), 0) or 0,
+                }
+            )
+
+        groups.sort(key=lambda group: group["key"])
+        for expanded_cohort in cohorts:
+            projection.append(
+                {
+                    "code": code,
+                    "cohort": expanded_cohort,
+                    "name_en": name_en,
+                    "name_zh": _clean_text(item.get("name_zh")) or None,
+                    "total_min_credits": _integer(item.get("total_min_credits"), 120)
+                    or 120,
+                    "common_core_min_credits": _integer(
+                        item.get("common_core_min_credits"), 30
+                    )
+                    or 30,
+                    "major_min_credits": _integer(item.get("major_min_credits")),
+                    "home_areas": (
+                        item.get("home_areas")
+                        if isinstance(item.get("home_areas"), list)
+                        else []
+                    ),
+                    "is_active": bool(item.get("is_active", True)),
+                    "requirement_groups": groups,
+                }
+            )
+
+    return sorted(projection, key=lambda program: (program["code"], program["cohort"]))
+
+
 def sync_curriculum_requirements_from_payload(payload: dict[str, Any]) -> dict[str, int]:
     programs = payload.get("programs") if isinstance(payload.get("programs"), list) else []
     result = {"programs_upserted": 0, "groups_upserted": 0, "groups_removed": 0, "programs_skipped": 0}

--- a/docs/backend-operations-api.md
+++ b/docs/backend-operations-api.md
@@ -101,9 +101,15 @@ the dispatched SHA. It serializes operations with both GitHub concurrency and
 `flock`, creates a PostgreSQL custom-format backup, verifies it with
 `pg_restore --list`, records its SHA-256, and only then starts the operation.
 The Python runner also acquires a PostgreSQL advisory lock and rebuilds a
-scheduler or curriculum plan under that lock; its canonical result digest must
-match the approved dry-run before mutation begins. After a successful apply, CI
-restarts the service and checks both systemd and the local scheduler API.
+scheduler or curriculum plan under that lock; both its canonical result digest
+and exact scoped pre-state digest must match the approved dry-run before
+mutation begins. A retry for an exact package
+may return `already-applied`, but only after the runner re-hashes the package and
+verifies the complete package-owned database projection. A package ledger alone
+is never treated as proof: an applied/running ledger with missing or drifted rows
+is blocked, and a newly applied package is verified again before success is
+reported. After a successful apply, CI restarts the service and checks both
+systemd and the local scheduler API.
 
 Sanitized JSON reports are stored immutably under the target's
 `operation-reports` directory using the request id; console logs additionally

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -10,7 +10,11 @@ from sqlalchemy.ext.compiler import compiles
 from app import create_app
 from app.config import Config
 from app.extensions import db
+from app.models.academic_map import CurriculumRequirementGroup
+from app.models.course import Course
+from app.models.course_domain import CourseCatalogVersion, CourseOffering, CourseSection
 from app.scripts import run_backend_operation as operations
+from app.scripts.import_pending_academic_data import PENDING_SCHEDULER_SUBJECTS
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -62,6 +66,165 @@ def _args(*extra):
             "scheduler-2610-v1",
             *extra,
         ]
+    )
+
+
+def _write_scheduler_package(tmp_path):
+    payload = {
+        "semester_id": "2610",
+        "semester_start_date": "2026-09-01",
+        "provenance": {
+            "source_name": "HKUST-GZ Class Schedule & Quota",
+            "term_url": "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/2610/",
+            "retrieved_at": "2026-08-09T12:00:00Z",
+            "subjects": [
+                {
+                    "code": code,
+                    "url": (
+                        "https://w5.hkust-gz.edu.cn/wcq/cgi-bin/index.php"
+                        f"?term=2610&subject={code}"
+                    ),
+                }
+                for code in sorted(PENDING_SCHEDULER_SUBJECTS)
+            ],
+        },
+        "courses": [
+            {
+                "course_code": "TEST1001",
+                "course_title": "Test Course",
+                "course_desc": "Reviewed description",
+                "credit": 3,
+                "subject": "TEST",
+                "catalog_number": "1001",
+                "course_title_abbr": "Test",
+                "pg_course": False,
+                "klms_course": False,
+                "sections": [
+                    {
+                        "semester_id": "2610",
+                        "section_id": "TEST1001-L01",
+                        "course_code": "TEST1001",
+                        "section_type": "L",
+                        "name": "L01",
+                        "bundle": 1,
+                        "layer": 0,
+                        "quota": 50,
+                        "enrol": 47,
+                        "avail": 3,
+                        "wait": 2,
+                        "is_main": True,
+                        "lectures": [
+                            {
+                                "day": 1,
+                                "start_time": "0900",
+                                "end_time": "1050",
+                                "room": "Room 101",
+                                "instructor": "Dr. Test",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    path = tmp_path / "scheduler-2610.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return {
+        "id": "scheduler-test",
+        "kind": "scheduler",
+        "semester_id": "2610",
+        "resolved_path": path,
+        "sha256": operations.file_sha256(path),
+        "expected": {
+            "courses": 1,
+            "offered_courses": 1,
+            "sections": 1,
+            "lectures": 1,
+        },
+    }
+
+
+def _write_curriculum_package(tmp_path):
+    payload = {
+        "programs": [
+            {
+                "code": "AI",
+                "cohort": "2026",
+                "name_en": "Artificial Intelligence",
+                "source_url": "https://ait.hkust-gz.edu.cn/programs/undergraduate-program/",
+                "source_pdf_sha256": "a" * 64,
+                "source_retrieved_at": "2026-08-09",
+                "total_min_credits": 120,
+                "common_core_min_credits": 30,
+                "major_min_credits": 85,
+                "home_areas": ["Information Hub"],
+                "requirement_groups": [
+                    {
+                        "key": "major_required",
+                        "name_en": "Major Required Courses",
+                        "category": "major_required",
+                        "min_credits": 6,
+                        "sort_order": 1,
+                        "rule": {
+                            "rule_tree": {
+                                "type": "required",
+                                "courses": ["AIAA 2205", "AIAA4490"],
+                            }
+                        },
+                    },
+                    {
+                        "key": "major_electives",
+                        "name_en": "Major Elective Courses",
+                        "category": "major_elective",
+                        "min_courses": 1,
+                        "sort_order": 2,
+                        "rule": {
+                            "rule_tree": {
+                                "type": "choose",
+                                "courses": ["AIAA4001"],
+                            }
+                        },
+                    },
+                ],
+            }
+        ]
+    }
+    path = tmp_path / "curriculum-2026.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return {
+        "id": "curriculum-test",
+        "kind": "curriculum",
+        "resolved_path": path,
+        "sha256": operations.file_sha256(path),
+        "expected": {
+            "program_definitions": 1,
+            "program_cohorts": 1,
+            "requirement_groups": 2,
+            "unique_course_codes": 3,
+        },
+    }
+
+
+def _apply_args(operation, package_id, approved_id):
+    args = _args(
+        "--mode",
+        "apply",
+        "--approved-dry-run-id",
+        approved_id,
+    )
+    args.operation = operation
+    args.package_id = package_id
+    return args
+
+
+def _write_approved_report(request_id, result):
+    serialized = operations._json_value(result)
+    operations._write_report(
+        {
+            "request_id": request_id,
+            "result": serialized,
+            "result_sha256": operations._sha256_json(serialized),
+        }
     )
 
 
@@ -487,6 +650,204 @@ def test_data_apply_replans_under_lock_and_matches_approved_result(monkeypatch, 
     )
     with pytest.raises(operations.OperationBlocked, match="current data plan"):
         operations._validate_current_data_plan(args, package)
+
+
+def test_scheduler_apply_retry_requires_exact_postconditions(
+    app, monkeypatch, tmp_path
+):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_scheduler_package(tmp_path)
+
+    dry_args = _args()
+    dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-initial", dry)
+    first = operations._run(
+        _apply_args("scheduler-import", package["id"], "scheduler-initial"),
+        package,
+    )
+
+    post_apply_dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-after", post_apply_dry)
+    retry = operations._run(
+        _apply_args("scheduler-import", package["id"], "scheduler-after"),
+        package,
+    )
+
+    assert operations._result_status(first) == "applied"
+    assert retry["status"] == "already-applied"
+    assert retry["postcondition"]["matches"] is True
+    with app.app_context():
+        assert CourseSection.query.one().quota == 50
+        CourseSection.query.one().quota = 51
+        db.session.commit()
+
+    with pytest.raises(operations.OperationBlocked, match="postconditions do not match"):
+        operations._run(
+            _apply_args("scheduler-import", package["id"], "scheduler-after"),
+            package,
+        )
+
+
+def test_scheduler_retry_rejects_course_field_drift(app, monkeypatch, tmp_path):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_scheduler_package(tmp_path)
+    dry_args = _args()
+    dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-course-drift", dry)
+    apply_args = _apply_args(
+        "scheduler-import", package["id"], "scheduler-course-drift"
+    )
+    operations._run(apply_args, package)
+
+    with app.app_context():
+        Course.query.filter_by(normalized_code="TEST1001").one().name = "Corrupt title"
+        db.session.commit()
+
+    with pytest.raises(operations.OperationBlocked, match="postconditions do not match"):
+        operations._run(apply_args, package)
+
+
+def test_scheduler_retry_rejects_repointed_catalog_version(
+    app, monkeypatch, tmp_path
+):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_scheduler_package(tmp_path)
+    dry_args = _args()
+    dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-catalog-drift", dry)
+    apply_args = _apply_args(
+        "scheduler-import", package["id"], "scheduler-catalog-drift"
+    )
+    operations._run(apply_args, package)
+
+    with app.app_context():
+        offering = CourseOffering.query.one()
+        wrong_version = CourseCatalogVersion(
+            course_id=offering.course_id,
+            source="scheduler_offerings",
+            source_version="9999",
+            title="Wrong catalog version",
+            credits=3,
+        )
+        db.session.add(wrong_version)
+        db.session.flush()
+        offering.catalog_version_id = wrong_version.id
+        db.session.commit()
+
+    with pytest.raises(operations.OperationBlocked, match="postconditions do not match"):
+        operations._run(apply_args, package)
+
+
+@pytest.mark.parametrize("ledger_status", ["applied", "running"])
+def test_scheduler_ledger_without_data_never_reports_success(
+    app, monkeypatch, tmp_path, ledger_status
+):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_scheduler_package(tmp_path)
+    dry_args = _args()
+    dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-ledger-only", dry)
+
+    with app.app_context():
+        db.session.execute(
+            operations.text(
+                """
+                CREATE TABLE scheduler_offering_import_runs (
+                    import_hash VARCHAR(64) PRIMARY KEY,
+                    semester_id VARCHAR(16) NOT NULL,
+                    mode VARCHAR(16) NOT NULL,
+                    status VARCHAR(16) NOT NULL,
+                    summary TEXT
+                )
+                """
+            )
+        )
+        db.session.execute(
+            operations.text(
+                """
+                INSERT INTO scheduler_offering_import_runs
+                    (import_hash, semester_id, mode, status, summary)
+                VALUES (:import_hash, '2610', 'apply', :status, '')
+                """
+            ),
+            {"import_hash": package["sha256"], "status": ledger_status},
+        )
+        db.session.commit()
+
+    with pytest.raises(operations.OperationBlocked, match="ledger exists"):
+        operations._run(
+            _apply_args(
+                "scheduler-import", package["id"], "scheduler-ledger-only"
+            ),
+            package,
+        )
+
+
+def test_scheduler_already_applied_path_rechecks_package_hash(
+    app, monkeypatch, tmp_path
+):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_scheduler_package(tmp_path)
+    dry_args = _args()
+    dry = operations._run(dry_args, package)
+    _write_approved_report("scheduler-hash", dry)
+    operations._run(
+        _apply_args("scheduler-import", package["id"], "scheduler-hash"), package
+    )
+
+    raw = json.loads(package["resolved_path"].read_text(encoding="utf-8"))
+    raw["provenance"]["retrieved_at"] = "2026-08-10T12:00:00Z"
+    package["resolved_path"].write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(operations.OperationBlocked, match="SHA-256 mismatch"):
+        operations._run(
+            _apply_args("scheduler-import", package["id"], "scheduler-hash"),
+            package,
+        )
+
+
+def test_curriculum_apply_retry_requires_exact_normalized_postconditions(
+    app, monkeypatch, tmp_path
+):
+    monkeypatch.setenv(operations.REPORT_DIR_ENV, str(tmp_path / "reports"))
+    monkeypatch.setattr(operations, "create_import_app", lambda: app)
+    package = _write_curriculum_package(tmp_path)
+    dry_args = _args()
+    dry_args.operation = "curriculum-sync"
+    dry_args.package_id = package["id"]
+    dry = operations._run(dry_args, package)
+    _write_approved_report("curriculum-initial", dry)
+    first = operations._run(
+        _apply_args("curriculum-sync", package["id"], "curriculum-initial"),
+        package,
+    )
+
+    post_apply_dry = operations._run(dry_args, package)
+    _write_approved_report("curriculum-after", post_apply_dry)
+    retry = operations._run(
+        _apply_args("curriculum-sync", package["id"], "curriculum-after"),
+        package,
+    )
+
+    assert operations._result_status(first) == "applied"
+    assert retry["status"] == "already-applied"
+    with app.app_context():
+        group = CurriculumRequirementGroup.query.filter_by(
+            key="major_required"
+        ).one()
+        assert group.rule["rule_tree"]["courses"][0] == "AIAA2205"
+        group.rule = {"rule_tree": {"type": "required", "courses": []}}
+        db.session.commit()
+
+    with pytest.raises(operations.OperationBlocked, match="current data state"):
+        operations._run(
+            _apply_args("curriculum-sync", package["id"], "curriculum-after"),
+            package,
+        )
 
 
 def test_database_upgrade_uses_fixed_argv_without_shell(monkeypatch):


### PR DESCRIPTION
## Summary
- make exact scheduler/curriculum package retries succeed only after complete database postcondition verification
- bind apply to the dry-run pre-state while holding the PostgreSQL advisory lock
- re-hash packages under that lock and reject stale applied/running scheduler ledgers or unverified importer skips
- verify all scheduler importer-owned Course fields, offerings and semantic catalog links, catalog versions, domain/legacy sections and meetings, plus archived-row hygiene
- share curriculum normalization with its synchronizer and verify exact program/group projections
- require a complete post-apply verification before reporting success

## Validation
- full backend suite: 523 passed, 6 skipped
- relevant operations/import suite: 86 passed
- independent review found and then verified closure of Course/catalog-link false-success paths
- py_compile and git diff --check pass

## Deployment relevance
This is the backend half of the reusable campus academic-operation pipeline and must merge before the final offline campus artifact is built.