### PR TITLE
Harden shared dev data container

### DIFF
--- a/.github/workflows/harden-dev-data-container.yml
+++ b/.github/workflows/harden-dev-data-container.yml
@@ -1,0 +1,104 @@
+name: Harden Dev Data Container
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Audit first; apply only after reviewing the exact host digest"
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - apply
+      expected_aggregate_sha256:
+        description: "Exact aggregate SHA-256 emitted by the reviewed audit (apply only)"
+        required: false
+        type: string
+      confirmation:
+        description: "Apply requires HARDEN_DEV_DATA_CONTAINER_0777_TO_1777"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-mutations-dev
+  cancel-in-progress: false
+
+jobs:
+  harden:
+    name: ${{ inputs.mode }} fixed dev data container
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Require a fixed dev request
+        env:
+          MODE: ${{ inputs.mode }}
+          EXPECTED_AGGREGATE_SHA256: ${{ inputs.expected_aggregate_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -Eeuo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          case "$MODE" in
+            audit)
+              test -z "$EXPECTED_AGGREGATE_SHA256"
+              test -z "$CONFIRMATION"
+              ;;
+            apply)
+              [[ "$EXPECTED_AGGREGATE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+              test "$CONFIRMATION" = "HARDEN_DEV_DATA_CONTAINER_0777_TO_1777"
+              ;;
+            *) exit 2 ;;
+          esac
+
+      - name: Checkout reviewed helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Encode reviewed helper
+        id: helper
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sha256="$(sha256sum tools/harden_dev_data_container.py | cut -d ' ' -f 1)"
+          gzip -n -9 -c tools/harden_dev_data_container.py > /tmp/harden-dev-data-container.py.gz
+          payload="$(base64 -w 0 /tmp/harden-dev-data-container.py.gz)"
+          rm -f /tmp/harden-dev-data-container.py.gz
+          printf 'sha256=%s\n' "$sha256" >> "$GITHUB_OUTPUT"
+          printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
+
+      - name: Audit or harden exact dev data container
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          HARDEN_MODE: ${{ inputs.mode }}
+          HARDEN_EXPECTED_AGGREGATE_SHA256: ${{ inputs.expected_aggregate_sha256 }}
+          HARDEN_CONFIRMATION: ${{ inputs.confirmation }}
+          HARDEN_HELPER_SHA256: ${{ steps.helper.outputs.sha256 }}
+          HARDEN_HELPER_GZIP_B64: ${{ steps.helper.outputs.payload }}
+          HARDEN_RELEASE_SHA: ${{ github.sha }}
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USER }}
+          key: ${{ secrets.DEV_SSH_KEY }}
+          command_timeout: 5m
+          envs: HARDEN_MODE,HARDEN_EXPECTED_AGGREGATE_SHA256,HARDEN_CONFIRMATION,HARDEN_HELPER_SHA256,HARDEN_HELPER_GZIP_B64,HARDEN_RELEASE_SHA
+          script: |
+            set -Eeuo pipefail
+            helper="$(mktemp)"
+            trap 'rm -f "$helper"' EXIT
+            printf '%s' "$HARDEN_HELPER_GZIP_B64" | base64 --decode | gzip -d >"$helper"
+            test "$(sha256sum "$helper" | cut -d ' ' -f 1)" = "$HARDEN_HELPER_SHA256"
+            chmod 0500 "$helper"
+            if [ "$HARDEN_MODE" = "audit" ]; then
+              python3 -I "$helper" \
+                --mode audit \
+                --expected-release-sha "$HARDEN_RELEASE_SHA"
+            else
+              /usr/bin/sudo -n -l /usr/bin/chmod 1777 -- /data >/dev/null
+              python3 -I "$helper" \
+                --mode apply \
+                --expected-aggregate-sha256 "$HARDEN_EXPECTED_AGGREGATE_SHA256" \
+                --confirmation "$HARDEN_CONFIRMATION" \
+                --expected-release-sha "$HARDEN_RELEASE_SHA"
+            fi

--- a/deploy/sudoers/unikorn-harden-dev-data-container.in
+++ b/deploy/sudoers/unikorn-harden-dev-data-container.in
@@ -1,0 +1,5 @@
+# Render DEV_DEPLOY_USER, validate with visudo, then install as
+# /etc/sudoers.d/unikorn-harden-dev-data-container with mode 0440.
+# Replace DEV_DEPLOY_USER with the account configured as GitHub DEV_USER.
+# The reviewed workflow invokes this exact argv and no general shell as root.
+DEV_DEPLOY_USER ALL=(root) NOPASSWD: /usr/bin/chmod 1777 -- /data

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -285,6 +285,61 @@ def test_dev_data_parent_hardening_is_exact_two_phase_and_non_recursive():
     assert "unlink" not in helper
 
 
