### PR TITLE
release: retry scheduler popularity deployment

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -340,12 +340,57 @@ jobs:
             api_transaction_prepared=false
           }
 
+          read_systemd_unit_state() {
+            local unit_name="$1"
+            local properties property_line
+            local seen_load_state=false
+            local seen_active_state=false
+            local seen_unit_file_state=false
+
+            systemd_load_state=""
+            systemd_active_state=""
+            systemd_unit_file_state=""
+            if ! properties="$(/usr/bin/systemctl show --all \
+                -p LoadState -p ActiveState -p UnitFileState -- "${unit_name}")"; then
+              return 1
+            fi
+            while IFS= read -r property_line || [[ -n "${property_line}" ]]; do
+              case "${property_line}" in
+                LoadState=*)
+                  [[ "${seen_load_state}" == "false" ]] || return 1
+                  systemd_load_state="${property_line#LoadState=}"
+                  seen_load_state=true
+                  ;;
+                ActiveState=*)
+                  [[ "${seen_active_state}" == "false" ]] || return 1
+                  systemd_active_state="${property_line#ActiveState=}"
+                  seen_active_state=true
+                  ;;
+                UnitFileState=*)
+                  [[ "${seen_unit_file_state}" == "false" ]] || return 1
+                  systemd_unit_file_state="${property_line#UnitFileState=}"
+                  seen_unit_file_state=true
+                  ;;
+                *)
+                  return 1
+                  ;;
+              esac
+            done <<< "${properties}"
+            [[ "${seen_load_state}" == "true" && \
+               "${seen_active_state}" == "true" && \
+               "${seen_unit_file_state}" == "true" ]]
+          }
+
           assert_unit_inactive() {
             unit_name="$1"
-            load_state="$(/usr/bin/systemctl show -p LoadState --value "${unit_name}")"
-            active_state="$(/usr/bin/systemctl show -p ActiveState --value "${unit_name}")"
-            if [[ "${load_state}" != "not-found" && "${active_state}" != "inactive" && "${active_state}" != "failed" ]]; then
-              echo "${unit_name} did not quiesce (load=${load_state}, active=${active_state})." >&2
+            if ! read_systemd_unit_state "${unit_name}"; then
+              echo "Unable to verify that ${unit_name} quiesced." >&2
+              return 1
+            fi
+            if [[ "${systemd_load_state}" != "loaded" || \
+                  ( "${systemd_active_state}" != "inactive" && \
+                    "${systemd_active_state}" != "failed" ) ]]; then
+              echo "${unit_name} did not quiesce (load=${systemd_load_state}, active=${systemd_active_state}, unit-file=${systemd_unit_file_state})." >&2
               return 1
             fi
           }
@@ -368,13 +413,14 @@ jobs:
               unikorn-scheduler-popularity-verify.service \
               unikorn-scheduler-popularity-sample.timer \
               unikorn-scheduler-popularity-final.timer; do
-              legacy_load_state="$(/usr/bin/systemctl show -p LoadState --value "${legacy_sampler_unit}")"
-              legacy_active_state="$(/usr/bin/systemctl show -p ActiveState --value "${legacy_sampler_unit}")"
-              legacy_unit_file_state="$(/usr/bin/systemctl is-enabled "${legacy_sampler_unit}" 2>/dev/null || true)"
-              if [[ "${legacy_load_state}" != "not-found" || \
-                    "${legacy_active_state}" != "inactive" || \
-                    "${legacy_unit_file_state}" != "not-found" ]]; then
-                echo "Refusing user-cron activation while legacy sampler unit ${legacy_sampler_unit} exists (load=${legacy_load_state}, active=${legacy_active_state}, enabled=${legacy_unit_file_state})." >&2
+              if ! read_systemd_unit_state "${legacy_sampler_unit}"; then
+                echo "Unable to verify legacy sampler unit ${legacy_sampler_unit}." >&2
+                return 1
+              fi
+              if [[ "${systemd_load_state}" != "not-found" || \
+                    "${systemd_active_state}" != "inactive" || \
+                    -n "${systemd_unit_file_state}" ]]; then
+                echo "Refusing user-cron activation while legacy sampler unit ${legacy_sampler_unit} exists (load=${systemd_load_state}, active=${systemd_active_state}, unit-file=${systemd_unit_file_state})." >&2
                 return 1
               fi
             done
