### PR TITLE
fix: harden production release preflight

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -109,8 +109,15 @@ jobs:
           readonly sample_timer="unikorn-scheduler-popularity-sample.timer"
           readonly final_timer="unikorn-scheduler-popularity-final.timer"
           readonly verify_service="unikorn-scheduler-popularity-verify.service"
-          readonly sample_end_epoch="$(date -d '2026-09-30 23:55:00 Asia/Shanghai' +%s)"
-          readonly terminal_cutoff_epoch="$(date -d '2026-09-30 23:59:00 Asia/Shanghai' +%s)"
+          # Fixed UTC epochs for 2026-09-30 23:55 and 23:59 Asia/Shanghai.
+          # Keeping these as literals makes date parsing fail-closed and the
+          # corresponding test derives them independently with zoneinfo.
+          readonly sample_end_epoch=1790783700
+          readonly terminal_cutoff_epoch=1790783940
+          if (( sample_end_epoch <= 0 || terminal_cutoff_epoch <= sample_end_epoch )); then
+            echo "Invalid scheduler popularity sampling boundary." >&2
+            exit 1
+          fi
           # The protected window begins 45 minutes before cutoff, exceeding the
           # SSH action's 35-minute hard timeout by ten minutes.
           readonly protected_start_epoch="$((terminal_cutoff_epoch - 45 * 60))"
@@ -154,6 +161,25 @@ jobs:
               echo "${unit_name} did not quiesce (load=${load_state}, active=${active_state})." >&2
               return 1
             fi
+          }
+
+          timer_next_epoch() {
+            timer_name="$1"
+            next_elapse="$(
+              LC_ALL=C TZ=UTC0 /usr/bin/systemctl show \
+                -p NextElapseUSecRealtime --value "${timer_name}"
+            )"
+            if [[ -z "${next_elapse}" || "${next_elapse}" == "n/a" ]]; then
+              echo "${timer_name} has no next realtime elapse." >&2
+              return 1
+            fi
+            if ! next_epoch="$(
+              LC_ALL=C TZ=UTC0 /usr/bin/date --date="${next_elapse}" +%s
+            )" || [[ ! "${next_epoch}" =~ ^[0-9]+$ ]]; then
+              echo "Cannot parse ${timer_name} next elapse as UTC: ${next_elapse}" >&2
+              return 1
+            fi
+            printf '%s\n' "${next_epoch}"
           }
 
           require_sudo_permission() {
@@ -308,8 +334,8 @@ jobs:
                 echo "CRITICAL: untouched terminal timer lost its armed state." >&2
                 return 1
               fi
-              next_elapse="$(/usr/bin/systemctl show -p NextElapseUSecRealtime --value "${final_timer}")"
-              if [[ -z "${next_elapse}" || "${next_elapse}" == "n/a" || "$(date -d "${next_elapse}" +%s)" -ne "${terminal_cutoff_epoch}" ]]; then
+              if ! next_epoch="$(timer_next_epoch "${final_timer}")" || \
+                  (( next_epoch != terminal_cutoff_epoch )); then
                 echo "CRITICAL: untouched terminal timer no longer targets the exact cutoff." >&2
                 return 1
               fi
@@ -323,8 +349,8 @@ jobs:
               sudo -n /usr/bin/systemctl restart "${final_timer}"
               unit_enabled "${final_timer}"
               unit_active "${final_timer}"
-              next_elapse="$(/usr/bin/systemctl show -p NextElapseUSecRealtime --value "${final_timer}")"
-              test "$(date -d "${next_elapse}" +%s)" -eq "${terminal_cutoff_epoch}"
+              next_epoch="$(timer_next_epoch "${final_timer}")"
+              test "${next_epoch}" -eq "${terminal_cutoff_epoch}"
             fi
           }
 
@@ -376,7 +402,31 @@ jobs:
 
           echo "Starting production deployment for ${DEPLOY_SHA}..."
           cd "${app_dir}"
