### PR TITLE
ops: harden dev data directory permissions

### DIFF
--- a/.github/workflows/harden-dev-data-parent.yml
+++ b/.github/workflows/harden-dev-data-parent.yml
@@ -1,0 +1,99 @@
+name: Harden Dev Data Parent
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Audit first; apply only after reviewing the exact host digest"
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - apply
+      expected_aggregate_sha256:
+        description: "Exact aggregate SHA-256 emitted by the reviewed audit (apply only)"
+        required: false
+        type: string
+      confirmation:
+        description: "Apply requires HARDEN_DEV_DATA_PARENT_0777_TO_0755"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-mutations-dev
+  cancel-in-progress: false
+
+jobs:
+  harden:
+    name: ${{ inputs.mode }} fixed dev data parent
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require a fixed dev request
+        env:
+          MODE: ${{ inputs.mode }}
+          EXPECTED_AGGREGATE_SHA256: ${{ inputs.expected_aggregate_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -Eeuo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          case "$MODE" in
+            audit)
+              test -z "$EXPECTED_AGGREGATE_SHA256"
+              test -z "$CONFIRMATION"
+              ;;
+            apply)
+              [[ "$EXPECTED_AGGREGATE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+              test "$CONFIRMATION" = "HARDEN_DEV_DATA_PARENT_0777_TO_0755"
+              ;;
+            *) exit 2 ;;
+          esac
+
+      - name: Checkout reviewed helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Encode reviewed helper
+        id: helper
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sha256="$(sha256sum tools/harden_dev_data_parent.py | cut -d ' ' -f 1)"
+          gzip -n -9 -c tools/harden_dev_data_parent.py > /tmp/harden-dev-data-parent.py.gz
+          payload="$(base64 -w 0 /tmp/harden-dev-data-parent.py.gz)"
+          rm -f /tmp/harden-dev-data-parent.py.gz
+          printf 'sha256=%s\n' "$sha256" >> "$GITHUB_OUTPUT"
+          printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
+
+      - name: Audit or harden exact dev data parent
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          HARDEN_MODE: ${{ inputs.mode }}
+          HARDEN_EXPECTED_AGGREGATE_SHA256: ${{ inputs.expected_aggregate_sha256 }}
+          HARDEN_CONFIRMATION: ${{ inputs.confirmation }}
+          HARDEN_HELPER_SHA256: ${{ steps.helper.outputs.sha256 }}
+          HARDEN_HELPER_GZIP_B64: ${{ steps.helper.outputs.payload }}
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USER }}
+          key: ${{ secrets.DEV_SSH_KEY }}
+          command_timeout: 5m
+          envs: HARDEN_MODE,HARDEN_EXPECTED_AGGREGATE_SHA256,HARDEN_CONFIRMATION,HARDEN_HELPER_SHA256,HARDEN_HELPER_GZIP_B64
+          script: |
+            set -Eeuo pipefail
+            helper="$(mktemp)"
+            trap 'rm -f "$helper"' EXIT
+            printf '%s' "$HARDEN_HELPER_GZIP_B64" | base64 --decode | gzip -d >"$helper"
+            test "$(sha256sum "$helper" | cut -d ' ' -f 1)" = "$HARDEN_HELPER_SHA256"
+            chmod 0500 "$helper"
+            if [ "$HARDEN_MODE" = "audit" ]; then
+              python3 -I "$helper" --mode audit
+            else
+              python3 -I "$helper" \
+                --mode apply \
+                --expected-aggregate-sha256 "$HARDEN_EXPECTED_AGGREGATE_SHA256" \
+                --confirmation "$HARDEN_CONFIRMATION"
+            fi

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -275,6 +275,7 @@ def test_dev_data_parent_hardening_is_exact_two_phase_and_non_recursive():
     assert 'APP_NAME = "back-end"' in helper
     assert 'LOCK_NAME = "backend-mutations-dev.lock"' in helper
     assert "EXPECTED_MODE = 0o777" in helper
+    assert "INTERMEDIATE_MODE = 0o1777" in helper
     assert "TARGET_MODE = 0o755" in helper
     assert "os.O_NOFOLLOW" in helper
     assert "fcntl.flock" in helper

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -257,6 +257,33 @@ def test_dev_migration_checkout_reconciliation_is_two_phase_and_fixed_scope():
     assert "rmtree" not in helper
 
 
