### PR TITLE
release: activate scheduler popularity sampler

### DIFF
--- a/.github/workflows/deploy-backend-prod.yml
+++ b/.github/workflows/deploy-backend-prod.yml
@@ -426,6 +426,18 @@ jobs:
             done
           }
 
+          extract_sampler_release() {
+            local destination="$1"
+            # The sampler imports the application package, but it must not
+            # inherit unrelated tracked development artifacts (including
+            # repository-local virtualenv symlinks) from a whole-tree archive.
+            git archive "${DEPLOY_SHA}" -- \
+              app \
+              scripts/run_scheduler_popularity_cron.py \
+              scripts/sample_scheduler_popularity.py \
+              tools/render_scheduler_popularity_crontab.py | tar -x -C "${destination}"
+          }
+
           restore_sampling_crontab() {
             [[ "${crontab_mutated}" == "true" ]] || return 0
             echo "Restoring the exact pre-deployment user crontab." >&2
@@ -1000,12 +1012,13 @@ jobs:
               test "$(<"${sampler_candidate}/.unikorn-commit")" = "${DEPLOY_SHA}"
               test -f "${sampler_candidate}/scripts/run_scheduler_popularity_cron.py"
               test -f "${sampler_candidate}/scripts/sample_scheduler_popularity.py"
+              test -f "${sampler_candidate}/tools/render_scheduler_popularity_crontab.py"
               test -L "${sampler_candidate}/venv"
               test "$(readlink "${sampler_candidate}/venv")" = "${app_dir}/venv"
               test ! -w "${sampler_candidate}/scripts/run_scheduler_popularity_cron.py"
             else
               sampler_release_stage="$(mktemp -d "${sampler_root}/.${DEPLOY_SHA}.XXXXXX")"
-              git archive "${DEPLOY_SHA}" | tar -x -C "${sampler_release_stage}"
+              extract_sampler_release "${sampler_release_stage}"
               ln -s "${app_dir}/venv" "${sampler_release_stage}/venv"
               printf '%s\n' "${DEPLOY_SHA}" > "${sampler_release_stage}/.unikorn-commit"
               chmod -R a-w,a+rX "${sampler_release_stage}"
@@ -1014,7 +1027,7 @@ jobs:
             fi
             "${sampler_candidate}/venv/bin/python" -I -c 'import flask, sqlalchemy'
             sampler_verify_stage="$(mktemp -d /tmp/unikorn-popularity-release-verify.XXXXXX)"
-            git archive "${DEPLOY_SHA}" | tar -x -C "${sampler_verify_stage}"
+            extract_sampler_release "${sampler_verify_stage}"
             find "${sampler_candidate}" -type l -print | \
               grep -Fxq "${sampler_candidate}/venv"
             test "$(find "${sampler_candidate}" -type l -print | wc -l)" -eq 1

--- a/tests/test_deploy_health.py
+++ b/tests/test_deploy_health.py
@@ -593,7 +593,15 @@ def test_production_deploy_activates_bounded_popularity_sampling_with_user_cront
     assert health_at < release_at < baseline_at < activate_call_at
     assert "restore_sampling_crontab" in deploy_workflow
     assert "Immutable sampler release ready" in deploy_workflow
-    assert "git archive" in deploy_workflow
+    assert 'test -f "${sampler_candidate}/tools/render_scheduler_popularity_crontab.py"' in deploy_workflow
+    assert 'extract_sampler_release "${sampler_release_stage}"' in deploy_workflow
+    assert 'extract_sampler_release "${sampler_verify_stage}"' in deploy_workflow
+    assert 'git archive "${DEPLOY_SHA}" -- \\' in deploy_workflow
+    assert "              app \\" in deploy_workflow
+    assert "              scripts/run_scheduler_popularity_cron.py \\" in deploy_workflow
+    assert "              scripts/sample_scheduler_popularity.py \\" in deploy_workflow
+    assert "              tools/render_scheduler_popularity_crontab.py | tar -x" in deploy_workflow
+    assert deploy_workflow.count('git archive "${DEPLOY_SHA}" | tar') == 1
     assert "sampler_current" not in deploy_workflow
     assert 'chmod -R a-w,a+rX "${sampler_release_stage}"' in deploy_workflow
     assert 'ln -s "${app_dir}/venv" "${sampler_release_stage}/venv"' in deploy_workflow

--- a/tests/test_production_sampler_release_archive.py
+++ b/tests/test_production_sampler_release_archive.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import subprocess
+import tarfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_PATHS = (
+    "app",
+    "scripts/run_scheduler_popularity_cron.py",
+    "scripts/sample_scheduler_popularity.py",
+    "tools/render_scheduler_popularity_crontab.py",
+)
+
+
+def test_scoped_sampler_archive_contains_runtime_without_tracked_symlinks(tmp_path):
+    archive = tmp_path / "sampler.tar"
+    result = subprocess.run(
+        ["git", "archive", "--format=tar", f"--output={archive}", "HEAD", "--", *RELEASE_PATHS],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    with tarfile.open(archive) as payload:
+        members = payload.getmembers()
+        names = {member.name for member in members}
+
+    assert "app/__init__.py" in names
+    assert "app/services/scheduler_popularity.py" in names
+    assert "scripts/run_scheduler_popularity_cron.py" in names
+    assert "scripts/sample_scheduler_popularity.py" in names
+    assert "tools/render_scheduler_popularity_crontab.py" in names
+    assert not any(member.issym() or member.islnk() for member in members)
+    assert not any(name.startswith(".codex-venv/") for name in names)
+    assert ".codex-feedback-dev.db" not in names
+    assert all(
+        name == "app"
+        or name.startswith("app/")
+        or name == "scripts"
+        or name == "tools"
+        or name in RELEASE_PATHS[1:]
+        for name in names
+    )


### PR DESCRIPTION
## Release scope
- complete sampler activation after the prior production run successfully committed the API and migrations but rejected a whole-repository release artifact
- deploy the independently reviewed scoped immutable sampler release from PR #171

## Current production state
- live API checkout and service are healthy at f2fc3af
- both migration heads are current
- deployment journal is COMMITTED
- no popularity baseline or managed crontab has been activated

## Fix evidence
- exact fix f56f9a9 is independently approved with no P0/P1/P2 findings
- Backend CI 31724395227 passed every gate
- 115 focused deployment tests passed
- new archive test proves all required runtime files are present and Git contributes no symlink/hardlink or dev artifacts

The new production merge SHA creates a distinct immutable release, so the rejected f2fc3af artifact is not reused.