-          exec 9>/tmp/unikorn-backend-mutation-production.lock
+          readonly production_data_dir="/data/prod_unikorn"
+          readonly production_lock_path="${production_data_dir}/backend-mutations-production.lock"
+          data_owner="$(stat -c '%u' "${production_data_dir}")"
+          data_mode="$(stat -c '%a' "${production_data_dir}")"
+          if [[ -L "${production_data_dir}" || ! -d "${production_data_dir}" || \
+                ( "${data_owner}" != "0" && "${data_owner}" != "$(id -u)" ) || \
+                $((8#${data_mode} & 022)) -ne 0 ]]; then
+            echo "Production data directory has unsafe metadata." >&2
+            exit 1
+          fi
+          umask 077
+          # Read/write opening avoids truncating an existing path before its
+          # descriptor identity and metadata are validated below.
+          exec 9<>"${production_lock_path}"
+          umask 022
+          lock_fd_metadata="$(stat -Lc '%d:%i:%u:%g:%a:%h:%s' "/proc/$$/fd/9")"
+          lock_path_metadata="$(stat -Lc '%d:%i:%u:%g:%a:%h:%s' "${production_lock_path}")"
+          expected_lock_safety="$(id -u):600:1:0"
+          lock_safety="$(stat -Lc '%u:%a:%h:%s' "/proc/$$/fd/9")"
+          if [[ -L "${production_lock_path}" || ! -e "/proc/$$/fd/9" || \
+                "${lock_fd_metadata}" != "${lock_path_metadata}" || \
+                "${lock_safety}" != "${expected_lock_safety}" ]]; then
+            echo "Production mutation lock has unsafe metadata or identity." >&2
+            exit 1
+          fi
           flock -n 9
           echo "Preflighting non-interactive production service permissions..."
           unit_stage="$(mktemp -d /tmp/unikorn-popularity-units.XXXXXX)"
@@ -670,21 +720,21 @@ jobs:
 
           activate_timer() {
             timer_name="$1"
+            expected_epoch="${2:-}"
             sudo -n /usr/bin/systemctl enable "${timer_name}"
             sudo -n /usr/bin/systemctl restart "${timer_name}"
             unit_enabled "${timer_name}"
             unit_active "${timer_name}"
-            next_elapse="$(/usr/bin/systemctl show -p NextElapseUSecRealtime --value "${timer_name}")"
-            if [[ -z "${next_elapse}" || "${next_elapse}" == "n/a" ]]; then
-              echo "${timer_name} has no next realtime elapse." >&2
-              return 1
-            fi
-            next_epoch="$(date -d "${next_elapse}" +%s)"
+            next_epoch="$(timer_next_epoch "${timer_name}")"
             if (( next_epoch <= $(date +%s) )); then
-              echo "${timer_name} next elapse is not in the future: ${next_elapse}" >&2
+              echo "${timer_name} next elapse is not in the future: ${next_epoch}" >&2
               return 1
             fi
-            echo "${timer_name} next elapse: ${next_elapse}"
+            if [[ -n "${expected_epoch}" ]] && (( next_epoch != expected_epoch )); then
+              echo "${timer_name} targets ${next_epoch}, expected ${expected_epoch}." >&2
+              return 1
+            fi
+            echo "${timer_name} next elapse epoch: ${next_epoch}"
           }
 
           deactivate_timer() {
@@ -710,7 +760,7 @@ jobs:
             # reset-failed requires the just-installed service to be loaded on a first rollout.
             sudo -n /usr/bin/systemctl reset-failed "${final_service}"
             activate_timer "${sample_timer}"
-            activate_timer "${final_timer}"
+            activate_timer "${final_timer}" "${terminal_cutoff_epoch}"
           elif (( deploy_epoch < terminal_cutoff_epoch )); then
             echo "Regular sampling is complete; preserving only the terminal timer."
             final_timer_touched=true
@@ -722,7 +772,7 @@ jobs:
             # reset-failed requires the just-installed service to be loaded on a first rollout.
             sudo -n /usr/bin/systemctl reset-failed "${final_service}"
             deactivate_timer "${sample_timer}"
-            activate_timer "${final_timer}"
+            activate_timer "${final_timer}" "${terminal_cutoff_epoch}"
           else
             echo "Popularity sampling campaign is complete; disabling timers and verifying the terminal sample."
             deactivate_timer "${sample_timer}"

--- a/.github/workflows/reconcile-prod-migration-checkout.yml
+++ b/.github/workflows/reconcile-prod-migration-checkout.yml
@@ -1,4 +1,4 @@
-name: Reconcile Dev Migration Checkout
+name: Reconcile Production Migration Checkout
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
       confirmation:
-        description: "Apply requires QUARANTINE_DEV_LEGACY_MIGRATIONS"
+        description: "Apply requires QUARANTINE_PRODUCTION_LEGACY_OAUTH_MIGRATION"
         required: false
         type: string
 
@@ -24,16 +24,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: backend-mutations-dev
+  group: backend-mutations-production
   cancel-in-progress: false
 
 jobs:
   reconcile:
-    name: ${{ inputs.mode }} fixed dev migration checkout
+    name: ${{ inputs.mode }} fixed production migration checkout
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    environment: production
     steps:
-      - name: Require a fixed dev request
+      - name: Require a fixed production request from main
         env:
           MODE: ${{ inputs.mode }}
           EXPECTED_AGGREGATE_SHA256: ${{ inputs.expected_aggregate_sha256 }}
@@ -48,7 +49,7 @@ jobs:
               ;;
             apply)
               [[ "$EXPECTED_AGGREGATE_SHA256" =~ ^[0-9a-f]{64}$ ]]
-              test "$CONFIRMATION" = "QUARANTINE_DEV_LEGACY_MIGRATIONS"
+              test "$CONFIRMATION" = "QUARANTINE_PRODUCTION_LEGACY_OAUTH_MIGRATION"
               ;;
             *) exit 2 ;;
           esac
@@ -68,7 +69,7 @@ jobs:
           printf 'sha256=%s\n' "$sha256" >> "$GITHUB_OUTPUT"
           printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
 
-      - name: Audit or recoverably quarantine exact allowlist
+      - name: Audit or recoverably quarantine exact production file
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:
           RECONCILE_MODE: ${{ inputs.mode }}
@@ -78,9 +79,9 @@ jobs:
           RECONCILE_HELPER_SHA256: ${{ steps.helper.outputs.sha256 }}
           RECONCILE_HELPER_GZIP_B64: ${{ steps.helper.outputs.payload }}
         with:
-          host: ${{ secrets.DEV_HOST }}
-          username: ${{ secrets.DEV_USER }}
-          key: ${{ secrets.DEV_SSH_KEY }}
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
           command_timeout: 5m
           envs: RECONCILE_MODE,RECONCILE_EXPECTED_AGGREGATE_SHA256,RECONCILE_CONFIRMATION,RECONCILE_RUN_ID,RECONCILE_HELPER_SHA256,RECONCILE_HELPER_GZIP_B64
           script: |
@@ -91,10 +92,10 @@ jobs:
             test "$(sha256sum "$helper" | cut -d ' ' -f 1)" = "$RECONCILE_HELPER_SHA256"
             chmod 0500 "$helper"
             if [ "$RECONCILE_MODE" = "audit" ]; then
-              python3 -I "$helper" --target dev --mode audit
+              python3 -I "$helper" --target production --mode audit
             else
               python3 -I "$helper" \
-                --target dev \
+                --target production \
                 --mode apply \
                 --expected-aggregate-sha256 "$RECONCILE_EXPECTED_AGGREGATE_SHA256" \
                 --confirmation "$RECONCILE_CONFIRMATION" \

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -1,7 +1,9 @@
 import ast
+from datetime import datetime
 import hashlib
 from pathlib import Path
 import re
+from zoneinfo import ZoneInfo
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -220,6 +222,7 @@ def test_dev_migration_checkout_reconciliation_is_two_phase_and_fixed_scope():
         "exec 9>/data/dev_unikorn/backend-mutations-dev.lock"
     )
     assert "refs/heads/main" in workflow
+    assert "--target dev" in workflow
     assert "secrets.DEV_HOST" in workflow
     assert "secrets.DEV_USER" in workflow
     assert "secrets.DEV_SSH_KEY" in workflow
@@ -248,13 +251,71 @@ def test_dev_migration_checkout_reconciliation_is_two_phase_and_fixed_scope():
     assert "helper_sha256" in helper
     assert "committed_revisions" in helper
     assert "committed_heads" in helper
+    assert "committed_allowlisted_revision_duplicates" in helper
     assert "committed_allowlisted_revision_references" in helper
     assert '"depends_on"' in helper
     assert "os.link" in helper
     assert "SELECT version_num FROM alembic_version" in helper
     assert "dev_unikorn" in helper
+    assert '"production"' in helper
+    assert "/data/prod_unikorn/back-end" in helper
+    assert "000000000000_create_oauth_tables.py" in helper
     assert "git clean" not in helper
     assert "rmtree" not in helper
+
+
+def test_production_migration_checkout_reconciliation_is_two_phase_and_fixed_scope():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+    workflow = (
+        ROOT / ".github" / "workflows" / "reconcile-prod-migration-checkout.yml"
+    ).read_text(encoding="utf-8")
+    helper = (
+        ROOT / "tools" / "reconcile_dev_migration_checkout.py"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "group: backend-mutations-production" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "refs/heads/main" in workflow
+    assert "secrets.PROD_SSH_HOST" in workflow
+    assert "secrets.PROD_SSH_USER" in workflow
+    assert "secrets.PROD_SSH_KEY" in workflow
+    assert "environment: production" in workflow
+    assert "--target production" in workflow
+    assert "QUARANTINE_PRODUCTION_LEGACY_OAUTH_MIGRATION" in workflow
+    assert "expected_aggregate_sha256" in workflow
+    assert "git clean" not in workflow
+    assert "rm -rf" not in workflow
+    assert "/data/prod_unikorn/back-end" in helper
+    assert "/data/prod_unikorn/quarantine/legacy-migrations" in helper
+    assert "000000000000_create_oauth_tables.py" in helper
+    assert "ast.literal_eval" in helper
+    assert "PREPARED.json" in helper
+    assert "COMMITTED.json" in helper
+    assert "SELECT version_num FROM alembic_version" in helper
+    assert "prod_unikorn" in helper
+    assert "git clean" not in helper
+    assert "rmtree" not in helper
+    lock_path = "/data/prod_unikorn/backend-mutations-production.lock"
+    assert lock_path in helper
+    assert 'readonly production_data_dir="/data/prod_unikorn"' in deploy_workflow
+    assert (
+        'readonly production_lock_path="${production_data_dir}/backend-mutations-production.lock"'
+        in deploy_workflow
+    )
+    assert deploy_workflow.index("umask 077") < deploy_workflow.index(
+        'exec 9<>"${production_lock_path}"'
+    )
+    assert deploy_workflow.index('exec 9<>"${production_lock_path}"') < (
+        deploy_workflow.index("umask 022")
+    )
+    assert "lock_fd_metadata" in deploy_workflow
+    assert "lock_path_metadata" in deploy_workflow
+    assert "expected_lock_safety" in deploy_workflow
+    assert '[[ -L "${production_lock_path}"' in deploy_workflow
+    assert '[[ -L "${production_data_dir}"' in deploy_workflow
 
 
 def test_dev_data_parent_hardening_is_exact_two_phase_and_non_recursive():
@@ -409,6 +470,39 @@ def test_production_deploy_activates_bounded_popularity_sampling():
     assert "OnCalendar=2026-08-* *:0/5:00 Asia/Shanghai" in sample_timer
     assert "OnCalendar=2026-09-* *:0/5:00 Asia/Shanghai" in sample_timer
     assert "OnCalendar=2026-09-30 23:59:00 Asia/Shanghai" in final_timer
+
+
+def test_production_sampling_cutoff_epochs_are_exact_and_parse_fail_closed():
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+    ).read_text(encoding="utf-8")
+
+    sample_match = re.search(r"readonly sample_end_epoch=(\d+)", deploy_workflow)
+    terminal_match = re.search(
+        r"readonly terminal_cutoff_epoch=(\d+)", deploy_workflow
+    )
+    assert sample_match is not None
+    assert terminal_match is not None
+
+    zone = ZoneInfo("Asia/Shanghai")
+    expected_sample = int(datetime(2026, 9, 30, 23, 55, tzinfo=zone).timestamp())
+    expected_terminal = int(datetime(2026, 9, 30, 23, 59, tzinfo=zone).timestamp())
+    assert int(sample_match.group(1)) == expected_sample
+    assert int(terminal_match.group(1)) == expected_terminal
+    assert expected_terminal - expected_sample == 4 * 60
+    assert "terminal_cutoff_epoch <= sample_end_epoch" in deploy_workflow
+    assert "timer_next_epoch()" in deploy_workflow
+    assert "LC_ALL=C TZ=UTC0 /usr/bin/systemctl show" in deploy_workflow
+    assert (
+        'LC_ALL=C TZ=UTC0 /usr/bin/date --date="${next_elapse}" +%s'
+        in deploy_workflow
+    )
+    assert "date -d" not in deploy_workflow
+    assert 'activate_timer "${final_timer}" "${terminal_cutoff_epoch}"' in deploy_workflow
+    assert "readonly sample_end_epoch=\"$(date" not in deploy_workflow
+    assert "readonly terminal_cutoff_epoch=\"$(date" not in deploy_workflow
+    assert "backend-mutations-production.lock" in deploy_workflow
+    assert "/tmp/unikorn-backend-mutation-production.lock" not in deploy_workflow
 
 
 def test_production_first_install_loads_every_reset_unit_before_resetting_failures():

--- a/tests/test_reconcile_dev_migration_checkout.py
+++ b/tests/test_reconcile_dev_migration_checkout.py
@@ -92,6 +92,7 @@ def test_audit_is_deterministic_and_parses_metadata_without_execution(tmp_path, 
     assert first["live_current_allowlisted_revisions"] == []
     assert first["committed_revisions"] == ["committed_head"]
     assert first["committed_heads"] == ["committed_head"]
+    assert first["committed_allowlisted_revision_duplicates"] == []
     assert first["helper_sha256"] == hashlib.sha256(
         Path(reconciliation.__file__).read_bytes()
     ).hexdigest()
@@ -226,6 +227,26 @@ def test_apply_blocks_if_committed_graph_references_allowlisted_revision(
             audited["aggregate_sha256"],
             reconciliation.APPLY_CONFIRMATION,
             "123",
+        )
+    assert not quarantine.exists()
+
+
+def test_apply_blocks_if_allowlisted_file_duplicates_committed_revision(
+    tmp_path, monkeypatch
+):
+    repository, quarantine, _payloads = _checkout(tmp_path, monkeypatch)
+    (repository / reconciliation.ALLOWLIST[0]).write_bytes(
+        _migration("committed_head", None)
+    )
+    audited = reconciliation.audit(repository)
+    assert audited["committed_allowlisted_revision_duplicates"] == ["committed_head"]
+
+    with pytest.raises(reconciliation.ReconciliationBlocked, match="duplicates"):
+        reconciliation.apply(
+            repository,
+            audited["aggregate_sha256"],
+            reconciliation.APPLY_CONFIRMATION,
+            "124",
         )
     assert not quarantine.exists()
 
@@ -488,7 +509,7 @@ def test_source_reappearance_at_restore_syscall_never_replaces_conflict(
 
 
 def test_allowlist_is_exactly_the_twelve_observed_dev_paths():
-    assert reconciliation.ALLOWLIST == (
+    assert reconciliation.DEV_ALLOWLIST == (
         "migrations/versions/0e18af78068e_.py",
         "migrations/versions/1effc88ae61e_.py",
         "migrations/versions/6734a89a7bb7_.py",
@@ -502,6 +523,28 @@ def test_allowlist_is_exactly_the_twelve_observed_dev_paths():
         "migrations/versions/d79de51fc5f3_.py",
         "migrations/versions/da5f7cad7d38_.py",
     )
+
+
+def test_production_target_is_fixed_to_the_single_observed_collision(monkeypatch):
+    reconciliation.configure_target("production")
+    assert reconciliation.TARGET_NAME == "production"
+    assert reconciliation.APP_DIR == Path("/data/prod_unikorn/back-end")
+    assert reconciliation.QUARANTINE_ROOT == Path(
+        "/data/prod_unikorn/quarantine/legacy-migrations"
+    )
+    assert reconciliation.LOCK_PATH == Path(
+        "/data/prod_unikorn/backend-mutations-production.lock"
+    )
+    assert reconciliation.EXPECTED_BRANCH == "production"
+    assert reconciliation.EXPECTED_DATABASE == "prod_unikorn"
+    assert reconciliation.APPLY_CONFIRMATION == (
+        "QUARANTINE_PRODUCTION_LEGACY_OAUTH_MIGRATION"
+    )
+    assert reconciliation.ALLOWLIST == (
+        "migrations/versions/000000000000_create_oauth_tables.py",
+    )
+
+    reconciliation.configure_target("dev")
 
 
 def test_helper_lock_rejects_symlink_and_contended_regular_file(tmp_path, monkeypatch):

--- a/tools/reconcile_dev_migration_checkout.py
+++ b/tools/reconcile_dev_migration_checkout.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Audit and recoverably quarantine one known dev-checkout migration set.
+"""Audit and recoverably quarantine one known deployment migration set.
 
 This helper is intentionally stdlib-only so a reviewed copy can be streamed to
-the dev host without importing or executing any migration module.
+the target host without importing or executing any migration module.
 """
 
 from __future__ import annotations
@@ -27,11 +27,12 @@ LOCK_PATH = Path("/data/dev_unikorn/backend-mutations-dev.lock")
 EXPECTED_BRANCH = "main"
 EXPECTED_DATABASE = "dev_unikorn"
 APPLY_CONFIRMATION = "QUARANTINE_DEV_LEGACY_MIGRATIONS"
+TARGET_NAME = "dev"
 MAX_FILE_BYTES = 1_048_576
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 RUN_ID_RE = re.compile(r"[1-9][0-9]{0,19}\Z")
 
-ALLOWLIST = (
+DEV_ALLOWLIST = (
     "migrations/versions/0e18af78068e_.py",
     "migrations/versions/1effc88ae61e_.py",
     "migrations/versions/6734a89a7bb7_.py",
@@ -45,8 +46,54 @@ ALLOWLIST = (
     "migrations/versions/d79de51fc5f3_.py",
     "migrations/versions/da5f7cad7d38_.py",
 )
+PRODUCTION_ALLOWLIST = (
+    "migrations/versions/000000000000_create_oauth_tables.py",
+)
+TARGETS = {
+    "dev": {
+        "app_dir": Path("/data/dev_unikorn/back-end"),
+        "quarantine_root": Path("/data/dev_unikorn/quarantine/legacy-migrations"),
+        "lock_path": Path("/data/dev_unikorn/backend-mutations-dev.lock"),
+        "branch": "main",
+        "database": "dev_unikorn",
+        "confirmation": "QUARANTINE_DEV_LEGACY_MIGRATIONS",
+        "allowlist": DEV_ALLOWLIST,
+    },
+    "production": {
+        "app_dir": Path("/data/prod_unikorn/back-end"),
+        "quarantine_root": Path("/data/prod_unikorn/quarantine/legacy-migrations"),
+        "lock_path": Path("/data/prod_unikorn/backend-mutations-production.lock"),
+        "branch": "production",
+        "database": "prod_unikorn",
+        "confirmation": "QUARANTINE_PRODUCTION_LEGACY_OAUTH_MIGRATION",
+        "allowlist": PRODUCTION_ALLOWLIST,
+    },
+}
+ALLOWLIST = DEV_ALLOWLIST
 ALLOWLIST_SET = frozenset(ALLOWLIST)
 FAILURE_INJECTOR = None
+
+
+def configure_target(target: str) -> None:
+    """Select one reviewed target before opening any host path or database."""
+
+    global APP_DIR, QUARANTINE_ROOT, LOCK_PATH
+    global EXPECTED_BRANCH, EXPECTED_DATABASE, APPLY_CONFIRMATION, TARGET_NAME
+    global ALLOWLIST, ALLOWLIST_SET
+
+    try:
+        config = TARGETS[target]
+    except KeyError as error:
+        raise ReconciliationBlocked("unknown reconciliation target") from error
+    TARGET_NAME = target
+    APP_DIR = config["app_dir"]
+    QUARANTINE_ROOT = config["quarantine_root"]
+    LOCK_PATH = config["lock_path"]
+    EXPECTED_BRANCH = config["branch"]
+    EXPECTED_DATABASE = config["database"]
+    APPLY_CONFIRMATION = config["confirmation"]
+    ALLOWLIST = config["allowlist"]
+    ALLOWLIST_SET = frozenset(ALLOWLIST)
 
 
 class ReconciliationBlocked(RuntimeError):
@@ -104,7 +151,7 @@ def _acquire_lock() -> int:
         )
     except OSError as error:
         os.close(parent_fd)
-        raise ReconciliationBlocked("cannot safely open the fixed dev mutation lock") from error
+        raise ReconciliationBlocked("cannot safely open the fixed mutation lock") from error
     _fsync_directory(parent_fd)
     os.close(parent_fd)
     details = os.fstat(descriptor)
@@ -115,12 +162,12 @@ def _acquire_lock() -> int:
         or stat.S_IMODE(details.st_mode) != 0o600
     ):
         os.close(descriptor)
-        raise ReconciliationBlocked("fixed dev mutation lock has unsafe metadata")
+        raise ReconciliationBlocked("fixed mutation lock has unsafe metadata")
     try:
         fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError as error:
         os.close(descriptor)
-        raise ReconciliationBlocked("another dev backend mutation holds the lock") from error
+        raise ReconciliationBlocked("another backend mutation holds the lock") from error
     return descriptor
 
 
@@ -373,16 +420,16 @@ def committed_graph(repo: Path, allowlisted_revisions: set[str]) -> dict[str, An
 
 
 def _live_database_revisions(repo: Path) -> list[str]:
-    probe = """
+    probe = f"""
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import make_url
 from app.config import Config
 url = make_url(Config.SQLALCHEMY_DATABASE_URI)
-if url.get_backend_name() != 'postgresql' or url.database != 'dev_unikorn':
+if url.get_backend_name() != 'postgresql' or url.database != {EXPECTED_DATABASE!r}:
     raise SystemExit(23)
 engine = create_engine(Config.SQLALCHEMY_DATABASE_URI, **Config.SQLALCHEMY_ENGINE_OPTIONS)
 with engine.connect() as connection:
-    if connection.execute(text('SELECT current_database()')).scalar_one() != 'dev_unikorn':
+    if connection.execute(text('SELECT current_database()')).scalar_one() != {EXPECTED_DATABASE!r}:
         raise SystemExit(24)
     revisions = connection.execute(
         text('SELECT version_num FROM alembic_version ORDER BY version_num')
@@ -411,24 +458,26 @@ for revision in revisions:
         timeout=30,
     )
     if result.returncode:
-        raise ReconciliationBlocked("read-only dev Alembic revision probe failed")
+        raise ReconciliationBlocked("read-only Alembic revision probe failed")
     revisions = result.stdout.splitlines()
     if not revisions:
-        raise ReconciliationBlocked("dev Alembic version table returned no current revisions")
+        raise ReconciliationBlocked("Alembic version table returned no current revisions")
     for revision in revisions:
-        _validate_revision(revision, "dev alembic_version")
+        _validate_revision(revision, f"{TARGET_NAME} alembic_version")
     return sorted(set(revisions))
 
 
 def audit(repo: Path, *, live_revisions: list[str] | None = None) -> dict[str, Any]:
     if repo != APP_DIR or repo.is_symlink() or repo.resolve() != APP_DIR:
-        raise ReconciliationBlocked("repository path is not the fixed dev checkout")
+        raise ReconciliationBlocked("repository path is not the fixed target checkout")
     if not (repo / ".git").exists():
-        raise ReconciliationBlocked("fixed dev checkout is not a git worktree")
+        raise ReconciliationBlocked("fixed target checkout is not a git worktree")
     if _git(repo, "rev-parse", "--show-toplevel") != str(repo.resolve()):
-        raise ReconciliationBlocked("git toplevel does not match the fixed dev checkout")
+        raise ReconciliationBlocked("git toplevel does not match the fixed target checkout")
     if _git(repo, "symbolic-ref", "--short", "HEAD") != EXPECTED_BRANCH:
-        raise ReconciliationBlocked("fixed dev checkout is not on main")
+        raise ReconciliationBlocked(
+            f"fixed target checkout is not on {EXPECTED_BRANCH}"
+        )
     _exact_untracked_allowlist(repo)
     files = [_inspect_file(repo / path, path) for path in ALLOWLIST]
     revisions = [entry["revision"] for entry in files]
@@ -440,14 +489,15 @@ def audit(repo: Path, *, live_revisions: list[str] | None = None) -> dict[str, A
     )
     current_revisions = sorted(set(current_revisions))
     for revision in current_revisions:
-        _validate_revision(revision, "dev alembic_version")
+        _validate_revision(revision, f"{TARGET_NAME} alembic_version")
     current_allowlisted = sorted(set(revisions) & set(current_revisions))
+    committed_duplicates = sorted(set(revisions) & set(graph["revisions"]))
     current_unknown = sorted(
         set(current_revisions) - set(graph["revisions"]) - set(revisions)
     )
     context = {
         "schema_version": 1,
-        "target": "dev",
+        "target": TARGET_NAME,
         "repository": str(APP_DIR),
         "branch": EXPECTED_BRANCH,
         "repository_sha": _git(repo, "rev-parse", "HEAD"),
@@ -457,6 +507,7 @@ def audit(repo: Path, *, live_revisions: list[str] | None = None) -> dict[str, A
         "live_current_unknown_revisions": current_unknown,
         "committed_revisions": graph["revisions"],
         "committed_heads": graph["heads"],
+        "committed_allowlisted_revision_duplicates": committed_duplicates,
         "committed_allowlisted_revision_references": graph[
             "allowlisted_revision_references"
         ],
@@ -663,9 +714,13 @@ def apply(
     before = audit(repo)
     if before["aggregate_sha256"] != expected_digest:
         raise ReconciliationBlocked("current aggregate digest does not match the reviewed audit")
+    if before["committed_allowlisted_revision_duplicates"]:
+        raise ReconciliationBlocked(
+            "an allowlisted file duplicates a committed migration revision"
+        )
     if before["live_current_allowlisted_revisions"]:
         raise ReconciliationBlocked(
-            "live dev database still identifies an allowlisted migration as current"
+            f"live {TARGET_NAME} database still identifies an allowlisted migration as current"
         )
     if before["committed_allowlisted_revision_referenced"]:
         raise ReconciliationBlocked(
@@ -673,7 +728,7 @@ def apply(
         )
     if before["live_current_unknown_revisions"]:
         raise ReconciliationBlocked(
-            "live dev database has a current revision outside the committed and allowlisted graphs"
+            f"live {TARGET_NAME} database has a current revision outside the committed and allowlisted graphs"
         )
 
     destination = _validate_quarantine_target(
@@ -918,6 +973,7 @@ def apply(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True, choices=tuple(TARGETS))
     parser.add_argument("--mode", required=True, choices=("audit", "apply"))
     parser.add_argument("--expected-aggregate-sha256", default="")
     parser.add_argument("--confirmation", default="")
@@ -929,6 +985,7 @@ def main() -> int:
     arguments = build_parser().parse_args()
     lock_descriptor: int | None = None
     try:
+        configure_target(arguments.target)
         lock_descriptor = _acquire_lock()
         if arguments.mode == "audit":
             if any(


### PR DESCRIPTION
## Summary
- add protected two-phase production migration checkout audit/quarantine
- fail closed on scheduler campaign cutoff epochs and normalize timer timestamps to UTC
- share a durable validated production mutation lock between reconciliation and deployment

## Validation
- 587 passed, 6 skipped
- focused reconciliation/deployment tests: 52 passed
- YAML parse and git diff checks clean

No production mutation is automatic: audit and apply remain separate manual protected-environment workflows.