### PR TITLE
Report production Git metadata safely

### DIFF
--- a/.github/workflows/backend-operations.yml
+++ b/.github/workflows/backend-operations.yml
@@ -334,10 +334,17 @@ jobs:
               echo "Production Git directory is not the fixed real directory." >&2
               exit 1
             fi
-            git_owner="$(stat -c '%u' "${production_git_dir}")"
-            git_mode="$(stat -c '%a' "${production_git_dir}")"
-            if [[ "${git_owner}" != "$(id -u)" || $((8#${git_mode} & 022)) -ne 0 ]]; then
-              echo "Production Git directory has unsafe metadata." >&2
+            IFS=: read -r git_owner git_group git_mode < <(
+              stat -c '%u:%g:%a' "${production_git_dir}"
+            )
+            effective_uid="$(id -u)"
+            effective_gid="$(id -g)"
+            if [[ "${git_owner}" != "${effective_uid}" || $((8#${git_mode} & 022)) -ne 0 ]]; then
+              printf \
+                'Production Git directory has unsafe metadata: %s (owner_uid=%s, effective_uid=%s, group_gid=%s, effective_gid=%s, mode=%04o, required_owner_uid=%s, forbidden_write_bits=0022).\n' \
+                "${production_git_dir}" "${git_owner}" "${effective_uid}" \
+                "${git_group}" "${effective_gid}" "$((8#${git_mode}))" \
+                "${effective_uid}" >&2
               exit 1
             fi
             umask 077

--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -430,10 +430,17 @@ jobs:
             echo "Production Git directory is not the fixed real directory." >&2
             exit 1
           fi
-          git_owner="$(stat -c '%u' "${production_git_dir}")"
-          git_mode="$(stat -c '%a' "${production_git_dir}")"
-          if [[ "${git_owner}" != "$(id -u)" || $((8#${git_mode} & 022)) -ne 0 ]]; then
-            echo "Production Git directory has unsafe metadata." >&2
+          IFS=: read -r git_owner git_group git_mode < <(
+            stat -c '%u:%g:%a' "${production_git_dir}"
+          )
+          effective_uid="$(id -u)"
+          effective_gid="$(id -g)"
+          if [[ "${git_owner}" != "${effective_uid}" || $((8#${git_mode} & 022)) -ne 0 ]]; then
+            printf \
+              'Production Git directory has unsafe metadata: %s (owner_uid=%s, effective_uid=%s, group_gid=%s, effective_gid=%s, mode=%04o, required_owner_uid=%s, forbidden_write_bits=0022).\n' \
+              "${production_git_dir}" "${git_owner}" "${effective_uid}" \
+              "${git_group}" "${effective_gid}" "$((8#${git_mode}))" \
+              "${effective_uid}" >&2
             exit 1
           fi
           umask 077

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -903,6 +903,8 @@ def test_operation_workflow_is_a_hardened_dispatch_api():
     assert "test \"$(git rev-parse HEAD)\" = \"$OPS_RELEASE_SHA\"" in workflow
     assert "flock -n 9" in workflow
     assert 'readonly production_ops_dir="${production_git_dir}/unikorn-operations"' in workflow
+    assert "owner_uid=%s, effective_uid=%s, group_gid=%s, effective_gid=%s" in workflow
+    assert "forbidden_write_bits=0022" in workflow
     assert 'readonly production_lock_path="${production_ops_dir}/backend-mutations.lock"' in workflow
     assert "git rev-parse --absolute-git-dir" in workflow
     assert "/tmp/unikorn-backend-mutation-production.lock" not in workflow

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -318,6 +318,8 @@ def test_production_migration_checkout_reconciliation_is_two_phase_and_fixed_sco
     assert "expected_lock_safety" in deploy_workflow
     assert '[[ -L "${production_lock_path}"' in deploy_workflow
     assert '-L "${production_git_dir}"' in deploy_workflow
+    assert "owner_uid=%s, effective_uid=%s, group_gid=%s, effective_gid=%s" in deploy_workflow
+    assert "forbidden_write_bits=0022" in deploy_workflow
     assert '-L "${production_ops_dir}"' in deploy_workflow
     assert "verify-transactions" in deploy_workflow
     assert "UNIKORN_BACKEND_MUTATION_LOCK_FD=9" in deploy_workflow

--- a/tests/test_reconcile_dev_migration_checkout.py
+++ b/tests/test_reconcile_dev_migration_checkout.py
@@ -695,6 +695,34 @@ def test_production_audit_rejects_group_or_world_writable_allowlisted_file(
         reconciliation.audit(repository)
 
 
+def test_production_lock_parent_reports_unsafe_git_metadata_without_mutation(
+    tmp_path, monkeypatch
+):
+    repository, _quarantine, _payloads = _checkout(tmp_path, monkeypatch)
+    operations = repository / ".git" / "unikorn-operations"
+    monkeypatch.setattr(reconciliation, "TARGET_NAME", "production")
+    monkeypatch.setattr(reconciliation, "APP_DIR", repository)
+    monkeypatch.setattr(
+        reconciliation,
+        "LOCK_PATH",
+        operations / "backend-mutations.lock",
+    )
+    os.chmod(repository / ".git", 0o775)
+    git_details = (repository / ".git").stat()
+
+    with pytest.raises(reconciliation.ReconciliationBlocked) as caught:
+        reconciliation._open_lock_parent()
+
+    assert str(caught.value) == (
+        "production Git directory has unsafe metadata: "
+        f"{repository / '.git'} (owner_uid={git_details.st_uid}, "
+        f"effective_uid={os.geteuid()}, group_gid={git_details.st_gid}, "
+        f"effective_gid={os.getegid()}, mode=0775, "
+        f"required_owner_uid={os.geteuid()}, forbidden_write_bits=0022)"
+    )
+    assert not operations.exists()
+
+
 @pytest.mark.parametrize("tamper", ["prepared", "payload", "extra", "symlink"])
 def test_production_transaction_guard_blocks_tampering(tmp_path, monkeypatch, tamper):
     transaction, archived = _configure_production_transaction_fixture(

--- a/tools/reconcile_dev_migration_checkout.py
+++ b/tools/reconcile_dev_migration_checkout.py
@@ -183,7 +183,14 @@ def _open_lock_parent() -> int:
         or git_details.st_mode & 0o022
     ):
         os.close(git_fd)
-        raise ReconciliationBlocked("production Git directory has unsafe metadata")
+        raise ReconciliationBlocked(
+            "production Git directory has unsafe metadata: "
+            f"{APP_DIR / '.git'} (owner_uid={git_details.st_uid}, "
+            f"effective_uid={os.geteuid()}, group_gid={git_details.st_gid}, "
+            f"effective_gid={os.getegid()}, "
+            f"mode={stat.S_IMODE(git_details.st_mode):04o}, "
+            f"required_owner_uid={os.geteuid()}, forbidden_write_bits=0022)"
+        )
     source_parent_fd, _source_parent_identity = _open_source_parent(APP_DIR)
     source_parent_details = os.fstat(source_parent_fd)
     os.close(source_parent_fd)


### PR DESCRIPTION
## Summary
- preserve the fail-closed production Git-directory policy
- report only numeric UID/GID/mode facts needed for a safe host remediation
- prove an unsafe directory creates neither the operations root nor lock

## Validation
- 35 reconciliation tests passed
- 58 workflow/operations tests passed
- git diff --check
