### PR TITLE
fix: restore popularity sampler units on failed deploy

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -111,6 +111,8 @@ jobs:
           readonly verify_service="unikorn-scheduler-popularity-verify.service"
           readonly sample_end_epoch="$(date -d '2026-09-30 23:55:00 Asia/Shanghai' +%s)"
           readonly terminal_cutoff_epoch="$(date -d '2026-09-30 23:59:00 Asia/Shanghai' +%s)"
+          # The protected window begins 45 minutes before cutoff, exceeding the
+          # SSH action's 35-minute hard timeout by ten minutes.
           readonly protected_start_epoch="$((terminal_cutoff_epoch - 45 * 60))"
           readonly protected_end_epoch="$((terminal_cutoff_epoch + 130))"
 
@@ -121,10 +123,13 @@ jobs:
           sample_timer_was_loaded=false
           final_timer_was_loaded=false
           sampling_state_captured=false
+          sampler_units_mutated=false
+          regular_sampler_quiesced=false
           deployment_succeeded=false
           sampler_validated=false
           final_timer_touched=false
           unit_stage=""
+          unit_backup_stage=""
           sampler_release_stage=""
           api_response=""
           public_api_response=""
@@ -183,20 +188,94 @@ jobs:
             fi
           }
 
+          restore_sampler_unit_files() {
+            unit_restore_failed=false
+            [[ "${sampler_units_mutated}" == "true" ]] || return 0
+            echo "Restoring the exact pre-deployment sampler unit files." >&2
+            for unit_name in \
+              "${baseline_service}" "${sample_service}" "${verify_service}" \
+              "${sample_timer}"; do
+              marker_path="${unit_backup_stage}/${unit_name}.present"
+              backup_path="${unit_backup_stage}/${unit_name}"
+              target_path="/etc/systemd/system/${unit_name}"
+              if [[ -f "${marker_path}" ]]; then
+                sudo -n /usr/bin/install -m 0644 \
+                  "${backup_path}" "${target_path}" || unit_restore_failed=true
+                if [[ "${unit_restore_failed}" == "false" && \
+                      "$(sha256sum "${target_path}" | awk '{print $1}')" != "$(<"${marker_path}")" ]]; then
+                  echo "Restored unit checksum mismatch: ${target_path}" >&2
+                  unit_restore_failed=true
+                fi
+              else
+                if [[ -e "${target_path}" || -L "${target_path}" ]]; then
+                  sudo -n /usr/bin/rm -- "${target_path}" || unit_restore_failed=true
+                fi
+                if [[ -e "${target_path}" || -L "${target_path}" ]]; then
+                  echo "New sampler unit override remained after rollback: ${target_path}" >&2
+                  unit_restore_failed=true
+                fi
+              fi
+            done
+            sudo -n /usr/bin/systemctl daemon-reload || unit_restore_failed=true
+            for unit_name in \
+              "${baseline_service}" "${sample_service}" "${verify_service}" \
+              "${sample_timer}"; do
+              expected_load_state="$(<"${unit_backup_stage}/${unit_name}.load-state")"
+              expected_fragment_path="$(<"${unit_backup_stage}/${unit_name}.fragment-path")"
+              actual_load_state="$(/usr/bin/systemctl show -p LoadState --value "${unit_name}")"
+              actual_fragment_path="$(/usr/bin/systemctl show -p FragmentPath --value "${unit_name}")"
+              effective_fragment_matches=false
+              if [[ "${expected_fragment_path}" == "/etc/systemd/system/${unit_name}" ]]; then
+                [[ "${actual_fragment_path}" == "${expected_fragment_path}" ]] && \
+                  effective_fragment_matches=true
+              elif [[ -n "${expected_fragment_path}" && \
+                      "${actual_fragment_path}" == "${expected_fragment_path}" ]]; then
+                effective_fragment_matches=true
+              elif [[ -z "${expected_fragment_path}" && \
+                      ( "${actual_load_state}" == "not-found" || "${actual_load_state}" == "masked" ) ]]; then
+                effective_fragment_matches=true
+              fi
+              if [[ "${actual_load_state}" != "${expected_load_state}" || \
+                    "${effective_fragment_matches}" != "true" ]]; then
+                echo "Sampler unit rollback mismatch for ${unit_name}: expected load=${expected_load_state}, fragment=${expected_fragment_path}; got load=${actual_load_state}, fragment=${actual_fragment_path}." >&2
+                unit_restore_failed=true
+              fi
+            done
+            if [[ "${unit_restore_failed}" == "false" ]]; then
+              sampler_units_mutated=false
+            fi
+            [[ "${unit_restore_failed}" == "false" ]]
+          }
+
           restore_sampling_state() {
             deploy_status="$1"
             cleanup_failed=false
+            sampler_fragments_restored=true
             echo "Deployment failed (${deploy_status}); restoring prior sampling timer state." >&2
             if [[ "${sampling_state_captured}" == "true" ]]; then
-              for unit_name in \
-                "${sample_timer}" "${sample_service}" \
-                "${baseline_service}" "${verify_service}"; do
+              if unit_loaded "${sample_timer}"; then
+                sudo -n /usr/bin/systemctl stop "${sample_timer}" || cleanup_failed=true
+              fi
+              if unit_loaded "${sample_service}"; then
+                sudo -n /usr/bin/systemctl stop "${sample_service}" || cleanup_failed=true
+              fi
+              for unit_name in "${baseline_service}" "${verify_service}"; do
                 if unit_loaded "${unit_name}"; then
                   sudo -n /usr/bin/systemctl stop "${unit_name}" || cleanup_failed=true
                 fi
               done
 
-              if unit_loaded "${sample_timer}"; then
+              if [[ "${sampler_units_mutated}" == "true" ]]; then
+                if ! restore_sampler_unit_files; then
+                  sampler_fragments_restored=false
+                  cleanup_failed=true
+                  echo "CRITICAL: sampler unit files were not restored; leaving the regular timer stopped." >&2
+                fi
+              elif [[ "${regular_sampler_quiesced}" == "true" ]]; then
+                echo "No sampler unit files changed; restoring the timer state after quiescing." >&2
+              fi
+
+              if [[ "${sampler_fragments_restored}" == "true" ]] && unit_loaded "${sample_timer}"; then
                 if [[ "${sample_timer_was_enabled}" == "true" ]]; then
                   sudo -n /usr/bin/systemctl enable "${sample_timer}" || cleanup_failed=true
                 else
@@ -205,9 +284,11 @@ jobs:
                 [[ "${sample_timer_was_active}" == "false" ]] || \
                   sudo -n /usr/bin/systemctl start "${sample_timer}" || cleanup_failed=true
               fi
-              verify_timer_state \
-                "${sample_timer}" "${sample_timer_was_loaded}" \
-                "${sample_timer_was_enabled}" "${sample_timer_was_active}" || cleanup_failed=true
+              if [[ "${sampler_fragments_restored}" == "true" ]]; then
+                verify_timer_state \
+                  "${sample_timer}" "${sample_timer_was_loaded}" \
+                  "${sample_timer_was_enabled}" "${sample_timer_was_active}" || cleanup_failed=true
+              fi
               [[ "${cleanup_failed}" == "false" ]] || echo "WARNING: prior timer state could not be fully restored." >&2
             fi
           }
