### PR TITLE
Fix first popularity sampler production install

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -294,7 +294,8 @@ jobs:
           require_sudo_permission /usr/bin/systemctl daemon-reload
           require_sudo_permission /usr/bin/systemctl restart "${service_name}"
           require_sudo_permission /usr/bin/systemctl reset-failed \
-            "${baseline_service}" "${sample_service}" "${final_service}" "${verify_service}"
+            "${baseline_service}" "${sample_service}" "${verify_service}"
+          require_sudo_permission /usr/bin/systemctl reset-failed "${final_service}"
           for unit_name in \
             "${baseline_service}" "${sample_service}" "${final_service}" "${verify_service}" \
             "${sample_timer}" "${final_timer}"; do
@@ -459,7 +460,8 @@ jobs:
               "${unit_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"
           done
           sudo -n /usr/bin/systemctl daemon-reload
-          sudo -n /usr/bin/systemctl reset-failed "${baseline_service}" "${sample_service}" "${final_service}" "${verify_service}"
+          # The terminal unit is intentionally withheld until the sampler passes smoke checks.
+          sudo -n /usr/bin/systemctl reset-failed "${baseline_service}" "${sample_service}" "${verify_service}"
 
           echo "Smoke-testing popularity sampling as ${service_user}:${service_group}..."
           sudo -n /usr/bin/systemctl start "${baseline_service}"
@@ -561,6 +563,8 @@ jobs:
             sudo -n /usr/bin/install -m 0644 \
               "${unit_stage}/${final_timer}" "/etc/systemd/system/${final_timer}"
             sudo -n /usr/bin/systemctl daemon-reload
+            # reset-failed requires the just-installed service to be loaded on a first rollout.
+            sudo -n /usr/bin/systemctl reset-failed "${final_service}"
             activate_timer "${sample_timer}"
             activate_timer "${final_timer}"
           elif (( deploy_epoch < terminal_cutoff_epoch )); then
@@ -571,6 +575,8 @@ jobs:
             sudo -n /usr/bin/install -m 0644 \
               "${unit_stage}/${final_timer}" "/etc/systemd/system/${final_timer}"
             sudo -n /usr/bin/systemctl daemon-reload
+            # reset-failed requires the just-installed service to be loaded on a first rollout.
+            sudo -n /usr/bin/systemctl reset-failed "${final_service}"
             deactivate_timer "${sample_timer}"
             activate_timer "${final_timer}"
           else

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -356,6 +356,81 @@ def test_production_deploy_activates_bounded_popularity_sampling():
     assert "OnCalendar=2026-09-30 23:59:00 Asia/Shanghai" in final_timer
 
 
+def test_production_first_install_loads_every_reset_unit_before_resetting_failures():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+
+    staging = deploy_workflow[
+        deploy_workflow.index("Staging scheduler popularity sampling units..."):
+        deploy_workflow.index("Smoke-testing popularity sampling")
+    ]
+    reset_at = staging.index("systemctl reset-failed")
+    daemon_reload_at = staging.rindex("systemctl daemon-reload", 0, reset_at)
+    install_loop_at = staging.rindex("for unit_name in \\", 0, daemon_reload_at)
+    install_loop = staging[install_loop_at:staging.index("done", install_loop_at)]
+    reset_command = staging[reset_at:staging.index("\n", reset_at)]
+
+    installed_units = set(re.findall(r'"\$\{(\w+)\}"', install_loop))
+    reset_units = set(re.findall(r'"\$\{(\w+)\}"', reset_command))
+
+    assert reset_units
+    assert reset_units <= installed_units
+    assert "final_service" not in installed_units
+    assert "final_service" not in reset_units
+    assert "final_timer" not in installed_units
+    assert '"${unit_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"' in install_loop
+    assert install_loop_at < daemon_reload_at < reset_at
+
+    preflight = deploy_workflow[
+        deploy_workflow.index("Preflighting non-interactive"):
+        deploy_workflow.index("Required sudo permissions are available")
+    ]
+    assert (
+        'require_sudo_permission /usr/bin/systemctl reset-failed \\\n'
+        '            "${baseline_service}" "${sample_service}" "${verify_service}"'
+        in preflight
+    )
+    assert (
+        'require_sudo_permission /usr/bin/systemctl reset-failed "${final_service}"'
+        in preflight
+    )
+
+    before_cutoff_at = deploy_workflow.index("if (( deploy_epoch < sample_end_epoch ))")
+    terminal_only_at = deploy_workflow.index(
+        "elif (( deploy_epoch < terminal_cutoff_epoch ))"
+    )
+    campaign_complete_at = deploy_workflow.index(
+        'else\n            echo "Popularity sampling campaign is complete'
+    )
+
+    def assert_terminal_unit_installed_before_activation(branch):
+        final_service_install_at = branch.index(
+            '"${unit_stage}/${final_service}" "/etc/systemd/system/${final_service}"'
+        )
+        final_timer_install_at = branch.index(
+            '"${unit_stage}/${final_timer}" "/etc/systemd/system/${final_timer}"'
+        )
+        terminal_reload_at = branch.index("systemctl daemon-reload")
+        terminal_reset_at = branch.index('systemctl reset-failed "${final_service}"')
+        terminal_activate_at = branch.index('activate_timer "${final_timer}"')
+
+        assert (
+            max(final_service_install_at, final_timer_install_at)
+            < terminal_reload_at
+            < terminal_reset_at
+            < terminal_activate_at
+        )
+
+    assert deploy_workflow.index("sampler_validated=true") < before_cutoff_at
+    assert_terminal_unit_installed_before_activation(
+        deploy_workflow[before_cutoff_at:terminal_only_at]
+    )
+    assert_terminal_unit_installed_before_activation(
+        deploy_workflow[terminal_only_at:campaign_complete_at]
+    )
+
+
 def test_popularity_sampler_disables_app_startup_side_effects_before_import():
     sampler = (ROOT / "scripts" / "sample_scheduler_popularity.py").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## What changed

- avoids resetting the terminal popularity service before it is installed on the first production rollout
- keeps terminal service and timer withheld until sampler and API acceptance succeed
- resets the terminal service only after installation and daemon reload, before timer activation
- adds ordering regression coverage for a clean first install and both pre-cutoff branches

## Root cause

The initial rollout would run `systemctl reset-failed` against a terminal service that did not yet exist, causing `set -e` to abort before sampling activation.

## Validation

- deploy health tests: 18 passed
- YAML parse, Python compilation, and diff check clean
