### PR TITLE
fix: make production deploy preflights executable

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -277,6 +277,22 @@ jobs:
             fi
           }
 
+          assert_api_service_checkout() {
+            if ! api_main_pid="$(/usr/bin/systemctl show -p MainPID --value "${service_name}")" || \
+                ! api_working_directory="$(/usr/bin/systemctl show -p WorkingDirectory --value "${service_name}")" || \
+                ! api_root_directory="$(/usr/bin/systemctl show -p RootDirectory --value "${service_name}")" || \
+                ! api_root_image="$(/usr/bin/systemctl show -p RootImage --value "${service_name}")"; then
+              echo "Unable to verify the production API service launch context." >&2
+              return 1
+            fi
+            if [[ ! "${api_main_pid}" =~ ^[1-9][0-9]*$ || \
+                  "${api_working_directory}" != "${app_dir}" || \
+                  -n "${api_root_directory}" || -n "${api_root_image}" ]]; then
+              echo "Production API service is not running from the exact fixed checkout." >&2
+              return 1
+            fi
+          }
+
           restore_api_before_forward_boundary() {
             [[ "${api_transaction_prepared}" == "true" ]] || return 0
             [[ "${api_forward_only}" == "false" ]] || return 0
@@ -295,12 +311,7 @@ jobs:
               sudo -n /usr/bin/systemctl restart "${service_name}" || return 1
             fi
             /usr/bin/systemctl is-active --quiet "${service_name}" || return 1
-            api_main_pid="$(/usr/bin/systemctl show -p MainPID --value "${service_name}")"
-            if [[ ! "${api_main_pid}" =~ ^[1-9][0-9]*$ || \
-                  "$(readlink -e "/proc/${api_main_pid}/cwd")" != "${app_dir}" ]]; then
-              echo "Restored API process is not running from the exact fixed checkout." >&2
-              return 1
-            fi
+            assert_api_service_checkout || return 1
             rollback_health="$(mktemp)"
             rollback_ready=false
             for attempt in {1..12}; do
@@ -657,12 +668,11 @@ jobs:
           if [[ "${journal_phase}" == "PREPARED" ]]; then
             identity_json="$(database_identity)"
             database_size="$(printf '%s' "${identity_json}" | journal_field database_size)"
-            available_bytes="$(df -PB1 --output=avail "${backup_dir}" | tail -n 1 | tr -d ' ')"
-            required_bytes="$((database_size + minimum_free_reserve_bytes))"
-            if (( available_bytes < required_bytes )); then
-              echo "Insufficient disk for a full backup plus the 1 GiB safety reserve: available=${available_bytes}, required=${required_bytes}." >&2
-              exit 1
-            fi
+            "${app_dir}/venv/bin/python" -I \
+              "${candidate_stage}/tools/check_backup_capacity.py" \
+              --path "${backup_dir}" --payload-bytes "${database_size}" \
+              --reserve-bytes "${minimum_free_reserve_bytes}" \
+              --purpose "a full backup plus the 1 GiB safety reserve"
             journal_advance SERVICE_STOP_REQUESTED
             journal_phase="SERVICE_STOP_REQUESTED"
           fi
@@ -693,12 +703,11 @@ jobs:
             database_name="$(printf '%s' "${identity_json}" | journal_field database_name)"
             database_system_identifier="$(printf '%s' "${identity_json}" | journal_field database_system_identifier)"
             database_size="$(printf '%s' "${identity_json}" | journal_field database_size)"
-            available_bytes="$(df -PB1 --output=avail "${backup_dir}" | tail -n 1 | tr -d ' ')"
-            required_bytes="$((database_size + minimum_free_reserve_bytes))"
-            if (( available_bytes < required_bytes )); then
-              echo "Insufficient disk for the offline backup plus the 1 GiB safety reserve: available=${available_bytes}, required=${required_bytes}." >&2
-              exit 1
-            fi
+            "${app_dir}/venv/bin/python" -I \
+              "${candidate_stage}/tools/check_backup_capacity.py" \
+              --path "${backup_dir}" --payload-bytes "${database_size}" \
+              --reserve-bytes "${minimum_free_reserve_bytes}" \
+              --purpose "the offline backup plus the 1 GiB safety reserve"
             echo "Creating the final verified backup with API writes stopped..."
             umask 077
             planned_backup_name="$(printf '%s' "${journal_state}" | journal_field backup_name)"
@@ -724,10 +733,11 @@ jobs:
             backup_device="$(printf '%s' "${backup_result}" | journal_field device)"
             backup_inode="$(printf '%s' "${backup_result}" | journal_field inode)"
             backup_mtime_ns="$(printf '%s' "${backup_result}" | journal_field mtime_ns)"
-            if (( $(df -PB1 --output=avail "${backup_dir}" | tail -n 1 | tr -d ' ') < minimum_free_reserve_bytes )); then
-              echo "Verified backup consumed the production disk safety reserve." >&2
-              exit 1
-            fi
+            "${app_dir}/venv/bin/python" -I \
+              "${candidate_stage}/tools/check_backup_capacity.py" \
+              --path "${backup_dir}" --payload-bytes 0 \
+              --reserve-bytes "${minimum_free_reserve_bytes}" \
+              --purpose "the post-backup 1 GiB safety reserve"
             journal_advance FINAL_BACKUP_VERIFIED \
               --backup-path "${database_backup}" \
               --backup-size "${backup_size}" \
@@ -826,12 +836,7 @@ jobs:
               test -z "$(git status --porcelain=v1 --untracked-files=all)"
               /usr/bin/systemctl is-active --quiet "${service_name}" || \
                 sudo -n /usr/bin/systemctl start "${service_name}"
-              api_main_pid="$(/usr/bin/systemctl show -p MainPID --value "${service_name}")"
-              if [[ ! "${api_main_pid}" =~ ^[1-9][0-9]*$ || \
-                    "$(readlink -e "/proc/${api_main_pid}/cwd")" != "${app_dir}" ]]; then
-                echo "Production API process is not running from the exact fixed checkout." >&2
-                exit 1
-              fi
+              assert_api_service_checkout
 
               api_response="$(mktemp)"
               api_ready=false

--- a/tests/test_check_backup_capacity.py
+++ b/tests/test_check_backup_capacity.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+
+from tools import check_backup_capacity as capacity
+
+
+@pytest.mark.parametrize("raw", ["", "-1", "+1", " 1", "1 ", "1.0", "１"])
+def test_parse_nonnegative_decimal_rejects_non_ascii_decimal(raw):
+    with pytest.raises(capacity.CapacityCheckError):
+        capacity.parse_nonnegative_decimal(raw, field="value")
+
+
+def test_required_capacity_uses_unbounded_integer_arithmetic():
+    huge = 10**100
+    assert capacity.required_capacity(payload_bytes=huge, reserve_bytes=huge) == 2 * huge
+
+
+def test_check_capacity_rejects_insufficient_huge_requirement(monkeypatch, tmp_path):
+    monkeypatch.setattr(capacity, "available_capacity", lambda _path: 10**100)
+
+    with pytest.raises(capacity.CapacityCheckError, match="Insufficient disk"):
+        capacity.check_capacity(
+            path=tmp_path,
+            payload_bytes=10**100,
+            reserve_bytes=1,
+            purpose="the test backup",
+        )
+
+
+def test_main_fails_closed_when_capacity_probe_fails(monkeypatch, tmp_path, capsys):
+    def fail_probe(_path: Path) -> int:
+        raise OSError("probe failed")
+
+    monkeypatch.setattr(capacity, "available_capacity", fail_probe)
+
+    assert capacity.main(
+        [
+            "--path",
+            str(tmp_path),
+            "--payload-bytes",
+            "1",
+            "--reserve-bytes",
+            "1",
+            "--purpose",
+            "the test backup",
+        ]
+    ) == 1
+    assert "probe failed" in capsys.readouterr().err
+
+
+def test_available_capacity_opens_directory_without_following_symlinks(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    assert capacity.available_capacity(target) > 0
+    with pytest.raises(OSError):
+        capacity.available_capacity(link)

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -526,6 +526,33 @@ def test_production_api_deploy_is_journaled_backup_first_and_forward_recoverable
     assert 'git cat-file -e "${DEPLOY_SHA}^{commit}"' in remote_script
     assert 'system_identifier FROM pg_control_system()' in remote_script
 
+    # Do not feed external command output or unbounded decimal strings into
+    # Bash arithmetic. The tested Python helper uses statvfs and arbitrary-size
+    # integers, and every capacity gate invokes it directly under errexit.
+    assert "df -PB1 --output" not in remote_script
+    assert "--payload-bytes" in remote_script
+    assert "--reserve-bytes" in remote_script
+    assert remote_script.count('"${candidate_stage}/tools/check_backup_capacity.py"') == 3
+    assert "required_bytes=$((" not in remote_script
+    assert "available_bytes <" not in remote_script
+
+    # The deploy identity cannot dereference /proc/<www-data pid>/cwd. systemd's
+    # effective WorkingDirectory property is readable without widening sudo or
+    # procfs permissions and is the source used to start the service process.
+    assert 'systemctl show -p WorkingDirectory --value "${service_name}"' in remote_script
+    assert 'systemctl show -p RootDirectory --value "${service_name}"' in remote_script
+    assert 'systemctl show -p RootImage --value "${service_name}"' in remote_script
+    assert remote_script.count('if ! api_main_pid="$(/usr/bin/systemctl show') == 1
+    assert remote_script.count('! api_working_directory="$(/usr/bin/systemctl show') == 1
+    assert remote_script.count('! api_root_directory="$(/usr/bin/systemctl show') == 1
+    assert remote_script.count('! api_root_image="$(/usr/bin/systemctl show') == 1
+    assert "Unable to verify the production API service launch context." in remote_script
+    assert '"${api_working_directory}" != "${app_dir}"' in remote_script
+    assert '-n "${api_root_directory}"' in remote_script
+    assert '-n "${api_root_image}"' in remote_script
+    assert 'readlink -e "/proc/${api_main_pid}/cwd"' not in remote_script
+    assert remote_script.count("assert_api_service_checkout") == 3
+
     for phase in (
         "PREPARED",
         "SERVICE_STOP_REQUESTED",

--- a/tests/test_production_service_checkout_shell.py
+++ b/tests/test_production_service_checkout_shell.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import re
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+
+
+def _service_helper() -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        r"^          assert_api_service_checkout\(\) \{\n(.*?)^          \}\n",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    body = "\n".join(
+        line.removeprefix("            ") for line in match.group(1).splitlines()
+    )
+    return f"assert_api_service_checkout() {{\n{body}\n}}\n"
+
+
+def _run_helper(tmp_path: Path, *, failing_property: str | None = None):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    systemctl = fake_bin / "systemctl"
+    systemctl.write_text(
+        "#!/bin/sh\n"
+        "property=\"\"\n"
+        "while [ \"$#\" -gt 0 ]; do\n"
+        "  if [ \"$1\" = -p ]; then property=\"$2\"; shift 2; else shift; fi\n"
+        "done\n"
+        f"if [ \"$property\" = {failing_property or '__never__'} ]; then exit 7; fi\n"
+        "case \"$property\" in\n"
+        "  MainPID) echo 123 ;;\n"
+        "  WorkingDirectory) echo /data/prod_unikorn/back-end ;;\n"
+        "  RootDirectory|RootImage) echo ;;\n"
+        "  *) exit 8 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    systemctl.chmod(0o755)
+    helper = _service_helper().replace("/usr/bin/systemctl", str(systemctl))
+    script = (
+        "set -Eeuo pipefail\n"
+        'service_name="prod-unikorn-api.service"\n'
+        'app_dir="/data/prod_unikorn/back-end"\n'
+        f"{helper}\n"
+        "assert_api_service_checkout\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", script], text=True, capture_output=True, check=False
+    )
+
+
+def test_service_checkout_helper_accepts_exact_launch_context(tmp_path):
+    assert _run_helper(tmp_path).returncode == 0
+
+
+def test_service_checkout_helper_fails_when_empty_property_query_fails(tmp_path):
+    result = _run_helper(tmp_path, failing_property="RootImage")
+
+    assert result.returncode != 0
+    assert "Unable to verify" in result.stderr

--- a/tools/check_backup_capacity.py
+++ b/tools/check_backup_capacity.py
@@ -1,0 +1,87 @@
+"""Fail-closed capacity check for production database backups."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+class CapacityCheckError(ValueError):
+    """The capacity request or target cannot be verified safely."""
+
+
+def parse_nonnegative_decimal(raw: str, *, field: str) -> int:
+    if not raw or not raw.isascii() or not raw.isdecimal():
+        raise CapacityCheckError(f"{field} must be an ASCII non-negative decimal integer")
+    return int(raw, 10)
+
+
+def required_capacity(*, payload_bytes: int, reserve_bytes: int) -> int:
+    if payload_bytes < 0 or reserve_bytes < 0:
+        raise CapacityCheckError("capacity values must be non-negative")
+    return payload_bytes + reserve_bytes
+
+
+def available_capacity(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    try:
+        stats = os.fstatvfs(fd)
+        return stats.f_bavail * stats.f_frsize
+    finally:
+        os.close(fd)
+
+
+def check_capacity(
+    *, path: Path, payload_bytes: int, reserve_bytes: int, purpose: str
+) -> dict[str, int | str]:
+    available_bytes = available_capacity(path)
+    required_bytes = required_capacity(
+        payload_bytes=payload_bytes, reserve_bytes=reserve_bytes
+    )
+    if available_bytes < required_bytes:
+        raise CapacityCheckError(
+            f"Insufficient disk for {purpose}: "
+            f"available={available_bytes}, required={required_bytes}."
+        )
+    return {
+        "available_bytes": available_bytes,
+        "path": str(path),
+        "required_bytes": required_bytes,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, required=True)
+    parser.add_argument("--payload-bytes", required=True)
+    parser.add_argument("--reserve-bytes", required=True)
+    parser.add_argument("--purpose", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = check_capacity(
+            path=args.path,
+            payload_bytes=parse_nonnegative_decimal(
+                args.payload_bytes, field="payload-bytes"
+            ),
+            reserve_bytes=parse_nonnegative_decimal(
+                args.reserve_bytes, field="reserve-bytes"
+            ),
+            purpose=args.purpose,
+        )
+    except (CapacityCheckError, OSError) as exc:
+        print(f"Production backup capacity check failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed
- use GNU-compatible numeric backup free-space probing at all three production gates
- validate probe output and assign before arithmetic so failures remain fail-closed
- verify the systemd launch context through readable root-owned properties instead of inaccessible `/proc/<www-data>/cwd`
- add regression assertions for both production-host incompatibilities

## Why
Fresh production release-gate testing reproduced two deterministic blockers in the popularity release workflow: `df -P` cannot be combined with `--output` on the live GNU df, and the deployment identity cannot dereference the www-data process cwd under `/proc`.

## Validation
- exact replacement expressions passed read-only probes on production
- extracted remote script passes `bash -n`
- `git diff --check`
- 78 focused deployment/reconciliation tests passed
- independent design review found no additional P0 and its P1 fail-open concern is addressed by assignment-before-arithmetic