@@ -252,6 +333,7 @@ jobs:
             [[ -z "${api_response}" ]] || rm -f -- "${api_response}"
             [[ -z "${public_api_response}" ]] || rm -f -- "${public_api_response}"
             [[ -z "${unit_stage}" ]] || rm -rf -- "${unit_stage}"
+            [[ -z "${unit_backup_stage}" ]] || rm -rf -- "${unit_backup_stage}"
             [[ -z "${sampler_release_stage}" ]] || rm -rf -- "${sampler_release_stage}"
             [[ "${cleanup_failed}" == "false" ]] || echo "CRITICAL: terminal popularity timer verification failed during cleanup." >&2
             exit "${deploy_status}"
@@ -282,6 +364,7 @@ jobs:
           flock -n 9
           echo "Preflighting non-interactive production service permissions..."
           unit_stage="$(mktemp -d /tmp/unikorn-popularity-units.XXXXXX)"
+          unit_backup_stage="$(mktemp -d /tmp/unikorn-popularity-unit-backup.XXXXXX)"
           for unit_name in "${sample_timer}" "${final_timer}" "${sample_service}" "${baseline_service}" "${final_service}" "${verify_service}"; do
             require_sudo_permission /usr/bin/systemctl stop "${unit_name}"
             require_sudo_permission /usr/bin/systemctl start "${unit_name}"
