### PR TITLE
Audit production storage trust boundaries

### DIFF
--- a/.github/workflows/audit-prod-storage.yml
+++ b/.github/workflows/audit-prod-storage.yml
@@ -1,0 +1,67 @@
+name: Audit Production Storage
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-mutations-production
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit fixed production storage hierarchy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: Require a fixed production request from main
+        run: test "$GITHUB_REF" = "refs/heads/main"
+
+      - name: Checkout reviewed helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Encode reviewed helper
+        id: helper
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sha256="$(sha256sum tools/audit_prod_storage.py | cut -d ' ' -f 1)"
+          gzip -n -9 -c tools/audit_prod_storage.py > /tmp/audit-prod-storage.py.gz
+          payload="$(base64 -w 0 /tmp/audit-prod-storage.py.gz)"
+          rm -f /tmp/audit-prod-storage.py.gz
+          printf 'sha256=%s\n' "$sha256" >> "$GITHUB_OUTPUT"
+          printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
+
+      - name: Audit exact production storage hierarchy
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          AUDIT_HELPER_SHA256: ${{ steps.helper.outputs.sha256 }}
+          AUDIT_HELPER_GZIP_B64: ${{ steps.helper.outputs.payload }}
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          command_timeout: 5m
+          envs: AUDIT_HELPER_SHA256,AUDIT_HELPER_GZIP_B64
+          script: |
+            set -Eeuo pipefail
+            helper="$(mktemp)"
+            trap 'rm -f "$helper"' EXIT
+            printf '%s' "$AUDIT_HELPER_GZIP_B64" | base64 --decode | gzip -d >"$helper"
+            test "$(sha256sum "$helper" | cut -d ' ' -f 1)" = "$AUDIT_HELPER_SHA256"
+            chmod 0500 "$helper"
+            python3 -I "$helper"
+            effective_identity="$(id -u):$(id -g)"
+            for request in \
+              "/usr/bin/chmod 1777 -- /data" \
+              "/usr/bin/chown ${effective_identity} -- /data/prod_unikorn" \
+              "/usr/bin/chmod 0755 -- /data/prod_unikorn"; do
+              if /usr/bin/sudo -n -l ${request} >/dev/null 2>&1; then
+                printf 'sudo_permission=allowed command=%s\n' "$request"
+              else
+                printf 'sudo_permission=denied command=%s\n' "$request"
+              fi
+            done