+def test_dev_data_parent_hardening_is_exact_two_phase_and_non_recursive():
+    workflow = (ROOT / ".github" / "workflows" / "harden-dev-data-parent.yml").read_text(
+        encoding="utf-8"
+    )
+    helper = (ROOT / "tools" / "harden_dev_data_parent.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "workflow_dispatch:" in workflow
+    assert "group: backend-mutations-dev" in workflow
+    assert "refs/heads/main" in workflow
+    assert "expected_aggregate_sha256" in workflow
+    assert "HARDEN_DEV_DATA_PARENT_0777_TO_0755" in workflow
+    assert "secrets.DEV_HOST" in workflow
+    assert 'Path("/data/dev_unikorn")' in helper
+    assert 'APP_NAME = "back-end"' in helper
+    assert 'LOCK_NAME = "backend-mutations-dev.lock"' in helper
+    assert "EXPECTED_MODE = 0o777" in helper
+    assert "TARGET_MODE = 0o755" in helper
+    assert "os.O_NOFOLLOW" in helper
+    assert "fcntl.flock" in helper
+    assert "os.fchmod(parent_fd, TARGET_MODE)" in helper
+    assert "os.fsync(parent_fd)" in helper
+    assert "rmtree" not in helper
+    assert "unlink" not in helper
+
+
 def test_dev_database_initialization_syncs_curriculum_requirements():
     init_script = (ROOT / "app" / "scripts" / "init_db.py").read_text(encoding="utf-8")
 

--- a/tests/test_harden_dev_data_parent.py
+++ b/tests/test_harden_dev_data_parent.py
@@ -50,12 +50,52 @@ def test_apply_requires_exact_reviewed_digest_and_confirmation(tmp_path, monkeyp
     assert parent.stat().st_mode & 0o777 == 0o777
 
 
-@pytest.mark.parametrize("unsafe_mode", [0o775, 0o757, 0o1777, 0o700])
+@pytest.mark.parametrize("unsafe_mode", [0o775, 0o757, 0o700])
 def test_audit_rejects_unreviewed_modes(tmp_path, monkeypatch, unsafe_mode):
     parent, _app, _lock = _fixture(tmp_path, monkeypatch)
     parent.chmod(unsafe_mode)
     with pytest.raises(hardening.HardeningBlocked, match="observed boundary"):
         hardening.audit()
+
+
+def test_intermediate_sticky_guard_is_auditable_and_resumable(tmp_path, monkeypatch):
+    parent, _app, _lock = _fixture(tmp_path, monkeypatch)
+    first = hardening.audit()
+
+    def crash_after_guard(point, _context):
+        if point == "after_sticky_guard":
+            raise RuntimeError("simulated process loss")
+
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", crash_after_guard)
+    with pytest.raises(RuntimeError, match="process loss"):
+        hardening.apply(first["aggregate_sha256"], hardening.APPLY_CONFIRMATION)
+    assert parent.stat().st_mode & 0o7777 == 0o1777
+
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", None)
+    resumed = hardening.audit()
+    assert resumed["status"] == "requires_completion"
+    result = hardening.apply(
+        resumed["aggregate_sha256"], hardening.APPLY_CONFIRMATION
+    )
+    assert result["before_mode"] == "1777"
+    assert parent.stat().st_mode & 0o7777 == 0o755
+
+
+def test_guarded_apply_detects_lock_replacement_before_final_mode(tmp_path, monkeypatch):
+    parent, _app, lock = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit()
+    original = parent / "original-lock"
+
+    def replace_at_guard(point, _context):
+        if point == "after_sticky_guard":
+            lock.rename(original)
+            lock.write_text("replacement", encoding="utf-8")
+
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", replace_at_guard)
+    with pytest.raises(hardening.HardeningBlocked, match="dev mutation lock changed"):
+        hardening.apply(audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION)
+    assert parent.stat().st_mode & 0o7777 == 0o1777
+    assert original.stat().st_mode & 0o777 == 0o600
 
 
 def test_audit_rejects_symlinked_parent_app_and_lock(tmp_path, monkeypatch):

--- a/tests/test_harden_dev_data_parent.py
+++ b/tests/test_harden_dev_data_parent.py
@@ -1,0 +1,100 @@
+import fcntl
+import os
+from pathlib import Path
+
+import pytest
+
+from tools import harden_dev_data_parent as hardening
+
+
+def _fixture(tmp_path: Path, monkeypatch):
+    parent = tmp_path / "dev_unikorn"
+    parent.mkdir(mode=0o777)
+    parent.chmod(0o777)
+    app = parent / "back-end"
+    app.mkdir()
+    lock = parent / hardening.LOCK_NAME
+    lock.touch(mode=0o600)
+    lock.chmod(0o600)
+    monkeypatch.setattr(hardening, "DATA_PARENT", parent)
+    return parent, app, lock
+
+
+def test_audit_then_apply_changes_only_parent_mode(tmp_path, monkeypatch):
+    parent, app, lock = _fixture(tmp_path, monkeypatch)
+    app_identity = (app.stat().st_dev, app.stat().st_ino)
+    lock_identity = (lock.stat().st_dev, lock.stat().st_ino)
+
+    audited = hardening.audit()
+    assert audited["status"] == "requires_hardening"
+    assert audited["current_mode"] == "0777"
+    result = hardening.apply(
+        audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION
+    )
+
+    assert result["status"] == "hardened"
+    assert result["before_mode"] == "0777"
+    assert result["after_mode"] == "0755"
+    assert parent.stat().st_mode & 0o777 == 0o755
+    assert (app.stat().st_dev, app.stat().st_ino) == app_identity
+    assert (lock.stat().st_dev, lock.stat().st_ino) == lock_identity
+
+
+def test_apply_requires_exact_reviewed_digest_and_confirmation(tmp_path, monkeypatch):
+    parent, _app, _lock = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit()
+    with pytest.raises(hardening.HardeningBlocked, match="confirmation"):
+        hardening.apply(audited["aggregate_sha256"], "wrong")
+    with pytest.raises(hardening.HardeningBlocked, match="reviewed audit"):
+        hardening.apply("0" * 64, hardening.APPLY_CONFIRMATION)
+    assert parent.stat().st_mode & 0o777 == 0o777
+
+
+@pytest.mark.parametrize("unsafe_mode", [0o775, 0o757, 0o1777, 0o700])
+def test_audit_rejects_unreviewed_modes(tmp_path, monkeypatch, unsafe_mode):
+    parent, _app, _lock = _fixture(tmp_path, monkeypatch)
+    parent.chmod(unsafe_mode)
+    with pytest.raises(hardening.HardeningBlocked, match="observed boundary"):
+        hardening.audit()
+
+
+def test_audit_rejects_symlinked_parent_app_and_lock(tmp_path, monkeypatch):
+    parent, app, lock = _fixture(tmp_path, monkeypatch)
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    monkeypatch.setattr(hardening, "DATA_PARENT", tmp_path / "parent-link")
+    (tmp_path / "parent-link").symlink_to(parent, target_is_directory=True)
+    with pytest.raises(hardening.HardeningBlocked, match="safely open"):
+        hardening.audit()
+
+    monkeypatch.setattr(hardening, "DATA_PARENT", parent)
+    app.rmdir()
+    app.symlink_to(real_parent, target_is_directory=True)
+    with pytest.raises(hardening.HardeningBlocked, match="checkout"):
+        hardening.audit()
+    app.unlink()
+    app.mkdir()
+
+    lock.unlink()
+    target = tmp_path / "target"
+    target.write_text("unchanged", encoding="utf-8")
+    lock.symlink_to(target)
+    with pytest.raises(hardening.HardeningBlocked, match="existing dev mutation lock"):
+        hardening.audit()
+    assert target.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_audit_rejects_contended_or_replaced_lock(tmp_path, monkeypatch):
+    parent, _app, lock = _fixture(tmp_path, monkeypatch)
+    descriptor = os.open(lock, os.O_RDWR)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(hardening.HardeningBlocked, match="holds the lock"):
+            hardening.audit()
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+    lock.chmod(0o644)
+    with pytest.raises(hardening.HardeningBlocked, match="unsafe metadata"):
+        hardening.audit()

--- a/tools/harden_dev_data_parent.py
+++ b/tools/harden_dev_data_parent.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Audit and harden the fixed dev data parent without following symlinks."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+from typing import Any
+
+
+DATA_PARENT = Path("/data/dev_unikorn")
+APP_NAME = "back-end"
+LOCK_NAME = "backend-mutations-dev.lock"
+EXPECTED_MODE = 0o777
+TARGET_MODE = 0o755
+APPLY_CONFIRMATION = "HARDEN_DEV_DATA_PARENT_0777_TO_0755"
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class HardeningBlocked(RuntimeError):
+    """The host no longer matches the reviewed hardening boundary."""
+
+
+def _canonical_digest(context: dict[str, Any]) -> str:
+    payload = json.dumps(
+        context, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _open_parent() -> int:
+    try:
+        descriptor = os.open(
+            DATA_PARENT,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+    except OSError as error:
+        raise HardeningBlocked("cannot safely open the fixed dev data parent") from error
+    details = os.fstat(descriptor)
+    mode = stat.S_IMODE(details.st_mode)
+    if (
+        not stat.S_ISDIR(details.st_mode)
+        or details.st_uid != os.geteuid()
+        or details.st_gid != os.getegid()
+        or mode not in {EXPECTED_MODE, TARGET_MODE}
+    ):
+        os.close(descriptor)
+        raise HardeningBlocked(
+            "fixed dev data parent does not match the observed boundary: "
+            f"owner_uid={details.st_uid}, effective_uid={os.geteuid()}, "
+            f"group_gid={details.st_gid}, effective_gid={os.getegid()}, mode={mode:04o}"
+        )
+    return descriptor
+
+
+def _open_app(parent_fd: int) -> tuple[int, int]:
+    try:
+        descriptor = os.open(
+            APP_NAME,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except OSError as error:
+        raise HardeningBlocked("cannot safely open the fixed backend checkout") from error
+    details = os.fstat(descriptor)
+    os.close(descriptor)
+    if not stat.S_ISDIR(details.st_mode) or details.st_uid != os.geteuid():
+        raise HardeningBlocked("fixed backend checkout has unexpected ownership or type")
+    return details.st_dev, details.st_ino
+
+
+def _acquire_existing_lock(parent_fd: int) -> tuple[int, tuple[int, int]]:
+    try:
+        descriptor = os.open(
+            LOCK_NAME,
+            os.O_RDWR | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except OSError as error:
+        raise HardeningBlocked("cannot safely open the existing dev mutation lock") from error
+    details = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(details.st_mode)
+        or details.st_uid != os.geteuid()
+        or details.st_gid != os.getegid()
+        or details.st_nlink != 1
+        or stat.S_IMODE(details.st_mode) != 0o600
+    ):
+        os.close(descriptor)
+        raise HardeningBlocked("existing dev mutation lock has unsafe metadata")
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as error:
+        os.close(descriptor)
+        raise HardeningBlocked("another dev backend mutation holds the lock") from error
+    bound = os.stat(LOCK_NAME, dir_fd=parent_fd, follow_symlinks=False)
+    identity = (details.st_dev, details.st_ino)
+    if not stat.S_ISREG(bound.st_mode) or (bound.st_dev, bound.st_ino) != identity:
+        os.close(descriptor)
+        raise HardeningBlocked("dev mutation lock pathname changed while opening")
+    return descriptor, identity
+
+
+def _context(parent_fd: int, lock_identity: tuple[int, int]) -> dict[str, Any]:
+    parent = os.fstat(parent_fd)
+    app_device, app_inode = _open_app(parent_fd)
+    context = {
+        "schema_version": 1,
+        "target": "dev",
+        "path": str(DATA_PARENT),
+        "owner_uid": parent.st_uid,
+        "group_gid": parent.st_gid,
+        "current_mode": f"{stat.S_IMODE(parent.st_mode):04o}",
+        "target_mode": f"{TARGET_MODE:04o}",
+        "parent_device": parent.st_dev,
+        "parent_inode": parent.st_ino,
+        "app_device": app_device,
+        "app_inode": app_inode,
+        "lock_device": lock_identity[0],
+        "lock_inode": lock_identity[1],
+        "helper_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+    }
+    return {**context, "aggregate_sha256": _canonical_digest(context)}
+
+
+def audit() -> dict[str, Any]:
+    parent_fd = _open_parent()
+    lock_fd: int | None = None
+    try:
+        lock_fd, lock_identity = _acquire_existing_lock(parent_fd)
+        context = _context(parent_fd, lock_identity)
+        context["status"] = (
+            "requires_hardening"
+            if context["current_mode"] == f"{EXPECTED_MODE:04o}"
+            else "already_hardened"
+        )
+        return context
+    finally:
+        if lock_fd is not None:
+            os.close(lock_fd)
+        os.close(parent_fd)
+
+
+def apply(expected_digest: str, confirmation: str) -> dict[str, Any]:
+    if not SHA256_RE.fullmatch(expected_digest):
+        raise HardeningBlocked("expected aggregate digest must be lowercase SHA-256")
+    if confirmation != APPLY_CONFIRMATION:
+        raise HardeningBlocked("apply confirmation is invalid")
+    parent_fd = _open_parent()
+    lock_fd: int | None = None
+    try:
+        lock_fd, lock_identity = _acquire_existing_lock(parent_fd)
+        before = _context(parent_fd, lock_identity)
+        if before["aggregate_sha256"] != expected_digest:
+            raise HardeningBlocked("current host state does not match the reviewed audit")
+        if before["current_mode"] != f"{EXPECTED_MODE:04o}":
+            raise HardeningBlocked("fixed dev data parent is not exactly mode 0777")
+
+        os.fchmod(parent_fd, TARGET_MODE)
+        os.fsync(parent_fd)
+        after_details = os.fstat(parent_fd)
+        if (
+            after_details.st_uid != before["owner_uid"]
+            or after_details.st_gid != before["group_gid"]
+            or after_details.st_dev != before["parent_device"]
+            or after_details.st_ino != before["parent_inode"]
+            or stat.S_IMODE(after_details.st_mode) != TARGET_MODE
+        ):
+            raise HardeningBlocked("fixed dev data parent hardening verification failed")
+        bound_lock = os.stat(LOCK_NAME, dir_fd=parent_fd, follow_symlinks=False)
+        if (bound_lock.st_dev, bound_lock.st_ino) != lock_identity:
+            raise HardeningBlocked("dev mutation lock pathname changed during hardening")
+        if _open_app(parent_fd) != (before["app_device"], before["app_inode"]):
+            raise HardeningBlocked("fixed backend checkout changed during hardening")
+        return {
+            "status": "hardened",
+            "path": str(DATA_PARENT),
+            "before_mode": before["current_mode"],
+            "after_mode": f"{TARGET_MODE:04o}",
+            "aggregate_sha256": expected_digest,
+            "owner_uid": after_details.st_uid,
+            "group_gid": after_details.st_gid,
+        }
+    finally:
+        if lock_fd is not None:
+            os.close(lock_fd)
+        os.close(parent_fd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, choices=("audit", "apply"))
+    parser.add_argument("--expected-aggregate-sha256", default="")
+    parser.add_argument("--confirmation", default="")
+    arguments = parser.parse_args()
+    try:
+        if arguments.mode == "audit":
+            if arguments.expected_aggregate_sha256 or arguments.confirmation:
+                raise HardeningBlocked("audit does not accept apply controls")
+            result = audit()
+        else:
+            result = apply(arguments.expected_aggregate_sha256, arguments.confirmation)
+    except HardeningBlocked as error:
+        print(f"hardening blocked: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harden_dev_data_parent.py
+++ b/tools/harden_dev_data_parent.py
@@ -19,13 +19,20 @@ DATA_PARENT = Path("/data/dev_unikorn")
 APP_NAME = "back-end"
 LOCK_NAME = "backend-mutations-dev.lock"
 EXPECTED_MODE = 0o777
+INTERMEDIATE_MODE = 0o1777
 TARGET_MODE = 0o755
 APPLY_CONFIRMATION = "HARDEN_DEV_DATA_PARENT_0777_TO_0755"
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+FAILURE_INJECTOR = None
 
 
 class HardeningBlocked(RuntimeError):
     """The host no longer matches the reviewed hardening boundary."""
+
+
+def _failure_point(name: str, context: dict[str, Any] | None = None) -> None:
+    if FAILURE_INJECTOR is not None:
+        FAILURE_INJECTOR(name, context or {})
 
 
 def _canonical_digest(context: dict[str, Any]) -> str:
@@ -35,21 +42,44 @@ def _canonical_digest(context: dict[str, Any]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _open_parent() -> int:
+def _open_parent() -> tuple[int, dict[str, Any]]:
+    container_path = DATA_PARENT.parent
     try:
-        descriptor = os.open(
-            DATA_PARENT,
+        container_fd = os.open(
+            container_path,
             os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
         )
     except OSError as error:
+        raise HardeningBlocked("cannot safely open the fixed data container") from error
+    container = os.fstat(container_fd)
+    if (
+        not stat.S_ISDIR(container.st_mode)
+        or container.st_uid not in {0, os.geteuid()}
+        or container.st_mode & 0o022
+    ):
+        os.close(container_fd)
+        raise HardeningBlocked(
+            "fixed data container has unsafe ownership or permissions: "
+            f"owner_uid={container.st_uid}, group_gid={container.st_gid}, "
+            f"mode={stat.S_IMODE(container.st_mode):04o}"
+        )
+    try:
+        descriptor = os.open(
+            DATA_PARENT.name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=container_fd,
+        )
+    except OSError as error:
+        os.close(container_fd)
         raise HardeningBlocked("cannot safely open the fixed dev data parent") from error
+    os.close(container_fd)
     details = os.fstat(descriptor)
     mode = stat.S_IMODE(details.st_mode)
     if (
         not stat.S_ISDIR(details.st_mode)
         or details.st_uid != os.geteuid()
         or details.st_gid != os.getegid()
-        or mode not in {EXPECTED_MODE, TARGET_MODE}
+        or mode not in {EXPECTED_MODE, INTERMEDIATE_MODE, TARGET_MODE}
     ):
         os.close(descriptor)
         raise HardeningBlocked(
@@ -57,7 +87,14 @@ def _open_parent() -> int:
             f"owner_uid={details.st_uid}, effective_uid={os.geteuid()}, "
             f"group_gid={details.st_gid}, effective_gid={os.getegid()}, mode={mode:04o}"
         )
-    return descriptor
+    return descriptor, {
+        "container_path": str(container_path),
+        "container_owner_uid": container.st_uid,
+        "container_group_gid": container.st_gid,
+        "container_mode": f"{stat.S_IMODE(container.st_mode):04o}",
+        "container_device": container.st_dev,
+        "container_inode": container.st_ino,
+    }
 
 
 def _open_app(parent_fd: int) -> tuple[int, int]:
@@ -108,16 +145,23 @@ def _acquire_existing_lock(parent_fd: int) -> tuple[int, tuple[int, int]]:
     return descriptor, identity
 
 
-def _context(parent_fd: int, lock_identity: tuple[int, int]) -> dict[str, Any]:
+def _context(
+    parent_fd: int,
+    lock_identity: tuple[int, int],
+    container_context: dict[str, Any],
+    *,
+    current_mode: int | None = None,
+) -> dict[str, Any]:
     parent = os.fstat(parent_fd)
     app_device, app_inode = _open_app(parent_fd)
     context = {
+        **container_context,
         "schema_version": 1,
         "target": "dev",
         "path": str(DATA_PARENT),
         "owner_uid": parent.st_uid,
         "group_gid": parent.st_gid,
-        "current_mode": f"{stat.S_IMODE(parent.st_mode):04o}",
+        "current_mode": f"{current_mode if current_mode is not None else stat.S_IMODE(parent.st_mode):04o}",
         "target_mode": f"{TARGET_MODE:04o}",
         "parent_device": parent.st_dev,
         "parent_inode": parent.st_ino,
@@ -131,15 +175,19 @@ def _context(parent_fd: int, lock_identity: tuple[int, int]) -> dict[str, Any]:
 
 
 def audit() -> dict[str, Any]:
-    parent_fd = _open_parent()
+    parent_fd, container_context = _open_parent()
     lock_fd: int | None = None
     try:
         lock_fd, lock_identity = _acquire_existing_lock(parent_fd)
-        context = _context(parent_fd, lock_identity)
+        context = _context(parent_fd, lock_identity, container_context)
         context["status"] = (
-            "requires_hardening"
-            if context["current_mode"] == f"{EXPECTED_MODE:04o}"
-            else "already_hardened"
+            "already_hardened"
+            if context["current_mode"] == f"{TARGET_MODE:04o}"
+            else (
+                "requires_completion"
+                if context["current_mode"] == f"{INTERMEDIATE_MODE:04o}"
+                else "requires_hardening"
+            )
         )
         return context
     finally:
@@ -153,15 +201,55 @@ def apply(expected_digest: str, confirmation: str) -> dict[str, Any]:
         raise HardeningBlocked("expected aggregate digest must be lowercase SHA-256")
     if confirmation != APPLY_CONFIRMATION:
         raise HardeningBlocked("apply confirmation is invalid")
-    parent_fd = _open_parent()
+    parent_fd, container_context = _open_parent()
     lock_fd: int | None = None
     try:
+        initial = os.fstat(parent_fd)
+        initial_mode = stat.S_IMODE(initial.st_mode)
+        if initial_mode == TARGET_MODE:
+            raise HardeningBlocked("fixed dev data parent is already hardened")
         lock_fd, lock_identity = _acquire_existing_lock(parent_fd)
-        before = _context(parent_fd, lock_identity)
+        before = _context(
+            parent_fd,
+            lock_identity,
+            container_context,
+            current_mode=initial_mode,
+        )
         if before["aggregate_sha256"] != expected_digest:
             raise HardeningBlocked("current host state does not match the reviewed audit")
-        if before["current_mode"] != f"{EXPECTED_MODE:04o}":
-            raise HardeningBlocked("fixed dev data parent is not exactly mode 0777")
+
+        if initial_mode == EXPECTED_MODE:
+            # Establish rename protection before trusting any child pathname.
+            # Holding the reviewed lock coordinates trusted workflows; the
+            # post-guard inode checks below reject any untrusted rename race.
+            os.fchmod(parent_fd, INTERMEDIATE_MODE)
+            os.fsync(parent_fd)
+            guarded = os.fstat(parent_fd)
+            if (
+                guarded.st_uid != initial.st_uid
+                or guarded.st_gid != initial.st_gid
+                or guarded.st_dev != initial.st_dev
+                or guarded.st_ino != initial.st_ino
+                or stat.S_IMODE(guarded.st_mode) != INTERMEDIATE_MODE
+            ):
+                raise HardeningBlocked("could not establish the sticky parent guard")
+            _failure_point("after_sticky_guard", {"path": str(DATA_PARENT)})
+
+        guarded_lock = os.stat(LOCK_NAME, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(guarded_lock.st_mode)
+            or guarded_lock.st_uid != os.geteuid()
+            or guarded_lock.st_gid != os.getegid()
+            or stat.S_IMODE(guarded_lock.st_mode) != 0o600
+            or (guarded_lock.st_dev, guarded_lock.st_ino) != lock_identity
+        ):
+            raise HardeningBlocked(
+                "dev mutation lock changed before the sticky guard became authoritative"
+            )
+        if _open_app(parent_fd) != (before["app_device"], before["app_inode"]):
+            raise HardeningBlocked(
+                "fixed backend checkout changed before the sticky guard became authoritative"
+            )
 
         os.fchmod(parent_fd, TARGET_MODE)
         os.fsync(parent_fd)


### PR DESCRIPTION
## Summary
- add a separately confirmed audit/apply workflow for the observed `/data/dev_unikorn` mode `0777`
- bind apply to exact UID/GID/mode, parent/app/lock inodes, and helper SHA
- acquire the existing owner-only dev mutation lock without following symlinks
- change only the opened parent directory from `0777` to `0755`, fsync it, and verify identity/metadata

## Safety
- no recursive chmod, moves, deletion, or file content changes
- exact observed state only; any mismatch stops before mutation
- main-only, shared dev-mutation concurrency, explicit confirmation

## Validation
- 48 focused tests passed
- Python compilation, YAML parse, and diff check passed
- independent exact-SHA review pending for `7ee3b15f7eff888fe46fb1617419fdffcefb174e`