@@ -302,6 +385,13 @@ jobs:
             require_sudo_permission /usr/bin/install -m 0644 \
               "${unit_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"
           done
+          for unit_name in \
+            "${baseline_service}" "${sample_service}" "${verify_service}" \
+            "${sample_timer}"; do
+            require_sudo_permission /usr/bin/install -m 0644 \
+              "/etc/systemd/system/${unit_name}" "${unit_backup_stage}/${unit_name}"
+            require_sudo_permission /usr/bin/rm -- "/etc/systemd/system/${unit_name}"
+          done
           echo "Required sudo permissions are available."
 
           unit_loaded "${sample_timer}" && sample_timer_was_loaded=true
@@ -310,6 +400,34 @@ jobs:
           unit_active "${final_timer}" && final_timer_was_active=true
           unit_enabled "${sample_timer}" && sample_timer_was_enabled=true
           unit_enabled "${final_timer}" && final_timer_was_enabled=true
+          for unit_name in \
+            "${baseline_service}" "${sample_service}" "${verify_service}" \
+            "${sample_timer}"; do
+            unit_path="/etc/systemd/system/${unit_name}"
+            /usr/bin/systemctl show -p LoadState --value "${unit_name}" > \
+              "${unit_backup_stage}/${unit_name}.load-state"
+            /usr/bin/systemctl show -p FragmentPath --value "${unit_name}" > \
+              "${unit_backup_stage}/${unit_name}.fragment-path"
+            if [[ -e "${unit_path}" || -L "${unit_path}" ]]; then
+              if [[ ! -f "${unit_path}" || -L "${unit_path}" ]]; then
+                echo "Refusing to replace non-regular sampler unit path: ${unit_path}" >&2
+                exit 1
+              fi
+              if [[ "$(stat -c '%u:%g:%a' "${unit_path}")" != "0:0:644" ]]; then
+                echo "Refusing unexpected sampler unit ownership or mode: ${unit_path}" >&2
+                exit 1
+              fi
+              /usr/bin/install -m 0600 \
+                "${unit_path}" "${unit_backup_stage}/${unit_name}"
+              sha256sum "${unit_backup_stage}/${unit_name}" | awk '{print $1}' > \
+                "${unit_backup_stage}/${unit_name}.present"
+              if [[ "$(sha256sum "${unit_path}" | awk '{print $1}')" != \
+                    "$(<"${unit_backup_stage}/${unit_name}.present")" ]]; then
+                echo "Sampler unit changed while it was being snapshotted: ${unit_path}" >&2
+                exit 1
+              fi
+            fi
+          done
           sampling_state_captured=true
 
           echo "Existing SHA-pinned popularity samplers remain available during release mutations."