--- a/tests/test_audit_prod_storage.py
+++ b/tests/test_audit_prod_storage.py
@@ -1,0 +1,198 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from tools import audit_prod_storage as storage_audit
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _fixture(tmp_path: Path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir(mode=0o755)
+    data = root / storage_audit.DATA_NAME
+    data.mkdir(mode=0o777)
+    production = data / storage_audit.PRODUCTION_NAME
+    production.mkdir(mode=0o775)
+    repository = production / storage_audit.APP_NAME
+    repository.mkdir(mode=0o775)
+    _git(repository, "init", "--quiet", "--initial-branch=production")
+    _git(repository, "config", "user.name", "Production Storage Audit Test")
+    _git(repository, "config", "user.email", "audit@example.test")
+    migration = (
+        repository
+        / storage_audit.MIGRATIONS_NAME
+        / storage_audit.VERSIONS_NAME
+        / storage_audit.LEGACY_MIGRATION_NAME
+    )
+    migration.parent.mkdir(parents=True)
+    (repository / "README.md").write_text("tracked\n", encoding="utf-8")
+    _git(repository, "add", "README.md")
+    _git(repository, "commit", "--quiet", "-m", "initial")
+    migration.write_text("revision = 'legacy'\n", encoding="utf-8")
+    (repository / ".git").chmod(0o775)
+    for name in storage_audit.OPTIONAL_PRODUCTION_CHILDREN[:2]:
+        (production / name).mkdir(mode=0o755)
+
+    monkeypatch.setattr(storage_audit, "ROOT_PATH", root)
+    monkeypatch.setattr(storage_audit, "EXPECTED_APP_DIR", repository)
+    return root, data, production, repository, migration
+
+
+def test_audit_reports_complete_bound_hierarchy_and_digest(tmp_path, monkeypatch):
+    root, data, production, repository, migration = _fixture(tmp_path, monkeypatch)
+
+    result = storage_audit.audit()
+
+    context = {
+        key: value
+        for key, value in result.items()
+        if key not in {"aggregate_sha256", "status"}
+    }
+    assert result["aggregate_sha256"] == hashlib.sha256(
+        json.dumps(
+            context,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    assert result["status"] == "audited"
+    assert result["effective_uid"] == os.geteuid()
+    assert result["effective_gid"] == os.getegid()
+    assert result["branch"] == "production"
+    assert result["head_sha"] == _git(repository, "rev-parse", "HEAD")
+    assert result["branch"] == "production"
+    assert result["legacy_migration"]["sha256"] == hashlib.sha256(
+        migration.read_bytes()
+    ).hexdigest()
+    assert result["same_device"] is True
+    hierarchy = result["hierarchy"]
+    assert hierarchy["filesystem root"]["inode"] == root.stat().st_ino
+    assert hierarchy["data container"]["mode"] == "0755"
+    assert hierarchy["production data parent"]["inode"] == production.stat().st_ino
+    assert hierarchy["backend checkout"]["inode"] == repository.stat().st_ino
+    assert hierarchy["backend Git directory"]["mode"] == "0775"
+    assert hierarchy["migration versions directory"]["inode"] == migration.parent.stat().st_ino
+    assert [entry["status"] for entry in result["optional_children"]] == [
+        "present",
+        "present",
+        "absent",
+        "absent",
+    ]
+
+
+def test_audit_rejects_symlinked_fixed_components(tmp_path, monkeypatch):
+    _root, _data, production, repository, _migration = _fixture(tmp_path, monkeypatch)
+    real_git = repository / ".git-real"
+    (repository / ".git").rename(real_git)
+    (repository / ".git").symlink_to(real_git, target_is_directory=True)
+
+    with pytest.raises(storage_audit.AuditBlocked, match="Git directory"):
+        storage_audit.audit()
+
+    (repository / ".git").unlink()
+    real_git.rename(repository / ".git")
+    real_frontend = production / "front-end-real"
+    (production / "front-end").rename(real_frontend)
+    (production / "front-end").symlink_to(real_frontend, target_is_directory=True)
+    with pytest.raises(storage_audit.AuditBlocked, match="optional fixed child"):
+        storage_audit.audit()
+
+
+def test_audit_rejects_wrong_branch_or_dirty_state(tmp_path, monkeypatch):
+    _root, _data, _production, repository, migration = _fixture(tmp_path, monkeypatch)
+    _git(repository, "checkout", "-q", "-b", "not-production")
+    with pytest.raises(storage_audit.AuditBlocked, match="production branch"):
+        storage_audit.audit()
+
+    _git(repository, "checkout", "-q", "production")
+    migration.unlink()
+    with pytest.raises(storage_audit.AuditBlocked, match="cannot safely open fixed file"):
+        storage_audit.audit()
+
+
+def test_audit_never_invokes_git_or_changes_index(tmp_path, monkeypatch):
+    _root, _data, _production, repository, _migration = _fixture(tmp_path, monkeypatch)
+    expected_head = _git(repository, "rev-parse", "HEAD")
+    index = repository / ".git" / "index"
+    before = (index.stat().st_mtime_ns, hashlib.sha256(index.read_bytes()).hexdigest())
+    monkeypatch.setenv("GIT_DIR", str(tmp_path / "attacker-git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "attacker-tree"))
+    monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "'core.fsmonitor=!false'")
+
+    assert storage_audit.audit()["head_sha"] == expected_head
+    after = (index.stat().st_mtime_ns, hashlib.sha256(index.read_bytes()).hexdigest())
+    assert after == before
+    assert "subprocess" not in Path(storage_audit.__file__).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("race", ["present", "absent"])
+def test_audit_rejects_optional_child_changes_before_digest(
+    tmp_path, monkeypatch, race
+):
+    _root, _data, production, _repository, _migration = _fixture(tmp_path, monkeypatch)
+
+    def change_optional_state(point, _context):
+        if point != "before_final_revalidation":
+            return
+        if race == "present":
+            current = production / "backups"
+            current.rename(production / "backups-original")
+            current.mkdir(mode=0o755)
+        else:
+            (production / "operation-reports").mkdir(mode=0o755)
+
+    monkeypatch.setattr(storage_audit, "FAILURE_INJECTOR", change_optional_state)
+    with pytest.raises(storage_audit.AuditBlocked, match="optional child"):
+        storage_audit.audit()
+
+
+def test_audit_rejects_control_file_content_change_before_digest(
+    tmp_path, monkeypatch
+):
+    _root, _data, _production, repository, _migration = _fixture(tmp_path, monkeypatch)
+    production_ref = repository / ".git" / "refs" / "heads" / "production"
+    initial = production_ref.read_text(encoding="ascii")
+
+    def change_ref(point, _context):
+        if point == "before_final_revalidation":
+            production_ref.write_text("f" * 40 + "\n", encoding="ascii")
+
+    monkeypatch.setattr(storage_audit, "FAILURE_INJECTOR", change_ref)
+    with pytest.raises(storage_audit.AuditBlocked, match="fixed file changed"):
+        storage_audit.audit()
+    assert initial != production_ref.read_text(encoding="ascii")
+
+
+def test_workflow_is_read_only_fixed_and_serialized():
+    workflow = Path(".github/workflows/audit-prod-storage.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "group: backend-mutations-production" in workflow
+    assert "environment: production" in workflow
+    assert 'test "$GITHUB_REF" = "refs/heads/main"' in workflow
+    assert "tools/audit_prod_storage.py" in workflow
+    assert "secrets.PROD_SSH_HOST" in workflow
+    assert "secrets.PROD_SSH_USER" in workflow
+    assert "secrets.PROD_SSH_KEY" in workflow
+    assert "chmod 0500" in workflow
+    assert "/usr/bin/sudo -n -l" in workflow
+    assert "/usr/bin/chmod 1777 -- /data" in workflow
+    assert "/usr/bin/chown ${effective_identity} -- /data/prod_unikorn" in workflow
+    assert "sudo -n /usr/bin/chmod" not in workflow
+    assert "sudo -n /usr/bin/chown" not in workflow

--- a/tools/audit_prod_storage.py
+++ b/tools/audit_prod_storage.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Read-only, descriptor-bound audit of the fixed production storage hierarchy."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+from typing import Any
+
+
+ROOT_PATH = Path("/")
+DATA_NAME = "data"
+PRODUCTION_NAME = "prod_unikorn"
+APP_NAME = "back-end"
+GIT_NAME = ".git"
+MIGRATIONS_NAME = "migrations"
+VERSIONS_NAME = "versions"
+EXPECTED_APP_DIR = Path("/data/prod_unikorn/back-end")
+EXPECTED_HEAD = b"ref: refs/heads/production\n"
+PRODUCTION_REF_NAME = "production"
+LEGACY_MIGRATION_NAME = "000000000000_create_oauth_tables.py"
+GIT_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+OPTIONAL_PRODUCTION_CHILDREN = (
+    "backups",
+    "front-end",
+    "operation-reports",
+    "scheduler-popularity-releases",
+)
+MAX_CONTROL_FILE_BYTES = 4096
+MAX_MIGRATION_BYTES = 1_048_576
+FAILURE_INJECTOR = None
+
+
+class AuditBlocked(RuntimeError):
+    """The fixed hierarchy could not be inspected without ambiguity."""
+
+
+def _failure_point(name: str, context: dict[str, Any] | None = None) -> None:
+    if FAILURE_INJECTOR is not None:
+        FAILURE_INJECTOR(name, context or {})
+
+
+def _identity(details: os.stat_result) -> tuple[int, int]:
+    return details.st_dev, details.st_ino
+
+
+def _metadata(details: os.stat_result, path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "device": details.st_dev,
+        "inode": details.st_ino,
+        "owner_uid": details.st_uid,
+        "group_gid": details.st_gid,
+        "mode": f"{stat.S_IMODE(details.st_mode):04o}",
+    }
+
+
+def _open_directory_path(path: Path, description: str) -> int:
+    try:
+        return os.open(
+            path,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        )
+    except OSError as error:
+        raise AuditBlocked(f"cannot safely open fixed {description}") from error
+
+
+def _open_child(parent_fd: int, name: str, description: str) -> int:
+    try:
+        return os.open(
+            name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except OSError as error:
+        raise AuditBlocked(f"cannot safely open fixed {description}") from error
+
+
+def _bound_stat(parent_fd: int, name: str, description: str) -> os.stat_result:
+    try:
+        details = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as error:
+        raise AuditBlocked(f"cannot revalidate fixed {description}") from error
+    if not stat.S_ISDIR(details.st_mode):
+        raise AuditBlocked(f"fixed {description} is not a real directory")
+    return details
+
+
+def _open_optional_child(
+    parent_fd: int,
+    name: str,
+    path: Path,
+) -> tuple[int | None, dict[str, Any]]:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except FileNotFoundError:
+        return None, {"path": str(path), "status": "absent"}
+    except OSError as error:
+        raise AuditBlocked(f"cannot safely open optional fixed child {path}") from error
+    details = os.fstat(descriptor)
+    bound = _bound_stat(parent_fd, name, f"optional child {path}")
+    if _identity(details) != _identity(bound):
+        os.close(descriptor)
+        raise AuditBlocked(f"optional child identity changed: {path}")
+    return descriptor, {**_metadata(details, path), "status": "present"}
+
+
+def _open_bound_file(
+    parent_fd: int,
+    name: str,
+    path: Path,
+    *,
+    max_bytes: int,
+) -> tuple[int, os.stat_result, bytes, dict[str, Any]]:
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except OSError as error:
+        raise AuditBlocked(f"cannot safely open fixed file {path}") from error
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size > max_bytes
+        ):
+            raise AuditBlocked(f"fixed file has unsafe metadata: {path}")
+        payload = os.read(descriptor, max_bytes + 1)
+        after = os.fstat(descriptor)
+        bound = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            len(payload) != before.st_size
+            or _identity(before) != _identity(after)
+            or _identity(before) != _identity(bound)
+            or before.st_size != after.st_size
+            or before.st_mtime_ns != after.st_mtime_ns
+            or not stat.S_ISREG(bound.st_mode)
+        ):
+            raise AuditBlocked(f"fixed file changed while reading: {path}")
+        record = {
+            **_metadata(before, path),
+            "size": before.st_size,
+            "nlink": before.st_nlink,
+            "mtime_ns": before.st_mtime_ns,
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+        return descriptor, before, payload, record
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _revalidate_bound_file(
+    parent_fd: int,
+    name: str,
+    descriptor: int,
+    initial: os.stat_result,
+    record: dict[str, Any],
+) -> None:
+    before = os.fstat(descriptor)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    payload = os.read(descriptor, record["size"] + 1)
+    after = os.fstat(descriptor)
+    try:
+        bound = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as error:
+        raise AuditBlocked(f"cannot revalidate fixed file {record['path']}") from error
+    current_record = {
+        **_metadata(after, Path(record["path"])),
+        "size": after.st_size,
+        "nlink": after.st_nlink,
+        "mtime_ns": after.st_mtime_ns,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or not stat.S_ISREG(after.st_mode)
+        or not stat.S_ISREG(bound.st_mode)
+        or _identity(before) != _identity(initial)
+        or _identity(after) != _identity(initial)
+        or _identity(bound) != _identity(initial)
+        or len(payload) != record["size"]
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or current_record != record
+    ):
+        raise AuditBlocked(f"fixed file changed during audit: {record['path']}")
+
+
+def _open_git_control_files(
+    git_fd: int,
+    versions_fd: int,
+) -> tuple[
+    list[int],
+    list[tuple[int, str, int, os.stat_result, dict[str, Any]]],
+    list[tuple[int, str, int, os.stat_result, dict[str, Any]]],
+    dict[str, Any],
+]:
+    descriptors: list[int] = []
+    directories: list[tuple[int, str, int, os.stat_result, dict[str, Any]]] = []
+    files: list[tuple[int, str, int, os.stat_result, dict[str, Any]]] = []
+    try:
+        head_fd, head_details, head_payload, head_record = _open_bound_file(
+            git_fd,
+            "HEAD",
+            EXPECTED_APP_DIR / GIT_NAME / "HEAD",
+            max_bytes=MAX_CONTROL_FILE_BYTES,
+        )
+        descriptors.append(head_fd)
+        files.append((git_fd, "HEAD", head_fd, head_details, head_record))
+        if head_payload != EXPECTED_HEAD:
+            raise AuditBlocked("production Git HEAD is not the production branch")
+
+        refs_fd = _open_child(git_fd, "refs", "Git refs directory")
+        descriptors.append(refs_fd)
+        refs_details = os.fstat(refs_fd)
+        refs_record = _metadata(
+            refs_details,
+            EXPECTED_APP_DIR / GIT_NAME / "refs",
+        )
+        directories.append((git_fd, "refs", refs_fd, refs_details, refs_record))
+        heads_fd = _open_child(refs_fd, "heads", "Git heads directory")
+        descriptors.append(heads_fd)
+        heads_details = os.fstat(heads_fd)
+        heads_record = _metadata(
+            heads_details,
+            EXPECTED_APP_DIR / GIT_NAME / "refs" / "heads",
+        )
+        directories.append(
+            (refs_fd, "heads", heads_fd, heads_details, heads_record)
+        )
+        ref_fd, ref_details, ref_payload, ref_record = _open_bound_file(
+            heads_fd,
+            PRODUCTION_REF_NAME,
+            EXPECTED_APP_DIR / GIT_NAME / "refs" / "heads" / PRODUCTION_REF_NAME,
+            max_bytes=MAX_CONTROL_FILE_BYTES,
+        )
+        descriptors.append(ref_fd)
+        files.append(
+            (
+                heads_fd,
+                PRODUCTION_REF_NAME,
+                ref_fd,
+                ref_details,
+                ref_record,
+            )
+        )
+        try:
+            head_sha = ref_payload.decode("ascii").rstrip("\n")
+        except UnicodeDecodeError as error:
+            raise AuditBlocked("production Git ref is not ASCII") from error
+        if ref_payload != f"{head_sha}\n".encode("ascii") or not GIT_SHA_RE.fullmatch(
+            head_sha
+        ):
+            raise AuditBlocked("production Git ref is not an exact SHA")
+
+        migration_fd, migration_details, _migration_payload, migration_record = (
+            _open_bound_file(
+                versions_fd,
+                LEGACY_MIGRATION_NAME,
+                EXPECTED_APP_DIR
+                / MIGRATIONS_NAME
+                / VERSIONS_NAME
+                / LEGACY_MIGRATION_NAME,
+                max_bytes=MAX_MIGRATION_BYTES,
+            )
+        )
+        descriptors.append(migration_fd)
+        files.append(
+            (
+                versions_fd,
+                LEGACY_MIGRATION_NAME,
+                migration_fd,
+                migration_details,
+                migration_record,
+            )
+        )
+        return descriptors, directories, files, {
+            "branch": "production",
+            "head_sha": head_sha,
+            "git_control_directories": [refs_record, heads_record],
+            "git_control_files": [head_record, ref_record],
+            "legacy_migration": migration_record,
+        }
+    except Exception:
+        _close_all(*descriptors)
+        raise
+
+
+def _close_all(*descriptors: int | None) -> None:
+    for descriptor in reversed(descriptors):
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def audit() -> dict[str, Any]:
+    root_fd = _open_directory_path(ROOT_PATH, "filesystem root")
+    data_fd = production_fd = app_fd = git_fd = migrations_fd = versions_fd = None
+    optional_states: list[tuple[str, int | None, dict[str, Any]]] = []
+    control_descriptors: list[int] = []
+    control_directories: list[
+        tuple[int, str, int, os.stat_result, dict[str, Any]]
+    ] = []
+    control_files: list[tuple[int, str, int, os.stat_result, dict[str, Any]]] = []
+    try:
+        data_fd = _open_child(root_fd, DATA_NAME, "data container")
+        production_fd = _open_child(
+            data_fd, PRODUCTION_NAME, "production data parent"
+        )
+        app_fd = _open_child(production_fd, APP_NAME, "backend checkout")
+        git_fd = _open_child(app_fd, GIT_NAME, "backend Git directory")
+        migrations_fd = _open_child(app_fd, MIGRATIONS_NAME, "migrations directory")
+        versions_fd = _open_child(
+            migrations_fd, VERSIONS_NAME, "migration versions directory"
+        )
+
+        fixed = [
+            (root_fd, None, None, ROOT_PATH, "filesystem root"),
+            (data_fd, root_fd, DATA_NAME, ROOT_PATH / DATA_NAME, "data container"),
+            (
+                production_fd,
+                data_fd,
+                PRODUCTION_NAME,
+                ROOT_PATH / DATA_NAME / PRODUCTION_NAME,
+                "production data parent",
+            ),
+            (
+                app_fd,
+                production_fd,
+                APP_NAME,
+                EXPECTED_APP_DIR,
+                "backend checkout",
+            ),
+            (
+                git_fd,
+                app_fd,
+                GIT_NAME,
+                EXPECTED_APP_DIR / GIT_NAME,
+                "backend Git directory",
+            ),
+            (
+                migrations_fd,
+                app_fd,
+                MIGRATIONS_NAME,
+                EXPECTED_APP_DIR / MIGRATIONS_NAME,
+                "migrations directory",
+            ),
+            (
+                versions_fd,
+                migrations_fd,
+                VERSIONS_NAME,
+                EXPECTED_APP_DIR / MIGRATIONS_NAME / VERSIONS_NAME,
+                "migration versions directory",
+            ),
+        ]
+        identities: dict[str, tuple[int, int]] = {}
+        hierarchy: dict[str, dict[str, Any]] = {}
+        for descriptor, parent_fd, name, path, description in fixed:
+            details = os.fstat(descriptor)
+            if not stat.S_ISDIR(details.st_mode):
+                raise AuditBlocked(f"fixed {description} is not a directory")
+            if parent_fd is None:
+                bound = os.stat(ROOT_PATH, follow_symlinks=False)
+            else:
+                bound = _bound_stat(parent_fd, name, description)
+            if _identity(details) != _identity(bound):
+                raise AuditBlocked(f"fixed {description} identity changed")
+            identities[description] = _identity(details)
+            hierarchy[description] = _metadata(details, path)
+
+        optional_children = []
+        production_path = ROOT_PATH / DATA_NAME / PRODUCTION_NAME
+        for name in OPTIONAL_PRODUCTION_CHILDREN:
+            descriptor, record = _open_optional_child(
+                production_fd,
+                name,
+                production_path / name,
+            )
+            if descriptor is not None:
+                pass
+            optional_states.append((name, descriptor, record))
+            optional_children.append(record)
+
+        (
+            control_descriptors,
+            control_directories,
+            control_files,
+            git_context,
+        ) = _open_git_control_files(git_fd, versions_fd)
+
+        context = {
+            "schema_version": 1,
+            "target": "production",
+            "effective_uid": os.geteuid(),
+            "effective_gid": os.getegid(),
+            "hierarchy": hierarchy,
+            "optional_children": optional_children,
+            "same_device": len(
+                {record["device"] for record in hierarchy.values()}
+            )
+            == 1,
+            "helper_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+            **git_context,
+        }
+
+        _failure_point("before_final_revalidation", {})
+        for descriptor, parent_fd, name, _path, description in fixed:
+            details = os.fstat(descriptor)
+            if parent_fd is None:
+                bound = os.stat(ROOT_PATH, follow_symlinks=False)
+            else:
+                bound = _bound_stat(parent_fd, name, description)
+            if (
+                _identity(details) != identities[description]
+                or _identity(bound) != identities[description]
+                or _metadata(details, hierarchy[description]["path"])
+                != hierarchy[description]
+                or _metadata(bound, hierarchy[description]["path"])
+                != hierarchy[description]
+            ):
+                raise AuditBlocked(f"fixed {description} changed during audit")
+
+        for name, descriptor, record in optional_states:
+            if descriptor is None:
+                try:
+                    os.stat(name, dir_fd=production_fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    continue
+                except OSError as error:
+                    raise AuditBlocked(
+                        f"cannot revalidate absent optional child {record['path']}"
+                    ) from error
+                raise AuditBlocked(
+                    f"absent optional child appeared during audit: {record['path']}"
+                )
+            details = os.fstat(descriptor)
+            bound = _bound_stat(
+                production_fd,
+                name,
+                f"optional child {record['path']}",
+            )
+            expected = {key: value for key, value in record.items() if key != "status"}
+            if (
+                _metadata(details, Path(record["path"])) != expected
+                or _metadata(bound, Path(record["path"])) != expected
+            ):
+                raise AuditBlocked(
+                    f"optional child changed during audit: {record['path']}"
+                )
+
+        for parent_fd, name, descriptor, initial, record in control_files:
+            _revalidate_bound_file(
+                parent_fd,
+                name,
+                descriptor,
+                initial,
+                record,
+            )
+
+        for parent_fd, name, descriptor, initial, record in control_directories:
+            current = os.fstat(descriptor)
+            bound = _bound_stat(parent_fd, name, f"control directory {record['path']}")
+            if (
+                _identity(current) != _identity(initial)
+                or _identity(bound) != _identity(initial)
+                or _metadata(current, Path(record["path"])) != record
+                or _metadata(bound, Path(record["path"])) != record
+            ):
+                raise AuditBlocked(
+                    f"Git control directory changed during audit: {record['path']}"
+                )
+
+        payload = json.dumps(
+            context,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return {
+            **context,
+            "aggregate_sha256": hashlib.sha256(payload).hexdigest(),
+            "status": "audited",
+        }
+    finally:
+        _close_all(
+            *(descriptor for _name, descriptor, _record in optional_states),
+            *control_descriptors,
+            root_fd,
+            data_fd,
+            production_fd,
+            app_fd,
+            git_fd,
+            migrations_fd,
+            versions_fd,
+        )
+
+
+def main() -> int:
+    try:
+        result = audit()
+    except AuditBlocked as error:
+        print(f"production storage audit blocked: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a read-only, descriptor-bound production storage hierarchy audit
- record numeric ownership/mode/device/inode facts from `/` through the migration directory
- report only whether three exact sudo permissions exist; execute none of them

## Validation
- 5 focused tests passed
- git diff --check
