### PR TITLE
ops: support protected root-owned dev parent

### DIFF
--- a/tests/test_reconcile_dev_migration_checkout.py
+++ b/tests/test_reconcile_dev_migration_checkout.py
@@ -525,3 +525,40 @@ def test_helper_lock_rejects_symlink_and_contended_regular_file(tmp_path, monkey
     finally:
         fcntl.flock(first_descriptor, fcntl.LOCK_UN)
         os.close(first_descriptor)
+
+
+def test_fixed_parent_accepts_root_or_current_user_but_rejects_writable_owner(
+    tmp_path, monkeypatch
+):
+    parent = tmp_path / "data"
+    parent.mkdir(mode=0o755)
+    descriptor = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    real_fstat = reconciliation.os.fstat
+    real_details = real_fstat(descriptor)
+
+    class Details:
+        st_mode = real_details.st_mode
+        st_dev = real_details.st_dev
+        st_ino = real_details.st_ino
+        st_uid = 0
+        st_gid = os.getegid()
+
+    try:
+        monkeypatch.setattr(reconciliation.os, "fstat", lambda _descriptor: Details())
+        assert reconciliation._validate_fixed_parent_descriptor(
+            descriptor, str(parent)
+        ) == (real_details.st_dev, real_details.st_ino)
+
+        Details.st_uid = os.geteuid()
+        reconciliation._validate_fixed_parent_descriptor(descriptor, str(parent))
+
+        Details.st_uid = max(os.geteuid(), 1) + 1000
+        with pytest.raises(reconciliation.ReconciliationBlocked, match="unsafe parent"):
+            reconciliation._validate_fixed_parent_descriptor(descriptor, str(parent))
+
+        Details.st_uid = 0
+        Details.st_mode = real_details.st_mode | 0o020
+        with pytest.raises(reconciliation.ReconciliationBlocked, match="unsafe parent"):
+            reconciliation._validate_fixed_parent_descriptor(descriptor, str(parent))
+    finally:
+        os.close(descriptor)

--- a/tools/reconcile_dev_migration_checkout.py
+++ b/tools/reconcile_dev_migration_checkout.py
@@ -74,10 +74,15 @@ def _validate_fixed_parent_descriptor(descriptor: int, label: str) -> tuple[int,
     details = os.fstat(descriptor)
     if (
         not stat.S_ISDIR(details.st_mode)
-        or details.st_uid != os.geteuid()
+        or details.st_uid not in {0, os.geteuid()}
         or details.st_mode & 0o022
     ):
-        raise ReconciliationBlocked(f"unsafe parent directory: {label}")
+        raise ReconciliationBlocked(
+            "unsafe parent directory: "
+            f"{label} (owner_uid={details.st_uid}, effective_uid={os.geteuid()}, "
+            f"group_gid={details.st_gid}, effective_gid={os.getegid()}, "
+            f"mode={stat.S_IMODE(details.st_mode):04o})"
+        )
     return details.st_dev, details.st_ino
 
 


### PR DESCRIPTION
## Summary
- allow the fixed `/data/dev_unikorn` parent to be owned by root or the deploy account
- continue rejecting symlinks and group/world-writable parents
- include non-secret UID/GID/mode diagnostics on fail-closed validation

The first audit run stopped before reading migrations because the fixed parent is not deploy-user-owned. No server files were moved or changed.

## Validation
- 39 focused tests passed
- Python compilation and diff checks passed
- independent review pending exact head `ab46731d08c40cf3fa158565556427ea53165386`