@@ -453,9 +571,19 @@ jobs:
             /usr/bin/systemd-analyze verify "${unit_stage}"/*.service "${unit_stage}"/*.timer
           fi
 
+          regular_sampler_quiesced=true
+          if unit_loaded "${sample_timer}"; then
+            sudo -n /usr/bin/systemctl stop "${sample_timer}"
+          fi
+          if unit_loaded "${sample_service}"; then
+            sudo -n /usr/bin/systemctl stop "${sample_service}"
+          fi
+          assert_unit_inactive "${sample_timer}"
+          assert_unit_inactive "${sample_service}"
           for unit_name in \
             "${baseline_service}" "${sample_service}" "${verify_service}" \
             "${sample_timer}"; do
+            sampler_units_mutated=true
             sudo -n /usr/bin/install -m 0644 \
               "${unit_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"
           done
@@ -586,9 +714,13 @@ jobs:
             sudo -n /usr/bin/systemctl start "${verify_service}"
             test "$(/usr/bin/systemctl show -p Result --value "${verify_service}")" = "success"
           fi
+          deployment_succeeded=true
+          sampler_units_mutated=false
+          regular_sampler_quiesced=false
           rm -rf "${unit_stage}"
           unit_stage=""
-          deployment_succeeded=true
+          rm -rf "${unit_backup_stage}"
+          unit_backup_stage=""
           echo "Scheduler popularity sampling timers activated for ${service_user}:${service_group}."
 
           echo "Production deployment completed at ${deployed_sha}."

--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -169,6 +169,10 @@ jobs:
             expected_enabled="$3"
             expected_active="$4"
             if [[ "${expected_loaded}" == "false" ]] && ! unit_loaded "${timer_name}"; then
+              if unit_enabled "${timer_name}"; then
+                echo "${timer_name} remained enabled without its pre-deployment unit." >&2
+                return 1
+              fi
               return 0
             fi
             if ! unit_loaded "${timer_name}"; then
@@ -256,6 +260,11 @@ jobs:
               if unit_loaded "${sample_timer}"; then
                 sudo -n /usr/bin/systemctl stop "${sample_timer}" || cleanup_failed=true
               fi
+              # Remove candidate enablement links while its fragment is still
+              # loaded; prior enablement is recreated only after restoration.
+              if unit_enabled "${sample_timer}"; then
+                sudo -n /usr/bin/systemctl disable "${sample_timer}" || cleanup_failed=true
+              fi
               if unit_loaded "${sample_service}"; then
                 sudo -n /usr/bin/systemctl stop "${sample_service}" || cleanup_failed=true
               fi
@@ -333,7 +342,14 @@ jobs:
             [[ -z "${api_response}" ]] || rm -f -- "${api_response}"
             [[ -z "${public_api_response}" ]] || rm -f -- "${public_api_response}"
             [[ -z "${unit_stage}" ]] || rm -rf -- "${unit_stage}"
-            [[ -z "${unit_backup_stage}" ]] || rm -rf -- "${unit_backup_stage}"
+            if [[ -n "${unit_backup_stage}" ]]; then
+              if [[ "${sampler_units_mutated}" == "true" ]]; then
+                echo "CRITICAL: preserving sampler unit rollback evidence at ${unit_backup_stage}." >&2
+                cleanup_failed=true
+              else
+                rm -rf -- "${unit_backup_stage}"
+              fi
+            fi
             [[ -z "${sampler_release_stage}" ]] || rm -rf -- "${sampler_release_stage}"
             [[ "${cleanup_failed}" == "false" ]] || echo "CRITICAL: terminal popularity timer verification failed during cleanup." >&2
             exit "${deploy_status}"
@@ -389,7 +405,7 @@ jobs:
             "${baseline_service}" "${sample_service}" "${verify_service}" \
             "${sample_timer}"; do
             require_sudo_permission /usr/bin/install -m 0644 \
-              "/etc/systemd/system/${unit_name}" "${unit_backup_stage}/${unit_name}"
+              "${unit_backup_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"
             require_sudo_permission /usr/bin/rm -- "/etc/systemd/system/${unit_name}"
           done
           echo "Required sudo permissions are available."

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -486,6 +486,133 @@ def test_production_first_install_loads_every_reset_unit_before_resetting_failur
     )
 
 
+def test_production_failure_restores_exact_predeployment_sampler_units_before_timer_state():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+
+    capture_at = deploy_workflow.index(
+        'unit_path="/etc/systemd/system/${unit_name}"'
+    )
+    mutation_at = deploy_workflow.index("sampler_units_mutated=true")
+    smoke_at = deploy_workflow.index('systemctl start "${baseline_service}"')
+    restore_function_at = deploy_workflow.index("restore_sampler_unit_files()")
+    restore_call_at = deploy_workflow.index("if ! restore_sampler_unit_files; then")
+    timer_rearm_at = deploy_workflow.index(
+        'systemctl start "${sample_timer}"', restore_call_at
+    )
+
+    assert capture_at < mutation_at < smoke_at
+    assert restore_function_at < restore_call_at < timer_rearm_at
+    assert 'marker_path="${unit_backup_stage}/${unit_name}.present"' in deploy_workflow
+    assert '/usr/bin/install -m 0600' in deploy_workflow
+    assert 'sha256sum "${unit_backup_stage}/${unit_name}"' in deploy_workflow
+    assert 'Sampler unit changed while it was being snapshotted' in deploy_workflow
+    assert (
+        '"${backup_path}" "${target_path}" || unit_restore_failed=true'
+        in deploy_workflow
+    )
+    assert (
+        'sudo -n /usr/bin/rm -- "${target_path}" || unit_restore_failed=true'
+        in deploy_workflow
+    )
+    assert '"$(sha256sum "${target_path}" | awk' in deploy_workflow
+    assert 'New sampler unit override remained after rollback' in deploy_workflow
+    assert '"${unit_backup_stage}/${unit_name}.load-state"' in deploy_workflow
+    assert '"${unit_backup_stage}/${unit_name}.fragment-path"' in deploy_workflow
+    assert 'Sampler unit rollback mismatch for ${unit_name}' in deploy_workflow
+    assert 'effective_fragment_matches=false' in deploy_workflow
+    assert 'sampler_fragments_restored=true' in deploy_workflow
+    assert 'leaving the regular timer stopped' in deploy_workflow
+    assert deploy_workflow.index(
+        "systemctl daemon-reload || unit_restore_failed=true", restore_function_at
+    ) < timer_rearm_at
+    assert (
+        'if [[ ! -f "${unit_path}" || -L "${unit_path}" ]]; then'
+        in deploy_workflow
+    )
+
+    restored_units = deploy_workflow[
+        restore_function_at:deploy_workflow.index(
+            "restore_sampling_state()", restore_function_at
+        )
+    ]
+    capture_loop_at = deploy_workflow.rindex("for unit_name in \\", 0, capture_at)
+    captured_units = deploy_workflow[
+        capture_loop_at:deploy_workflow.index(
+            "sampling_state_captured=true", capture_at
+        )
+    ]
+    for unit_variable in (
+        "baseline_service",
+        "sample_service",
+        "verify_service",
+        "sample_timer",
+    ):
+        assert f'"${{{unit_variable}}}"' in restored_units
+        assert f'"${{{unit_variable}}}"' in captured_units
+
+
+def test_production_sampler_unit_rollback_permissions_are_preflighted():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+    preflight = deploy_workflow[
+        deploy_workflow.index("Preflighting non-interactive"):
+        deploy_workflow.index("Required sudo permissions are available")
+    ]
+
+    assert (
+        'require_sudo_permission /usr/bin/rm -- "/etc/systemd/system/${unit_name}"'
+        in preflight
+    )
+
+
+def test_production_quiesces_regular_sampler_immediately_before_unit_replacement():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+    staging_at = deploy_workflow.index("Staging scheduler popularity sampling units...")
+    install_at = deploy_workflow.index(
+        '"${unit_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"',
+        staging_at,
+    )
+    install_loop_at = deploy_workflow.rindex("for unit_name in \\", staging_at, install_at)
+    quiesce_start = deploy_workflow.rindex(
+        "regular_sampler_quiesced=true", staging_at, install_loop_at
+    )
+    quiesce = deploy_workflow[quiesce_start:install_at]
+
+    assert quiesce.index("regular_sampler_quiesced=true") < quiesce.index(
+        'systemctl stop "${sample_timer}"'
+    )
+    assert 'systemctl stop "${sample_timer}"' in quiesce
+    assert 'systemctl stop "${sample_service}"' in quiesce
+    assert 'assert_unit_inactive "${sample_timer}"' in quiesce
+    assert 'assert_unit_inactive "${sample_service}"' in quiesce
+    assert "regular_sampler_quiesced=true" in quiesce
+    restore = deploy_workflow[
+        deploy_workflow.index("restore_sampling_state()"):
+        deploy_workflow.index("verify_terminal_timer_untouched()")
+    ]
+    assert 'elif [[ "${regular_sampler_quiesced}" == "true" ]]' in restore
+    rearm_at = restore.index('systemctl start "${sample_timer}"')
+    assert restore.rindex(
+        'if [[ "${sampler_fragments_restored}" == "true" ]]', 0, rearm_at
+    ) < rearm_at
+
+
+def test_production_protected_window_exceeds_remote_command_timeout_margin():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "command_timeout: 35m" in deploy_workflow
+    assert "terminal_cutoff_epoch - 45 * 60" in deploy_workflow
+    assert "exceeding the" in deploy_workflow
+    assert "35-minute hard timeout by ten minutes" in deploy_workflow
+
+
 def test_popularity_sampler_disables_app_startup_side_effects_before_import():
     sampler = (ROOT / "scripts" / "sample_scheduler_popularity.py").read_text(
         encoding="utf-8"

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -524,6 +524,7 @@ def test_production_failure_restores_exact_predeployment_sampler_units_before_ti
     assert 'effective_fragment_matches=false' in deploy_workflow
     assert 'sampler_fragments_restored=true' in deploy_workflow
     assert 'leaving the regular timer stopped' in deploy_workflow
+    assert 'preserving sampler unit rollback evidence at ${unit_backup_stage}' in deploy_workflow
     assert deploy_workflow.index(
         "systemctl daemon-reload || unit_restore_failed=true", restore_function_at
     ) < timer_rearm_at
@@ -563,9 +564,34 @@ def test_production_sampler_unit_rollback_permissions_are_preflighted():
     ]
 
     assert (
+        'require_sudo_permission /usr/bin/install -m 0644 \\\n'
+        '              "${unit_backup_stage}/${unit_name}" "/etc/systemd/system/${unit_name}"'
+        in preflight
+    )
+    assert (
         'require_sudo_permission /usr/bin/rm -- "/etc/systemd/system/${unit_name}"'
         in preflight
     )
+
+
+def test_first_install_rollback_removes_candidate_timer_enablement_before_fragment():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+    restore = deploy_workflow[
+        deploy_workflow.index("restore_sampling_state()"):
+        deploy_workflow.index("verify_terminal_timer_untouched()")
+    ]
+
+    disable_at = restore.index('systemctl disable "${sample_timer}"')
+    fragment_restore_at = restore.index("if ! restore_sampler_unit_files; then")
+    assert disable_at < fragment_restore_at
+    verify = deploy_workflow[
+        deploy_workflow.index("verify_timer_state()"):
+        deploy_workflow.index("restore_sampler_unit_files()")
+    ]
+    assert 'if unit_enabled "${timer_name}"; then' in verify
+    assert "remained enabled without its pre-deployment unit" in verify
 
 
 def test_production_quiesces_regular_sampler_immediately_before_unit_replacement():


### PR DESCRIPTION
Closes the production-gate P1 before popularity deployment.\n\nOn any failed deployment, snapshot the four pre-smoke sampler unit overrides; quiesce the active sample timer/service before mutation; restore byte-for-byte or remove first-install overrides; daemon-reload; verify hashes and effective FragmentPath/LoadState; then and only then restore prior timer state. Unsafe symlink/non-regular unit paths are rejected and partial installs are recoverable.\n\nLocal verification: focused scheduler/deploy suite 72 passed; deploy-only suite 24 passed; YAML parse, extracted Bash syntax, and diff checks pass. Independent exact-commit review is in progress.