@@ -429,6 +475,23 @@ jobs:
               fi
               grep -Fq 'no crontab for' "${crontab_stage}/rollback-error" || return 1
             fi
+            crontab_mutated=false
+          }
+
+          activate_sampling_crontab() {
+            # This is the final pre-mutation gate. A failure here leaves the
+            # already-committed API in place and the original crontab untouched,
+            # so the same deployment SHA can safely retry sampler activation.
+            assert_legacy_sampler_units_absent
+            crontab_mutated=true
+            crontab "${crontab_candidate}"
+            crontab -l > "${crontab_readback}"
+            test "$(sha256sum "${crontab_readback}" | cut -d ' ' -f1)" = "${expected_crontab_sha}"
+            # A second read closes the most obvious concurrent-edit window.
+            sleep 1
+            crontab -l > "${crontab_readback}.second"
+            cmp -s "${crontab_readback}" "${crontab_readback}.second"
+            "${sampler_args[@]}" --mode status >/dev/null
             crontab_mutated=false
           }
 
@@ -1065,16 +1128,7 @@ jobs:
             fi
             cmp -s "${crontab_before}" "${crontab_before}.verify"
             installed_crontab_sha="${expected_crontab_sha}"
-            crontab_mutated=true
-            crontab "${crontab_candidate}"
-            crontab -l > "${crontab_readback}"
-            test "$(sha256sum "${crontab_readback}" | cut -d ' ' -f1)" = "${expected_crontab_sha}"
-            # A second read closes the most obvious concurrent-edit window.
-            sleep 1
-            crontab -l > "${crontab_readback}.second"
-            cmp -s "${crontab_readback}" "${crontab_readback}.second"
-            "${sampler_args[@]}" --mode status >/dev/null
-            crontab_mutated=false
+            activate_sampling_crontab
             unset UNIKORN_BACKEND_MUTATION_LOCK_FD UNIKORN_BACKEND_MUTATION_LOCK_DEV_INO
             echo "Scheduler popularity user crontab activated and byte-for-byte verified."
           }

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -586,10 +586,11 @@ def test_production_deploy_activates_bounded_popularity_sampling_with_user_cront
     health_at = deploy_workflow.index("Local scheduler API verified")
     release_at = deploy_workflow.index("Building an immutable popularity sampler release")
     baseline_at = deploy_workflow.index("Taking the one permitted deployment baseline")
+    activate_call_at = deploy_workflow.rindex("activate_sampling_crontab")
     activate_at = deploy_workflow.index('crontab "${crontab_candidate}"')
 
     assert trap_at < flock_at < checkout_at < migrate_at < health_at
-    assert health_at < release_at < baseline_at < activate_at
+    assert health_at < release_at < baseline_at < activate_call_at
     assert "restore_sampling_crontab" in deploy_workflow
     assert "Immutable sampler release ready" in deploy_workflow
     assert "git archive" in deploy_workflow
@@ -611,7 +612,7 @@ def test_production_deploy_activates_bounded_popularity_sampling_with_user_cront
     assert "systemctl enable" not in deploy_workflow
     assert "Refusing user-cron activation while legacy sampler unit" in deploy_workflow
     assert "unikorn-scheduler-popularity-final.timer" in deploy_workflow