+def test_dev_data_container_hardening_is_exact_two_phase_and_non_recursive():
+    workflow = (
+        ROOT / ".github" / "workflows" / "harden-dev-data-container.yml"
+    ).read_text(encoding="utf-8")
+    helper = (ROOT / "tools" / "harden_dev_data_container.py").read_text(
+        encoding="utf-8"
+    )
+    sudoers = (
+        ROOT / "deploy" / "sudoers" / "unikorn-harden-dev-data-container.in"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "group: backend-mutations-dev" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "refs/heads/main" in workflow
+    assert "expected_aggregate_sha256" in workflow
+    assert "HARDEN_DEV_DATA_CONTAINER_0777_TO_1777" in workflow
+    assert "secrets.DEV_HOST" in workflow
+    assert "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" in workflow
+    assert "appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2" in workflow
+    assert "/usr/bin/sudo -n -l /usr/bin/chmod 1777 -- /data" in workflow
+    assert 'ROOT_PATH = Path("/")' in helper
+    assert 'DATA_PATH = Path("/data")' in helper
+    assert 'DEV_PARENT_NAME = "dev_unikorn"' in helper
+    assert 'APP_NAME = "back-end"' in helper
+    assert 'LOCK_NAME = "backend-mutations-dev.lock"' in helper
+    assert "EXPECTED_MODE = 0o777" in helper
+    assert "TARGET_MODE = 0o1777" in helper
+    assert "os.O_NOFOLLOW" in helper
+    assert "os.O_CLOEXEC" in helper
+    assert "dir_fd=" in helper
+    assert "fcntl.LOCK_EX" in helper
+    assert "subprocess.run" in helper
+    assert '"/usr/bin/sudo"' in helper
+    assert '"/usr/bin/chmod"' in helper
+    assert "os.fsync(data_fd)" in helper
+    assert "expected_release_sha" in helper
+    assert "rmtree" not in helper
+    assert "unlink" not in helper
+    assert "os.rename" not in helper
+    assert "NOPASSWD: /usr/bin/chmod 1777 -- /data" in sudoers
+
+
+def test_dev_data_parent_accepts_only_safe_shared_root_container():
+    helper = (ROOT / "tools" / "harden_dev_data_parent.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "safe_non_writable_container" in helper
+    assert "safe_shared_container" in helper
+    assert "container.st_uid == 0" in helper
+    assert "container.st_gid == 0" in helper
+    assert "container_mode == 0o1777" in helper
+
+
 def test_dev_database_initialization_syncs_curriculum_requirements():
     init_script = (ROOT / "app" / "scripts" / "init_db.py").read_text(encoding="utf-8")
 

--- a/tests/test_harden_dev_data_container.py
+++ b/tests/test_harden_dev_data_container.py
@@ -1,0 +1,269 @@
+import fcntl
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from tools import harden_dev_data_container as hardening
+
+RELEASE_SHA = "a" * 40
+
+
+def _fixture(tmp_path: Path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir(mode=0o755)
+    root.chmod(0o755)
+    data = root / "data"
+    data.mkdir(mode=0o777)
+    data.chmod(0o777)
+    dev_parent = data / hardening.DEV_PARENT_NAME
+    dev_parent.mkdir(mode=0o777)
+    dev_parent.chmod(0o777)
+    app = dev_parent / hardening.APP_NAME
+    app.mkdir()
+    lock = dev_parent / hardening.LOCK_NAME
+    lock.touch(mode=0o600)
+    lock.chmod(0o600)
+
+    monkeypatch.setattr(hardening, "ROOT_PATH", root)
+    monkeypatch.setattr(hardening, "DATA_PATH", data)
+    monkeypatch.setattr(hardening, "ROOT_OWNER_UID", os.geteuid())
+    monkeypatch.setattr(hardening, "ROOT_GROUP_GID", os.getegid())
+
+    commands = []
+
+    def exact_chmod(command, **kwargs):
+        commands.append((command, kwargs))
+        assert command == [
+            hardening.SUDO_PATH,
+            "-n",
+            hardening.CHMOD_PATH,
+            "1777",
+            "--",
+            str(data),
+        ]
+        data.chmod(hardening.TARGET_MODE)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hardening.subprocess, "run", exact_chmod)
+    return root, data, dev_parent, app, lock, commands
+
+
+def test_audit_then_apply_invokes_only_exact_sudo_chmod(tmp_path, monkeypatch):
+    _root, data, dev_parent, app, lock, commands = _fixture(tmp_path, monkeypatch)
+    identities = {
+        "dev_parent": (dev_parent.stat().st_dev, dev_parent.stat().st_ino),
+        "app": (app.stat().st_dev, app.stat().st_ino),
+        "lock": (lock.stat().st_dev, lock.stat().st_ino),
+    }
+
+    audited = hardening.audit(RELEASE_SHA)
+    assert audited["status"] == "requires_hardening"
+    assert audited["data_mode"] == "0777"
+    assert audited["root_owner_uid"] == os.geteuid()
+    assert audited["helper_sha256"]
+
+    result = hardening.apply(
+        audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+    )
+    assert result["status"] == "hardened"
+    assert result["before_mode"] == "0777"
+    assert result["after_mode"] == "1777"
+    assert data.stat().st_mode & 0o7777 == 0o1777
+    assert len(commands) == 1
+    assert (dev_parent.stat().st_dev, dev_parent.stat().st_ino) == identities["dev_parent"]
+    assert (app.stat().st_dev, app.stat().st_ino) == identities["app"]
+    assert (lock.stat().st_dev, lock.stat().st_ino) == identities["lock"]
+
+
+def test_apply_requires_literal_confirmation_and_exact_digest(tmp_path, monkeypatch):
+    _root, data, _dev_parent, _app, _lock, commands = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit(RELEASE_SHA)
+    with pytest.raises(hardening.HardeningBlocked, match="confirmation"):
+        hardening.apply(audited["aggregate_sha256"], "wrong", RELEASE_SHA)
+    with pytest.raises(hardening.HardeningBlocked, match="reviewed audit"):
+        hardening.apply("0" * 64, hardening.APPLY_CONFIRMATION, RELEASE_SHA)
+    assert data.stat().st_mode & 0o7777 == 0o777
+    assert commands == []
+
+
+def test_already_sticky_state_is_auditable_and_apply_is_idempotent(tmp_path, monkeypatch):
+    _root, data, _dev_parent, _app, _lock, commands = _fixture(tmp_path, monkeypatch)
+    data.chmod(0o1777)
+    audited = hardening.audit(RELEASE_SHA)
+    assert audited["status"] == "already_sticky"
+    result = hardening.apply(
+        audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+    )
+    assert result["status"] == "already_sticky"
+    assert result["before_mode"] == "1777"
+    assert commands == []
+
+
+@pytest.mark.parametrize("mode", [0o775, 0o1755, 0o755])
+def test_audit_rejects_unreviewed_data_modes(tmp_path, monkeypatch, mode):
+    _root, data, _dev_parent, _app, _lock, _commands = _fixture(tmp_path, monkeypatch)
+    data.chmod(mode)
+    with pytest.raises(hardening.HardeningBlocked, match="observed boundary"):
+        hardening.audit(RELEASE_SHA)
+
+
+def test_audit_rejects_symlinked_data_child_app_and_lock(tmp_path, monkeypatch):
+    root, data, dev_parent, app, lock, _commands = _fixture(tmp_path, monkeypatch)
+    real_data = tmp_path / "real-data"
+    data.rename(real_data)
+    data.symlink_to(real_data, target_is_directory=True)
+    with pytest.raises(hardening.HardeningBlocked, match="data container"):
+        hardening.audit(RELEASE_SHA)
+
+    data.unlink()
+    real_data.rename(data)
+    real_dev_parent = tmp_path / "real-dev"
+    dev_parent.rename(real_dev_parent)
+    dev_parent.symlink_to(real_dev_parent, target_is_directory=True)
+    with pytest.raises(hardening.HardeningBlocked, match="dev data parent"):
+        hardening.audit(RELEASE_SHA)
+
+    dev_parent.unlink()
+    real_dev_parent.rename(dev_parent)
+    app.rmdir()
+    app.symlink_to(tmp_path, target_is_directory=True)
+    with pytest.raises(hardening.HardeningBlocked, match="backend checkout"):
+        hardening.audit(RELEASE_SHA)
+    app.unlink()
+    app.mkdir()
+
+    lock.unlink()
+    target = tmp_path / "target"
+    target.write_text("unchanged", encoding="utf-8")
+    lock.symlink_to(target)
+    with pytest.raises(hardening.HardeningBlocked, match="mutation lock"):
+        hardening.audit(RELEASE_SHA)
+    assert target.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_audit_uses_exclusive_lock_and_rejects_other_mutation(tmp_path, monkeypatch):
+    _root, _data, _dev_parent, _app, lock, _commands = _fixture(tmp_path, monkeypatch)
+    descriptor = os.open(lock, os.O_RDWR)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(hardening.HardeningBlocked, match="holds the lock"):
+            hardening.audit(RELEASE_SHA)
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def test_child_rename_race_fails_closed_after_sticky_protection(tmp_path, monkeypatch):
+    _root, data, dev_parent, _app, _lock, _commands = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit(RELEASE_SHA)
+    moved = data / "moved-dev"
+
+    original_run = hardening.subprocess.run
+
+    def chmod_then_rename(command, **kwargs):
+        completed = original_run(command, **kwargs)
+        dev_parent.rename(moved)
+        replacement = data / hardening.DEV_PARENT_NAME
+        replacement.mkdir(mode=0o755)
+        return completed
+
+    monkeypatch.setattr(hardening.subprocess, "run", chmod_then_rename)
+    with pytest.raises(hardening.HardeningBlocked, match="dev data parent pathname"):
+        hardening.apply(
+            audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+        )
+    assert data.stat().st_mode & 0o7777 == 0o1777
+    assert moved.is_dir()
+
+
+def test_failure_after_chmod_leaves_auditable_sticky_recovery(tmp_path, monkeypatch):
+    _root, data, _dev_parent, _app, _lock, _commands = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit(RELEASE_SHA)
+
+    def interrupt(point, _context):
+        if point == "after_sticky_guard":
+            raise RuntimeError("simulated process loss")
+
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", interrupt)
+    with pytest.raises(RuntimeError, match="process loss"):
+        hardening.apply(
+            audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+        )
+    assert data.stat().st_mode & 0o7777 == 0o1777
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", None)
+    assert hardening.audit(RELEASE_SHA)["status"] == "already_sticky"
+
+
+def test_audit_rejects_unsafe_lock_metadata(tmp_path, monkeypatch):
+    _root, _data, _dev_parent, _app, lock, _commands = _fixture(tmp_path, monkeypatch)
+    lock.chmod(0o644)
+    with pytest.raises(hardening.HardeningBlocked, match="unsafe metadata"):
+        hardening.audit(RELEASE_SHA)
+
+
+def test_audit_rejects_wrong_lock_group(tmp_path, monkeypatch):
+    _root, _data, _dev_parent, _app, lock, _commands = _fixture(tmp_path, monkeypatch)
+    real_fstat = hardening.os.fstat
+    lock_identity = (lock.stat().st_dev, lock.stat().st_ino)
+
+    class WrongGroup:
+        def __init__(self, source):
+            for name in dir(source):
+                if name.startswith("st_"):
+                    setattr(self, name, getattr(source, name))
+            self.st_gid = os.getegid() + 1
+
+    def wrong_lock_group(descriptor):
+        details = real_fstat(descriptor)
+        if (details.st_dev, details.st_ino) == lock_identity:
+            return WrongGroup(details)
+        return details
+
+    monkeypatch.setattr(hardening.os, "fstat", wrong_lock_group)
+    with pytest.raises(hardening.HardeningBlocked, match="unsafe metadata"):
+        hardening.audit(RELEASE_SHA)
+
+
+def test_release_sha_is_required_and_bound_into_digest(tmp_path, monkeypatch):
+    _fixture(tmp_path, monkeypatch)
+    with pytest.raises(hardening.HardeningBlocked, match="release SHA"):
+        hardening.audit("bad")
+    first = hardening.audit(RELEASE_SHA)
+    second = hardening.audit("b" * 40)
+    assert first["expected_release_sha"] == RELEASE_SHA
+    assert first["aggregate_sha256"] != second["aggregate_sha256"]
+
+
+def test_sudo_failure_preserves_original_mode(tmp_path, monkeypatch):
+    _root, data, _dev_parent, _app, _lock, _commands = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit(RELEASE_SHA)
+
+    def denied(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="denied")
+
+    monkeypatch.setattr(hardening.subprocess, "run", denied)
+    with pytest.raises(hardening.HardeningBlocked, match="denied"):
+        hardening.apply(
+            audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+        )
+    assert data.stat().st_mode & 0o7777 == 0o777
+
+
+def test_race_before_chmod_is_caught_after_safe_transition(tmp_path, monkeypatch):
+    _root, data, dev_parent, _app, _lock, _commands = _fixture(tmp_path, monkeypatch)
+    audited = hardening.audit(RELEASE_SHA)
+    moved = data / "moved-before"
+
+    def move_before(point, _context):
+        if point == "before_sticky_guard":
+            dev_parent.rename(moved)
+            (data / hardening.DEV_PARENT_NAME).mkdir(mode=0o755)
+
+    monkeypatch.setattr(hardening, "FAILURE_INJECTOR", move_before)
+    with pytest.raises(hardening.HardeningBlocked, match="dev data parent pathname"):
+        hardening.apply(
+            audited["aggregate_sha256"], hardening.APPLY_CONFIRMATION, RELEASE_SHA
+        )
+    assert data.stat().st_mode & 0o7777 == 0o1777

--- a/tests/test_harden_dev_data_parent.py
+++ b/tests/test_harden_dev_data_parent.py
@@ -1,6 +1,7 @@
 import fcntl
 import os
 from pathlib import Path
+import stat
 
 import pytest
 
@@ -18,6 +19,32 @@ def _fixture(tmp_path: Path, monkeypatch):
     lock.chmod(0o600)
     monkeypatch.setattr(hardening, "DATA_PARENT", parent)
     return parent, app, lock
+
+
+def test_root_owned_sticky_shared_container_is_accepted(tmp_path, monkeypatch):
+    parent, _app, _lock = _fixture(tmp_path, monkeypatch)
+    parent.parent.chmod(0o1777)
+    real_fstat = hardening.os.fstat
+
+    class RootOwnedSticky:
+        def __init__(self, source):
+            for name in dir(source):
+                if name.startswith("st_"):
+                    setattr(self, name, getattr(source, name))
+            self.st_uid = 0
+            self.st_gid = 0
+            self.st_mode = stat.S_IFDIR | 0o1777
+
+    container_identity = (parent.parent.stat().st_dev, parent.parent.stat().st_ino)
+
+    def root_owned_container(descriptor):
+        details = real_fstat(descriptor)
+        if (details.st_dev, details.st_ino) == container_identity:
+            return RootOwnedSticky(details)
+        return details
+
+    monkeypatch.setattr(hardening.os, "fstat", root_owned_container)
+    assert hardening.audit()["status"] == "requires_hardening"
 
 
 def test_audit_then_apply_changes_only_parent_mode(tmp_path, monkeypatch):

--- a/tools/harden_dev_data_container.py
+++ b/tools/harden_dev_data_container.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Audit and add sticky protection to the fixed shared ``/data`` container."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_PATH = Path("/")
+DATA_PATH = Path("/data")
+DATA_NAME = "data"
+DEV_PARENT_NAME = "dev_unikorn"
+APP_NAME = "back-end"
+LOCK_NAME = "backend-mutations-dev.lock"
+ROOT_OWNER_UID = 0
+ROOT_GROUP_GID = 0
+EXPECTED_MODE = 0o777
+TARGET_MODE = 0o1777
+APPLY_CONFIRMATION = "HARDEN_DEV_DATA_CONTAINER_0777_TO_1777"
+SUDO_PATH = "/usr/bin/sudo"
+CHMOD_PATH = "/usr/bin/chmod"
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+RELEASE_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+FAILURE_INJECTOR = None
+
+
+class HardeningBlocked(RuntimeError):
+    """The host no longer matches the reviewed hardening boundary."""
+
+
+def _failure_point(name: str, context: dict[str, Any] | None = None) -> None:
+    if FAILURE_INJECTOR is not None:
+        FAILURE_INJECTOR(name, context or {})
+
+
+def _canonical_digest(context: dict[str, Any]) -> str:
+    payload = json.dumps(
+        context, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _mode(details: os.stat_result) -> int:
+    return stat.S_IMODE(details.st_mode)
+
+
+def _metadata(details: os.stat_result, prefix: str) -> dict[str, Any]:
+    return {
+        f"{prefix}_owner_uid": details.st_uid,
+        f"{prefix}_group_gid": details.st_gid,
+        f"{prefix}_mode": f"{_mode(details):04o}",
+        f"{prefix}_device": details.st_dev,
+        f"{prefix}_inode": details.st_ino,
+    }
+
+
+def _identity(details: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        details.st_dev,
+        details.st_ino,
+        details.st_uid,
+        details.st_gid,
+        _mode(details),
+    )
+
+
+def _open_directory(path: Path) -> int:
+    try:
+        return os.open(
+            path,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+    except OSError as error:
+        raise HardeningBlocked(f"cannot safely open fixed directory {path}") from error
+
+
+def _open_child(parent_fd: int, name: str, description: str) -> int:
+    try:
+        return os.open(
+            name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except OSError as error:
+        raise HardeningBlocked(f"cannot safely open fixed {description}") from error
+
+
+def _require_root(details: os.stat_result) -> None:
+    if (
+        not stat.S_ISDIR(details.st_mode)
+        or details.st_uid != ROOT_OWNER_UID
+        or details.st_gid != ROOT_GROUP_GID
+        or _mode(details) & 0o022
+    ):
+        raise HardeningBlocked(
+            "filesystem root has unsafe ownership or permissions: "
+            f"owner_uid={details.st_uid}, group_gid={details.st_gid}, "
+            f"mode={_mode(details):04o}"
+        )
+
+
+def _require_data(details: os.stat_result) -> None:
+    if (
+        not stat.S_ISDIR(details.st_mode)
+        or details.st_uid != ROOT_OWNER_UID
+        or details.st_gid != ROOT_GROUP_GID
+        or _mode(details) not in {EXPECTED_MODE, TARGET_MODE}
+    ):
+        raise HardeningBlocked(
+            "fixed data container does not match the observed boundary: "
+            f"owner_uid={details.st_uid}, group_gid={details.st_gid}, "
+            f"mode={_mode(details):04o}"
+        )
+
+
+def _require_dev_parent(details: os.stat_result) -> None:
+    if (
+        not stat.S_ISDIR(details.st_mode)
+        or details.st_uid != os.geteuid()
+        or details.st_gid != os.getegid()
+        or _mode(details) != 0o777
+    ):
+        raise HardeningBlocked(
+            "fixed dev data parent has unexpected ownership, type, or mode"
+        )
+
+
+def _require_app(details: os.stat_result) -> None:
+    if not stat.S_ISDIR(details.st_mode) or details.st_uid != os.geteuid():
+        raise HardeningBlocked("fixed backend checkout has unexpected ownership or type")
+
+
+def _open_lock(dev_parent_fd: int) -> int:
+    try:
+        descriptor = os.open(
+            LOCK_NAME,
+            os.O_RDWR | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=dev_parent_fd,
+        )
+    except OSError as error:
+        raise HardeningBlocked("cannot safely open existing dev mutation lock") from error
+    details = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(details.st_mode)
+        or details.st_uid != os.geteuid()
+        or details.st_gid != os.getegid()
+        or details.st_nlink != 1
+        or _mode(details) != 0o600
+    ):
+        os.close(descriptor)
+        raise HardeningBlocked("existing dev mutation lock has unsafe metadata")
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as error:
+        os.close(descriptor)
+        raise HardeningBlocked("another dev backend mutation holds the lock") from error
+    return descriptor
+
+
+def _stat_bound(name: str, parent_fd: int, description: str) -> os.stat_result:
+    try:
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as error:
+        raise HardeningBlocked(f"cannot revalidate fixed {description}") from error
+
+
+def _verify_directory(
+    actual: os.stat_result,
+    expected: tuple[int, int, int, int, int],
+    description: str,
+) -> None:
+    if not stat.S_ISDIR(actual.st_mode) or _identity(actual) != expected:
+        raise HardeningBlocked(f"fixed {description} metadata or identity changed")
+
+
+def _verify_lock(
+    actual: os.stat_result,
+    expected: tuple[int, int, int, int, int],
+    description: str,
+) -> None:
+    if (
+        not stat.S_ISREG(actual.st_mode)
+        or actual.st_nlink != 1
+        or _identity(actual) != expected
+    ):
+        raise HardeningBlocked(f"fixed {description} metadata or identity changed")
+
+
+def _verify_bindings(
+    root_fd: int,
+    data_fd: int,
+    dev_parent_fd: int,
+    app_fd: int,
+    lock_fd: int,
+    *,
+    root_identity: tuple[int, int, int, int, int],
+    data_identity: tuple[int, int, int, int, int],
+    dev_parent_identity: tuple[int, int, int, int, int],
+    app_identity: tuple[int, int, int, int, int],
+    lock_identity: tuple[int, int, int, int, int],
+) -> None:
+    _verify_directory(os.fstat(root_fd), root_identity, "filesystem root")
+    try:
+        root_bound = os.stat(ROOT_PATH, follow_symlinks=False)
+    except OSError as error:
+        raise HardeningBlocked("cannot revalidate filesystem root") from error
+    _verify_directory(root_bound, root_identity, "filesystem root pathname")
+
+    _verify_directory(os.fstat(data_fd), data_identity, "data container")
+    _verify_directory(
+        _stat_bound(DATA_NAME, root_fd, "data container pathname"),
+        data_identity,
+        "data container pathname",
+    )
+    _verify_directory(
+        os.fstat(dev_parent_fd), dev_parent_identity, "dev data parent"
+    )
+    _verify_directory(
+        _stat_bound(DEV_PARENT_NAME, data_fd, "dev data parent pathname"),
+        dev_parent_identity,
+        "dev data parent pathname",
+    )
+    _verify_directory(os.fstat(app_fd), app_identity, "backend checkout")
+    _verify_directory(
+        _stat_bound(APP_NAME, dev_parent_fd, "backend checkout pathname"),
+        app_identity,
+        "backend checkout pathname",
+    )
+    _verify_lock(os.fstat(lock_fd), lock_identity, "dev mutation lock")
+    _verify_lock(
+        _stat_bound(LOCK_NAME, dev_parent_fd, "dev mutation lock pathname"),
+        lock_identity,
+        "dev mutation lock pathname",
+    )
+
+
+def _close_all(*descriptors: int | None) -> None:
+    for descriptor in reversed(descriptors):
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _validate_release_sha(expected_release_sha: str) -> None:
+    if not RELEASE_SHA_RE.fullmatch(expected_release_sha):
+        raise HardeningBlocked("expected release SHA must be lowercase 40-character Git SHA")
+
+
+def _open_state(
+    expected_release_sha: str,
+) -> tuple[tuple[int, int, int, int, int], dict[str, Any]]:
+    _validate_release_sha(expected_release_sha)
+    root_fd = _open_directory(ROOT_PATH)
+    data_fd = dev_parent_fd = app_fd = lock_fd = None
+    try:
+        root = os.fstat(root_fd)
+        _require_root(root)
+        data_fd = _open_child(root_fd, DATA_NAME, "data container")
+        data = os.fstat(data_fd)
+        _require_data(data)
+        dev_parent_fd = _open_child(data_fd, DEV_PARENT_NAME, "dev data parent")
+        dev_parent = os.fstat(dev_parent_fd)
+        _require_dev_parent(dev_parent)
+        app_fd = _open_child(dev_parent_fd, APP_NAME, "backend checkout")
+        app = os.fstat(app_fd)
+        _require_app(app)
+        lock_fd = _open_lock(dev_parent_fd)
+        lock = os.fstat(lock_fd)
+
+        identities = {
+            "root_identity": _identity(root),
+            "data_identity": _identity(data),
+            "dev_parent_identity": _identity(dev_parent),
+            "app_identity": _identity(app),
+            "lock_identity": _identity(lock),
+        }
+        _verify_bindings(
+            root_fd,
+            data_fd,
+            dev_parent_fd,
+            app_fd,
+            lock_fd,
+            **identities,
+        )
+        context = {
+            "schema_version": 1,
+            "target": "dev",
+            "path": str(DATA_PATH),
+            "dev_parent_path": str(DATA_PATH / DEV_PARENT_NAME),
+            "app_path": str(DATA_PATH / DEV_PARENT_NAME / APP_NAME),
+            "lock_path": str(DATA_PATH / DEV_PARENT_NAME / LOCK_NAME),
+            "expected_release_sha": expected_release_sha,
+            "target_mode": f"{TARGET_MODE:04o}",
+            **_metadata(root, "root"),
+            **_metadata(data, "data"),
+            **_metadata(dev_parent, "dev_parent"),
+            **_metadata(app, "app"),
+            **_metadata(lock, "lock"),
+            "lock_nlink": lock.st_nlink,
+            "helper_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        }
+        return (
+            (root_fd, data_fd, dev_parent_fd, app_fd, lock_fd),
+            {**context, "aggregate_sha256": _canonical_digest(context)},
+        )
+    except Exception:
+        _close_all(root_fd, data_fd, dev_parent_fd, app_fd, lock_fd)
+        raise
+
+
+def audit(expected_release_sha: str) -> dict[str, Any]:
+    descriptors, context = _open_state(expected_release_sha)
+    try:
+        context["status"] = (
+            "already_sticky"
+            if context["data_mode"] == f"{TARGET_MODE:04o}"
+            else "requires_hardening"
+        )
+        return context
+    finally:
+        _close_all(*descriptors)
+
+
+def _identity_from_context(context: dict[str, Any], prefix: str):
+    return (
+        context[f"{prefix}_device"],
+        context[f"{prefix}_inode"],
+        context[f"{prefix}_owner_uid"],
+        context[f"{prefix}_group_gid"],
+        int(context[f"{prefix}_mode"], 8),
+    )
+
+
+def _run_exact_chmod() -> None:
+    command = [
+        SUDO_PATH,
+        "-n",
+        CHMOD_PATH,
+        "1777",
+        "--",
+        str(DATA_PATH),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as error:
+        raise HardeningBlocked("cannot invoke exact allowlisted chmod") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or "no diagnostic"
+        raise HardeningBlocked(f"exact allowlisted chmod failed: {detail}")
+
+
+def apply(
+    expected_digest: str,
+    confirmation: str,
+    expected_release_sha: str,
+) -> dict[str, Any]:
+    if not SHA256_RE.fullmatch(expected_digest):
+        raise HardeningBlocked("expected aggregate digest must be lowercase SHA-256")
+    if confirmation != APPLY_CONFIRMATION:
+        raise HardeningBlocked("apply confirmation is invalid")
+
+    descriptors, before = _open_state(expected_release_sha)
+    root_fd, data_fd, dev_parent_fd, app_fd, lock_fd = descriptors
+    try:
+        if before["aggregate_sha256"] != expected_digest:
+            raise HardeningBlocked("current host state does not match the reviewed audit")
+        identities = {
+            f"{prefix}_identity": _identity_from_context(before, prefix)
+            for prefix in ("root", "data", "dev_parent", "app", "lock")
+        }
+        _verify_bindings(*descriptors, **identities)
+
+        if int(before["data_mode"], 8) == TARGET_MODE:
+            return {
+                "status": "already_sticky",
+                "path": str(DATA_PATH),
+                "before_mode": before["data_mode"],
+                "after_mode": f"{TARGET_MODE:04o}",
+                "aggregate_sha256": expected_digest,
+                "owner_uid": before["data_owner_uid"],
+                "group_gid": before["data_group_gid"],
+            }
+
+        # If a writable-child rename races this point, chmod still establishes
+        # sticky protection on /data. The identity postcheck then fails closed
+        # and deliberately leaves the safer 1777 mode in place.
+        _failure_point("before_sticky_guard", {"path": str(DATA_PATH)})
+        _run_exact_chmod()
+        os.fsync(data_fd)
+        _failure_point("after_sticky_guard", {"path": str(DATA_PATH)})
+
+        guarded_data = (
+            identities["data_identity"][0],
+            identities["data_identity"][1],
+            identities["data_identity"][2],
+            identities["data_identity"][3],
+            TARGET_MODE,
+        )
+        _verify_bindings(
+            root_fd,
+            data_fd,
+            dev_parent_fd,
+            app_fd,
+            lock_fd,
+            root_identity=identities["root_identity"],
+            data_identity=guarded_data,
+            dev_parent_identity=identities["dev_parent_identity"],
+            app_identity=identities["app_identity"],
+            lock_identity=identities["lock_identity"],
+        )
+        guarded = os.fstat(data_fd)
+        return {
+            "status": "hardened",
+            "path": str(DATA_PATH),
+            "before_mode": before["data_mode"],
+            "after_mode": f"{TARGET_MODE:04o}",
+            "aggregate_sha256": expected_digest,
+            "owner_uid": guarded.st_uid,
+            "group_gid": guarded.st_gid,
+            "dev_parent_device": identities["dev_parent_identity"][0],
+            "dev_parent_inode": identities["dev_parent_identity"][1],
+        }
+    finally:
+        _close_all(*descriptors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, choices=("audit", "apply"))
+    parser.add_argument("--expected-aggregate-sha256", default="")
+    parser.add_argument("--confirmation", default="")
+    parser.add_argument("--expected-release-sha", required=True)
+    arguments = parser.parse_args()
+    try:
+        if arguments.mode == "audit":
+            if arguments.expected_aggregate_sha256 or arguments.confirmation:
+                raise HardeningBlocked("audit does not accept apply controls")
+            result = audit(arguments.expected_release_sha)
+        else:
+            result = apply(
+                arguments.expected_aggregate_sha256,
+                arguments.confirmation,
+                arguments.expected_release_sha,
+            )
+    except HardeningBlocked as error:
+        print(f"hardening blocked: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/harden_dev_data_parent.py
+++ b/tools/harden_dev_data_parent.py
@@ -52,10 +52,18 @@ def _open_parent() -> tuple[int, dict[str, Any]]:
     except OSError as error:
         raise HardeningBlocked("cannot safely open the fixed data container") from error
     container = os.fstat(container_fd)
+    container_mode = stat.S_IMODE(container.st_mode)
+    safe_non_writable_container = (
+        container.st_uid in {0, os.geteuid()} and not container_mode & 0o022
+    )
+    safe_shared_container = (
+        container.st_uid == 0
+        and container.st_gid == 0
+        and container_mode == 0o1777
+    )
     if (
         not stat.S_ISDIR(container.st_mode)
-        or container.st_uid not in {0, os.geteuid()}
-        or container.st_mode & 0o022
+        or not (safe_non_writable_container or safe_shared_container)
     ):
         os.close(container_fd)
         raise HardeningBlocked(


### PR DESCRIPTION
## What changed

- adds a two-phase exact-state audit/apply workflow for the observed shared `/data` permission boundary
- transitions only root-owned `/data` from `0777` to sticky `1777` through an exact sudo allowlist
- binds root, container, dev checkout, and existing mutation-lock identities plus release/helper hashes
- lets the existing child hardener accept only the safe root:root `1777` shared-container exception

## Why

The development host currently has root-owned `/data` at `0777`, which permits another Unix user to rename deploy-owned application directories. The sticky transition preserves shared writability while preventing cross-owner rename/unlink before `/data/dev_unikorn` is hardened separately.

## Validation

- full backend suite: 576 passed, 6 skipped
- focused hardening/deploy suite: 44 passed
- Python compilation, YAML parse, and diff check clean
