### PR TITLE
Audit production ACL and sudo boundaries

### DIFF
--- a/.github/workflows/audit-prod-storage.yml
+++ b/.github/workflows/audit-prod-storage.yml
@@ -56,8 +56,10 @@ jobs:
             python3 -I "$helper"
             effective_identity="$(id -u):$(id -g)"
             for request in \
+              "/usr/bin/chmod 0755 -- /data" \
               "/usr/bin/chmod 1777 -- /data" \
               "/usr/bin/chown ${effective_identity} -- /data/prod_unikorn" \
+              "/usr/bin/chown --no-dereference --from=33:33 ${effective_identity} -- /data/prod_unikorn" \
               "/usr/bin/chmod 0755 -- /data/prod_unikorn"; do
               if /usr/bin/sudo -n -l ${request} >/dev/null 2>&1; then
                 printf 'sudo_permission=allowed command=%s\n' "$request"
@@ -65,3 +67,11 @@ jobs:
                 printf 'sudo_permission=denied command=%s\n' "$request"
               fi
             done
+            printf 'identity_user=%s\n' "$(id -un)"
+            printf 'identity_uid=%s\n' "$(id -u)"
+            printf 'identity_primary_group=%s\n' "$(id -gn)"
+            printf 'identity_primary_gid=%s\n' "$(id -g)"
+            printf 'identity_all_groups=%s\n' "$(id -G)"
+            getent passwd "$(id -u)"
+            getent group "$(id -g)"
+            getent passwd | awk -F: -v gid="$(id -g)" '$4 == gid { print "primary_gid_user=" $1 }'

--- a/tests/test_audit_prod_storage.py
+++ b/tests/test_audit_prod_storage.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 import subprocess
+import sys
 
 import pytest
 
@@ -192,7 +193,34 @@ def test_workflow_is_read_only_fixed_and_serialized():
     assert "secrets.PROD_SSH_KEY" in workflow
     assert "chmod 0500" in workflow
     assert "/usr/bin/sudo -n -l" in workflow
+    assert "/usr/bin/chmod 0755 -- /data" in workflow
     assert "/usr/bin/chmod 1777 -- /data" in workflow
     assert "/usr/bin/chown ${effective_identity} -- /data/prod_unikorn" in workflow
+    assert (
+        "/usr/bin/chown --no-dereference --from=33:33 "
+        "${effective_identity} -- /data/prod_unikorn"
+        in workflow
+    )
+    assert 'printf \'identity_all_groups=%s\\n\' "$(id -G)"' in workflow
+    assert "getent group" in workflow
+    assert "getent passwd" in workflow
     assert "sudo -n /usr/bin/chmod" not in workflow
     assert "sudo -n /usr/bin/chown" not in workflow
+
+
+def test_audit_rejects_linux_posix_acl_xattrs(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        os,
+        "listxattr",
+        lambda _descriptor: ["system.posix_acl_default"],
+        raising=False,
+    )
+    with pytest.raises(storage_audit.AuditBlocked, match="unexpected POSIX ACL"):
+        storage_audit._reject_posix_acl(123, "test directory")
+
+
+def test_audit_accepts_linux_objects_without_posix_acl(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(os, "listxattr", lambda _descriptor: [], raising=False)
+    storage_audit._reject_posix_acl(123, "test directory")

--- a/tools/audit_prod_storage.py
+++ b/tools/audit_prod_storage.py
@@ -40,6 +40,21 @@ class AuditBlocked(RuntimeError):
     """The fixed hierarchy could not be inspected without ambiguity."""
 
 
+def _reject_posix_acl(descriptor: int, description: str) -> None:
+    """Reject Linux access/default ACLs; mode bits are the reviewed authority."""
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        names = os.listxattr(descriptor)
+    except (AttributeError, OSError) as error:
+        raise AuditBlocked(
+            f"cannot attest POSIX ACLs for fixed {description}"
+        ) from error
+    forbidden = {"system.posix_acl_access", "system.posix_acl_default"}
+    if forbidden.intersection(names):
+        raise AuditBlocked(f"fixed {description} has an unexpected POSIX ACL")
+
+
 def _failure_point(name: str, context: dict[str, Any] | None = None) -> None:
     if FAILURE_INJECTOR is not None:
         FAILURE_INJECTOR(name, context or {})
@@ -62,23 +77,35 @@ def _metadata(details: os.stat_result, path: Path) -> dict[str, Any]:
 
 def _open_directory_path(path: Path, description: str) -> int:
     try:
-        return os.open(
+        descriptor = os.open(
             path,
             os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
         )
     except OSError as error:
         raise AuditBlocked(f"cannot safely open fixed {description}") from error
+    try:
+        _reject_posix_acl(descriptor, description)
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
 
 
 def _open_child(parent_fd: int, name: str, description: str) -> int:
     try:
-        return os.open(
+        descriptor = os.open(
             name,
             os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
             dir_fd=parent_fd,
         )
     except OSError as error:
         raise AuditBlocked(f"cannot safely open fixed {description}") from error
+    try:
+        _reject_posix_acl(descriptor, description)
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
 
 
 def _bound_stat(parent_fd: int, name: str, description: str) -> os.stat_result:
@@ -106,8 +133,13 @@ def _open_optional_child(
         return None, {"path": str(path), "status": "absent"}
     except OSError as error:
         raise AuditBlocked(f"cannot safely open optional fixed child {path}") from error
-    details = os.fstat(descriptor)
-    bound = _bound_stat(parent_fd, name, f"optional child {path}")
+    try:
+        details = os.fstat(descriptor)
+        _reject_posix_acl(descriptor, f"optional child {path}")
+        bound = _bound_stat(parent_fd, name, f"optional child {path}")
+    except Exception:
+        os.close(descriptor)
+        raise
     if _identity(details) != _identity(bound):
         os.close(descriptor)
         raise AuditBlocked(f"optional child identity changed: {path}")
@@ -130,6 +162,7 @@ def _open_bound_file(
     except OSError as error:
         raise AuditBlocked(f"cannot safely open fixed file {path}") from error
     try:
+        _reject_posix_acl(descriptor, f"file {path}")
         before = os.fstat(descriptor)
         if (
             not stat.S_ISREG(before.st_mode)


### PR DESCRIPTION
## Summary
- reject POSIX ACL xattrs in the descriptor-bound production storage audit
- report exact current and proposed sudo permissions without executing them
- report deploy identity and primary-group membership for trust review

## Safety
This PR is read-only. The rejected mutating hardener/workflow is not included.

## Verification
- `pytest -q tests/test_audit_prod_storage.py` (10 passed)
- YAML parse passed
- `git diff --check` passed