-    assert deploy_workflow.count("assert_legacy_sampler_units_absent") == 3
+    assert deploy_workflow.count("assert_legacy_sampler_units_absent") == 4
     migration = deploy_workflow.index("flask db upgrade heads")
     pre_migration_guard = deploy_workflow.index(
         "assert_legacy_sampler_units_absent",
@@ -624,11 +625,24 @@ def test_production_deploy_activates_bounded_popularity_sampling_with_user_cront
     release_build = deploy_workflow.index(
         "Building an immutable popularity sampler release", sampler_start
     )
+    activation_helper_at = deploy_workflow.index("activate_sampling_crontab()")
+    final_legacy_guard = deploy_workflow.index(
+        "assert_legacy_sampler_units_absent", activation_helper_at
+    )
     assert pre_migration_guard < migration
     assert sampler_start < legacy_guard < release_build
-    assert 'legacy_load_state="$(/usr/bin/systemctl show -p LoadState' in deploy_workflow
-    assert 'legacy_active_state="$(/usr/bin/systemctl show -p ActiveState' in deploy_workflow
-    assert 'legacy_unit_file_state="$(/usr/bin/systemctl is-enabled' in deploy_workflow
+    assert final_legacy_guard < activate_at
+    assert release_build < activate_call_at
+    assert deploy_workflow.index('test "${journal_phase}" = "COMMITTED"') < activate_call_at
+    assert "/usr/bin/systemctl show --all" in deploy_workflow
+    assert "-p LoadState -p ActiveState -p UnitFileState" in deploy_workflow
+    assert "seen_load_state" in deploy_workflow
+    assert "seen_active_state" in deploy_workflow
+    assert "seen_unit_file_state" in deploy_workflow
+    assert "systemctl is-enabled" not in deploy_workflow
+    assert "Unable to verify legacy sampler unit" in deploy_workflow
+    assert '-n "${systemd_unit_file_state}"' in deploy_workflow
+    assert '"${systemd_load_state}" != "loaded"' in deploy_workflow
 
 
 def test_production_sampling_cutoff_epochs_are_exact_and_parse_fail_closed():
@@ -661,15 +675,20 @@ def test_production_crontab_install_is_verified_and_rollback_safe():
     deploy_workflow = (
         ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
     ).read_text(encoding="utf-8")
+    activation_helper = deploy_workflow.index("activate_sampling_crontab()")
     capture = deploy_workflow.index('crontab -l > "${crontab_before}"')
     race_check = deploy_workflow.index('cmp -s "${crontab_before}" "${crontab_before}.verify"')
-    install = deploy_workflow.index('crontab "${crontab_candidate}"')
+    activation_call = deploy_workflow.rindex("activate_sampling_crontab")
+    install = deploy_workflow.index('crontab "${crontab_candidate}"', activation_helper)
     readback = deploy_workflow.index('crontab -l > "${crontab_readback}"')
     hash_check = deploy_workflow.index('sha256sum "${crontab_readback}"')
     smoke = deploy_workflow.index('"${sampler_args[@]}" --mode status >/dev/null')
     commit = deploy_workflow.index("crontab_mutated=false", install)
-    mutation_guard = deploy_workflow.rindex("crontab_mutated=true", capture, install)
-    assert capture < race_check < mutation_guard < install < readback < hash_check < smoke < commit
+    mutation_guard = deploy_workflow.rindex(
+        "crontab_mutated=true", activation_helper, install
+    )
+    assert mutation_guard < install < readback < hash_check < smoke < commit
+    assert capture < race_check < activation_call
     assert "restore_sampling_crontab()" in deploy_workflow
     assert 'crontab "${crontab_before}" || return 1' in deploy_workflow
     assert 'cmp -s "${crontab_before}" "${crontab_stage}/rollback-read"' in deploy_workflow
@@ -678,7 +697,7 @@ def test_production_crontab_install_is_verified_and_rollback_safe():
     candidate_hash_bound = deploy_workflow.index(
         'installed_crontab_sha="${expected_crontab_sha}"'
     )
-    assert capture < original_hash < candidate_hash_bound < mutation_guard < install
+    assert capture < original_hash < candidate_hash_bound < activation_call
     assert '"${rollback_current_sha}" == "${original_crontab_sha}"' in deploy_workflow
     assert '"${rollback_current_sha}" != "${installed_crontab_sha}"' in deploy_workflow
     assert "Refusing rollback because the user crontab changed after candidate activation" in deploy_workflow

--- a/tests/test_production_legacy_sampler_units_shell.py
+++ b/tests/test_production_legacy_sampler_units_shell.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+import re
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+
+
+def _helper(name: str) -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^          {name}\(\) \{{\n(.*?)^          \}}\n",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    body = "\n".join(
+        line.removeprefix("            ") for line in match.group(1).splitlines()
+    )
+    return f"{name}() {{\n{body}\n}}\n"
+
+
+def _run_helper(tmp_path: Path, *, mode: str, assertion: str):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    systemctl = fake_bin / "systemctl"
+    systemctl.write_text(
+        "#!/bin/sh\n"
+        "[ \"$FAKE_SYSTEMD_MODE\" != query-failure ] || exit 7\n"
+        "case \"$FAKE_SYSTEMD_MODE\" in\n"
+        "  missing) printf 'LoadState=not-found\\nActiveState=inactive\\nUnitFileState=\\n' ;;\n"
+        "  loaded-inactive) printf 'LoadState=loaded\\nActiveState=inactive\\nUnitFileState=enabled\\n' ;;\n"
+        "  loaded-failed) printf 'LoadState=loaded\\nActiveState=failed\\nUnitFileState=enabled\\n' ;;\n"
+        "  active) printf 'LoadState=loaded\\nActiveState=active\\nUnitFileState=enabled\\n' ;;\n"
+        "  disabled) printf 'LoadState=loaded\\nActiveState=inactive\\nUnitFileState=disabled\\n' ;;\n"
+        "  static) printf 'LoadState=loaded\\nActiveState=inactive\\nUnitFileState=static\\n' ;;\n"
+        "  masked) printf 'LoadState=masked\\nActiveState=inactive\\nUnitFileState=masked\\n' ;;\n"
+        "  generated) printf 'LoadState=loaded\\nActiveState=inactive\\nUnitFileState=generated\\n' ;;\n"
+        "  transient) printf 'LoadState=loaded\\nActiveState=inactive\\nUnitFileState=transient\\n' ;;\n"
+        "  omitted) printf 'LoadState=not-found\\nActiveState=inactive\\n' ;;\n"
+        "  duplicate) printf 'LoadState=not-found\\nLoadState=loaded\\nActiveState=inactive\\nUnitFileState=\\n' ;;\n"
+        "  unknown) printf 'LoadState=not-found\\nActiveState=inactive\\nUnitFileState=\\nDescription=x\\n' ;;\n"
+        "  malformed) printf 'LoadState=not-found\\nActiveState\\nUnitFileState=\\n' ;;\n"
+        "  *) exit 8 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    systemctl.chmod(0o755)
+    helpers = (
+        _helper("read_systemd_unit_state")
+        + _helper("assert_unit_inactive")
+        + _helper("assert_legacy_sampler_units_absent")
+    ).replace("/usr/bin/systemctl", str(systemctl))
+    script = (
+        "set -Eeuo pipefail\n"
+        f"{helpers}\n"
+        f"{assertion}\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={"FAKE_SYSTEMD_MODE": mode},
+    )
+
+
+def test_missing_units_with_exact_empty_unit_file_state_are_accepted(tmp_path):
+    assert _run_helper(
+        tmp_path, mode="missing", assertion="assert_legacy_sampler_units_absent"
+    ).returncode == 0
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["loaded-inactive", "active", "disabled", "static", "masked", "generated", "transient"],
+)
+def test_any_installed_legacy_unit_state_is_rejected(tmp_path, mode):
+    result = _run_helper(
+        tmp_path, mode=mode, assertion="assert_legacy_sampler_units_absent"
+    )
+
+    assert result.returncode != 0
+    assert "Refusing user-cron activation" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "mode", ["query-failure", "omitted", "duplicate", "unknown", "malformed"]
+)
+def test_untrustworthy_legacy_unit_query_is_rejected(tmp_path, mode):
+    result = _run_helper(
+        tmp_path, mode=mode, assertion="assert_legacy_sampler_units_absent"
+    )
+
+    assert result.returncode != 0
+    assert "Unable to verify legacy sampler unit" in result.stderr
+
+
+@pytest.mark.parametrize("mode", ["loaded-inactive", "loaded-failed"])
+def test_api_unit_accepts_only_loaded_quiesced_states(tmp_path, mode):
+    assert _run_helper(
+        tmp_path,
+        mode=mode,
+        assertion="assert_unit_inactive prod-unikorn-api.service",
+    ).returncode == 0
+
+
+@pytest.mark.parametrize(
+    "mode", ["missing", "active", "query-failure", "omitted", "duplicate", "unknown", "malformed"]
+)
+def test_api_unit_rejects_absent_active_or_untrustworthy_states(tmp_path, mode):
+    result = _run_helper(
+        tmp_path,
+        mode=mode,
+        assertion="assert_unit_inactive prod-unikorn-api.service",
+    )
+
+    assert result.returncode != 0

