### PR TITLE
ci: report production SSH host keys

### DIFF
--- a/.github/workflows/audit-prod-storage.yml
+++ b/.github/workflows/audit-prod-storage.yml
@@ -35,6 +35,17 @@ jobs:
           printf 'sha256=%s\n' "$sha256" >> "$GITHUB_OUTPUT"
           printf 'payload=%s\n' "$payload" >> "$GITHUB_OUTPUT"
 
+      - name: Report production host public-key fingerprints
+        env:
+          PROD_SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
+        run: |
+          set -Eeuo pipefail
+          keys="$(mktemp)"
+          trap 'rm -f "$keys"' EXIT
+          ssh-keyscan -T 10 -t rsa,ecdsa,ed25519 -- "$PROD_SSH_HOST" 2>/dev/null > "$keys"
+          test -s "$keys"
+          ssh-keygen -lf "$keys" -E sha256 | sed -E 's/ [^ ]+ \((RSA|ECDSA|ED25519)\)$/ (\1)/'
+
       - name: Audit exact production storage hierarchy
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:

--- a/tests/test_audit_prod_storage.py
+++ b/tests/test_audit_prod_storage.py
@@ -192,6 +192,8 @@ def test_workflow_is_read_only_fixed_and_serialized():
     assert "secrets.PROD_SSH_USER" in workflow
     assert "secrets.PROD_SSH_KEY" in workflow
     assert "secrets.PROD_SSH_FINGERPRINT" in workflow
+    assert "ssh-keyscan -T 10 -t rsa,ecdsa,ed25519" in workflow
+    assert "ssh-keygen -lf \"$keys\" -E sha256" in workflow
     assert "chmod 0500" in workflow
     assert "/usr/bin/sudo -n -l" in workflow
     assert "sudo_policy=matched_authentication_unknown" in workflow


### PR DESCRIPTION
Temporary read-only diagnostic after enforced host-key verification failed for all independently verified keys on the public hostname. Reports only public host-key fingerprints for the secret-configured production target; does not reveal the host or credentials.\n\nValidation: 10 focused tests, YAML parse, diff check.