--- a/tests/test_production_sampler_activation_retry_shell.py
+++ b/tests/test_production_sampler_activation_retry_shell.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+import hashlib
+import os
+import re
+import subprocess
+
+from tools import production_deploy_journal as journal
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-backend-prod.yml"
+TARGET_SHA = "b" * 40
+OLD_SHA = "a" * 40
+
+
+def _helper(name: str) -> str:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^          {name}\(\) \{{\n(.*?)^          \}}\n",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    body = "\n".join(
+        line.removeprefix("            ") for line in match.group(1).splitlines()
+    )
+    return f"{name}() {{\n{body}\n}}\n"
+
+
+def _fake_crontab(tmp_path: Path) -> tuple[Path, Path, Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    state = tmp_path / "live-crontab"
+    log = tmp_path / "crontab-log"
+    executable = fake_bin / "crontab"
+    executable.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n"
+        "  -l)\n"
+        "    if [ -f \"$FAKE_CRONTAB_STATE\" ]; then cat \"$FAKE_CRONTAB_STATE\"; exit 0; fi\n"
+        "    echo 'no crontab for deployer' >&2\n"
+        "    exit 1\n"
+        "    ;;\n"
+        "  -r) rm -f \"$FAKE_CRONTAB_STATE\"; printf 'remove\\n' >> \"$FAKE_CRONTAB_LOG\" ;;\n"
+        "  *) cp -- \"$1\" \"$FAKE_CRONTAB_STATE\"; printf 'install\\n' >> \"$FAKE_CRONTAB_LOG\" ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return fake_bin, state, log
+
+
+def _activation_script(
+    tmp_path: Path, *, guard_succeeds: bool, with_cleanup_trap: bool
+) -> subprocess.CompletedProcess[str]:
+    fake_bin, state, log = _fake_crontab(tmp_path)
+    state.write_text("# original\n", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    before = stage / "before"
+    before.write_bytes(state.read_bytes())
+    candidate = stage / "candidate"
+    candidate.write_text("# replacement\n", encoding="utf-8")
+    readback = stage / "readback"
+    expected_sha = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    helpers = _helper("restore_sampling_crontab") + _helper(
+        "activate_sampling_crontab"
+    )
+    guard_body = ":" if guard_succeeds else "return 17"
+    trap = "trap 'restore_sampling_crontab' EXIT\n" if with_cleanup_trap else ""
+    script = (
+        "set -Eeuo pipefail\n"
+        f"{helpers}\n"
+        f"assert_legacy_sampler_units_absent() {{ {guard_body}; }}\n"
+        "sleep() { :; }\n"
+        "sampler_args=(true)\n"
+        "crontab_existed=true\n"
+        "crontab_mutated=false\n"
+        f"crontab_stage={stage!s}\n"
+        f"crontab_before={before!s}\n"
+        f"crontab_candidate={candidate!s}\n"
+        f"crontab_readback={readback!s}\n"
+        f"original_crontab_sha={hashlib.sha256(before.read_bytes()).hexdigest()}\n"
+        f"installed_crontab_sha={expected_sha}\n"
+        f"expected_crontab_sha={expected_sha}\n"
+        f"{trap}"
+        "activate_sampling_crontab\n"
+        "test \"${crontab_mutated}\" = false\n"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "FAKE_CRONTAB_STATE": str(state),
+            "FAKE_CRONTAB_LOG": str(log),
+        }
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def _advance_journal_to_committed(tmp_path: Path, monkeypatch):
+    operations_root = tmp_path / "operations"
+    operations_root.mkdir(mode=0o700)
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir(mode=0o750)
+    monkeypatch.setattr(journal, "JOURNAL_ROOT", operations_root / "api-deploy")
+    monkeypatch.setattr(journal, "BACKUP_ROOT", backup_root)
+    backup = backup_root / f"prod_unikorn-20260813T010203Z-{TARGET_SHA[:12]}.dump"
+    payload = b"verified backup"
+    backup.write_bytes(payload)
+    backup.chmod(0o600)
+
+    journal.prepare(TARGET_SHA, OLD_SHA)
+    journal.advance(TARGET_SHA, "SERVICE_STOP_REQUESTED")
+    journal.advance(TARGET_SHA, "SERVICE_STOPPED")
+    journal.advance(TARGET_SHA, "FINAL_BACKUP_STARTED", backup_name=backup.name)
+    details = backup.stat()
+    journal.advance(
+        TARGET_SHA,
+        "FINAL_BACKUP_VERIFIED",
+        backup_path=str(backup),
+        backup_size=len(payload),
+        backup_sha256=hashlib.sha256(payload).hexdigest(),
+        backup_device=details.st_dev,
+        backup_inode=details.st_ino,
+        backup_mtime_ns=details.st_mtime_ns,
+        database_name="prod_unikorn",
+        database_system_identifier="7483928182746123456",
+    )
+    for phase in journal.PHASES[5:]:
+        journal.advance(TARGET_SHA, phase)
+
+
+def test_committed_sampler_preflight_failure_is_non_mutating_and_retryable(
+    tmp_path, monkeypatch
+):
+    first_dir = tmp_path / "first"
+    first_dir.mkdir()
+    first = _activation_script(
+        first_dir, guard_succeeds=False, with_cleanup_trap=True
+    )
+    assert first.returncode != 0
+    assert (first_dir / "live-crontab").read_text(encoding="utf-8") == "# original\n"
+    assert not (first_dir / "crontab-log").exists()
+
+    _advance_journal_to_committed(tmp_path, monkeypatch)
+    resumed = journal.prepare(TARGET_SHA, "c" * 40)
+    assert resumed["phase"] == "COMMITTED"
+    assert resumed["resumed"] is True
+
+    second_dir = tmp_path / "second"
+    second_dir.mkdir()
+    second = _activation_script(
+        second_dir, guard_succeeds=True, with_cleanup_trap=False
+    )
+    assert second.returncode == 0, second.stderr
+    assert (second_dir / "live-crontab").read_text(encoding="utf-8") == "# replacement\n"
+    assert (second_dir / "crontab-log").read_text(encoding="utf-8") == "install\n"


### PR DESCRIPTION
## Release scope
- retry the already-reviewed scheduler popularity backend release after the first production run stopped before mutation
- include only the hardened production unit-state/crontab preflight correction from PR #169

## Evidence
- first failed run 31719182788 made no production mutation
- production metadata prerequisite is exact
- correction exact SHA 274b126 independently approved twice with no P0/P1/P2 findings
- Backend CI 31722180579 passed isolated tests, pristine PostgreSQL migrations, immutable dependency verification, and production image build
- 114 focused deployment tests passed locally

## Deployment behavior
The production workflow deploys the exact production merge SHA, migrates to both expected heads, installs an immutable sampler release, takes the initial baseline, and activates the bounded 5-minute user crontab through 2026-09-30 23:59 Asia/Shanghai.